### PR TITLE
PP-8443 Configure database setup

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -67,10 +67,6 @@
       "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
     },
     {
-      "path": "detect_secrets.filters.common.is_baseline_file",
-      "filename": ".secrets.baseline"
-    },
-    {
       "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
       "min_level": 2
     },
@@ -109,10 +105,18 @@
         "filename": ".pre-commit-config.yaml",
         "hashed_secret": "d8371c23f86b4df4be2854848f6f28f13d7582f5",
         "is_verified": false,
-        "line_number": 3,
-        "is_secret": false
+        "line_number": 3
+      }
+    ],
+    "src/test/java/uk/gov/pay/rule/PostgresTestDocker.java": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/test/java/uk/gov/pay/rule/PostgresTestDocker.java",
+        "hashed_secret": "a94a8fe5ccb19ba61c4c0873d391e987982fbbd3",
+        "is_verified": false,
+        "line_number": 29
       }
     ]
   },
-  "generated_at": "2021-09-16T14:58:45Z"
+  "generated_at": "2021-09-21T11:13:02Z"
 }

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
         <jackson.version>2.12.5</jackson.version>
         <junit5.version>5.8.0</junit5.version>
         <testcontainers.version>1.16.0</testcontainers.version>
-        <mainClass>uk.gov.pay.webhooks.WebhooksApp</mainClass>
+        <mainClass>uk.gov.pay.webhooks.app.WebhooksApp</mainClass>
     </properties>
 
     <dependencyManagement>
@@ -57,6 +57,11 @@
                     <artifactId>liquibase-core</artifactId>
                 </exclusion>
             </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>com.google.inject</groupId>
+            <artifactId>guice</artifactId>
+            <version>5.0.1</version>
         </dependency>
         <dependency>
             <groupId>org.liquibase</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -17,8 +17,10 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <dropwizard.version>2.0.25</dropwizard.version>
-        <liquibase.version>3.10.2</liquibase.version>
+        <liquibase.version>4.4.3</liquibase.version>
         <jackson.version>2.12.5</jackson.version>
+        <junit5.version>5.8.0</junit5.version>
+        <testcontainers.version>1.16.0</testcontainers.version>
         <mainClass>uk.gov.pay.webhooks.WebhooksApp</mainClass>
     </properties>
 
@@ -30,11 +32,6 @@
                 <version>${dropwizard.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.postgresql</groupId>
-                <artifactId>postgresql</artifactId>
-                <version>42.2.23</version>
             </dependency>
         </dependencies>
     </dependencyManagement>
@@ -71,6 +68,52 @@
                     <artifactId>jstl</artifactId>
                 </exclusion>
             </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.postgresql</groupId>
+            <artifactId>postgresql</artifactId>
+            <version>42.2.23</version>
+        </dependency>
+        <!-- test dependencies -->
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-core</artifactId>
+            <version>2.2</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.dropwizard</groupId>
+            <artifactId>dropwizard-jdbi3</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.dropwizard</groupId>
+            <artifactId>dropwizard-testing</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
+            <version>${junit5.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>postgresql</artifactId>
+            <version>${testcontainers.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <version>${junit5.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.rest-assured</groupId>
+            <artifactId>rest-assured</artifactId>
+            <version>4.4.0</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -17,6 +17,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <dropwizard.version>2.0.25</dropwizard.version>
+        <liquibase.version>3.10.2</liquibase.version>
         <jackson.version>2.12.5</jackson.version>
         <mainClass>uk.gov.pay.webhooks.WebhooksApp</mainClass>
     </properties>
@@ -29,6 +30,11 @@
                 <version>${dropwizard.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.postgresql</groupId>
+                <artifactId>postgresql</artifactId>
+                <version>42.2.23</version>
             </dependency>
         </dependencies>
     </dependencyManagement>
@@ -43,6 +49,28 @@
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
             <version>${jackson.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.dropwizard</groupId>
+            <artifactId>dropwizard-migrations</artifactId>
+            <version>${dropwizard.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.liquibase</groupId>
+                    <artifactId>liquibase-core</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.liquibase</groupId>
+            <artifactId>liquibase-core</artifactId>
+            <version>${liquibase.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>javax.servlet</groupId>
+                    <artifactId>jstl</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -21,6 +21,7 @@
         <jackson.version>2.12.5</jackson.version>
         <junit5.version>5.8.0</junit5.version>
         <testcontainers.version>1.16.0</testcontainers.version>
+        <pay-java-commons.version>1.0.20210914101116</pay-java-commons.version>
         <mainClass>uk.gov.pay.webhooks.app.WebhooksApp</mainClass>
     </properties>
 
@@ -78,6 +79,11 @@
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
             <version>42.2.23</version>
+        </dependency>
+        <dependency>
+            <groupId>uk.gov.service.payments</groupId>
+            <artifactId>utils</artifactId>
+            <version>${pay-java-commons.version}</version>
         </dependency>
         <!-- test dependencies -->
         <dependency>

--- a/src/main/java/uk/gov/pay/webhooks/WebhooksApp.java
+++ b/src/main/java/uk/gov/pay/webhooks/WebhooksApp.java
@@ -2,6 +2,11 @@ package uk.gov.pay.webhooks;
 
 import io.dropwizard.Application;
 import io.dropwizard.Configuration;
+import io.dropwizard.configuration.EnvironmentVariableSubstitutor;
+import io.dropwizard.configuration.SubstitutingSourceProvider;
+import io.dropwizard.db.DataSourceFactory;
+import io.dropwizard.migrations.MigrationsBundle;
+import io.dropwizard.setup.Bootstrap;
 import io.dropwizard.setup.Environment;
 import uk.gov.pay.webhooks.healthcheck.HealthCheckResource;
 import uk.gov.pay.webhooks.healthcheck.Ping;
@@ -20,7 +25,19 @@ public void run(WebhooksConfiguration configuration,
     
     }
 
+    @Override
+    public void initialize(Bootstrap<WebhooksConfiguration> bootstrap){
+        bootstrap.setConfigurationSourceProvider(
+                new SubstitutingSourceProvider(bootstrap.getConfigurationSourceProvider(),
+                        new EnvironmentVariableSubstitutor(false))
+        );
 
-
+        bootstrap.addBundle(new MigrationsBundle<>() {
+            @Override
+            public DataSourceFactory getDataSourceFactory(WebhooksConfiguration configuration) {
+                return configuration.getDataSourceFactory();
+            }
+        });
+    }
 
 }

--- a/src/main/java/uk/gov/pay/webhooks/WebhooksConfiguration.java
+++ b/src/main/java/uk/gov/pay/webhooks/WebhooksConfiguration.java
@@ -1,7 +1,24 @@
 package uk.gov.pay.webhooks;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import io.dropwizard.Configuration;
+import io.dropwizard.db.DataSourceFactory;
+
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
 
 public class WebhooksConfiguration extends Configuration {
-    
+    @Valid
+    @NotNull
+    private DataSourceFactory database = new DataSourceFactory();
+
+    @JsonProperty("database")
+    public DataSourceFactory getDataSourceFactory() {
+        return database;
+    }
+
+    @JsonProperty("database")
+    public void setDataSourceFactory(DataSourceFactory dataSourceFactory) {
+        this.database = dataSourceFactory;
+    }
 }

--- a/src/main/java/uk/gov/pay/webhooks/app/WebhooksApp.java
+++ b/src/main/java/uk/gov/pay/webhooks/app/WebhooksApp.java
@@ -11,6 +11,7 @@ import uk.gov.pay.webhooks.healthcheck.HealthCheckResource;
 import uk.gov.pay.webhooks.healthcheck.Ping;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
+import uk.gov.service.payments.commons.utils.healthchecks.DatabaseHealthCheck;
 
 public class WebhooksApp extends Application<WebhooksConfig> {
     public static void main(String[] args) throws Exception {
@@ -23,7 +24,7 @@ public void run(WebhooksConfig configuration,
         final Injector injector = Guice.createInjector(new WebhooksModule(configuration, environment));
 
         environment.healthChecks().register("ping", new Ping());
-
+        environment.healthChecks().register("database", new DatabaseHealthCheck(configuration.getDataSourceFactory()));
         environment.jersey().register(injector.getInstance(HealthCheckResource.class));
     }
 

--- a/src/main/java/uk/gov/pay/webhooks/app/WebhooksConfig.java
+++ b/src/main/java/uk/gov/pay/webhooks/app/WebhooksConfig.java
@@ -1,4 +1,4 @@
-package uk.gov.pay.webhooks;
+package uk.gov.pay.webhooks.app;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.dropwizard.Configuration;
@@ -7,7 +7,7 @@ import io.dropwizard.db.DataSourceFactory;
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 
-public class WebhooksConfiguration extends Configuration {
+public class WebhooksConfig extends Configuration {
     @Valid
     @NotNull
     private DataSourceFactory database = new DataSourceFactory();

--- a/src/main/java/uk/gov/pay/webhooks/app/WebhooksModule.java
+++ b/src/main/java/uk/gov/pay/webhooks/app/WebhooksModule.java
@@ -1,0 +1,20 @@
+package uk.gov.pay.webhooks.app;
+
+import com.google.inject.AbstractModule;
+import io.dropwizard.setup.Environment;
+
+public class WebhooksModule extends AbstractModule {
+    private final WebhooksConfig configuration;
+    private final Environment environment;
+
+    public WebhooksModule(final WebhooksConfig configuration, final Environment environment) {
+        this.configuration = configuration;
+        this.environment = environment;
+    }
+
+    @Override
+    protected void configure() {
+        bind(WebhooksConfig.class).toInstance(configuration);
+        bind(Environment.class).toInstance(environment);
+    }
+}

--- a/src/main/java/uk/gov/pay/webhooks/healthcheck/HealthCheckResource.java
+++ b/src/main/java/uk/gov/pay/webhooks/healthcheck/HealthCheckResource.java
@@ -22,7 +22,7 @@ public class HealthCheckResource {
     }
 
     @GET
-    @Path("/")
+    @Path("healthcheck")
     @Produces(APPLICATION_JSON)
     public Response healthCheck() {
         var ok = Map.of("healthy", "true");

--- a/src/main/java/uk/gov/pay/webhooks/healthcheck/HealthCheckResource.java
+++ b/src/main/java/uk/gov/pay/webhooks/healthcheck/HealthCheckResource.java
@@ -1,14 +1,15 @@
 package uk.gov.pay.webhooks.healthcheck;
 
+import com.codahale.metrics.health.HealthCheck;
 import io.dropwizard.setup.Environment;
 
 import javax.inject.Inject;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
-import javax.ws.rs.core.Response;
 
 import java.util.Map;
+import java.util.Set;
 
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 
@@ -24,8 +25,7 @@ public class HealthCheckResource {
     @GET
     @Path("healthcheck")
     @Produces(APPLICATION_JSON)
-    public Response healthCheck() {
-        var ok = Map.of("healthy", "true");
-        return Response.ok(ok).build();
+    public Set<Map.Entry<String, HealthCheck.Result>> healthCheck() {
+        return environment.healthChecks().runHealthChecks().entrySet();
     }
 }

--- a/src/main/resources/migrations.xml
+++ b/src/main/resources/migrations.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+         http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+
+    <includeAll path="migrations"/>
+
+</databaseChangeLog>

--- a/src/main/resources/migrations/0001_create_table_webhooks.sql
+++ b/src/main/resources/migrations/0001_create_table_webhooks.sql
@@ -1,0 +1,18 @@
+--liquibase formatted sql
+
+--changeset uk.gov.pay:create-table-webhooks
+
+CREATE TYPE live_or_test AS ENUM('LIVE', 'TEST');
+
+CREATE table webhooks (
+    id SERIAL PRIMARY KEY,
+    created_at TIMESTAMP WITHOUT TIME ZONE NOT NULL,
+    external_id VARCHAR(30) NOT NULL,
+    service_id VARCHAR(30) NOT NULL,
+    type live_or_test NOT NULL,
+    callback_url VARCHAR(2048) NOT NULL,
+    description TEXT,
+    status VARCHAR(32) NOT NULL
+)
+
+--rollback DROP table webhooks; DROP type live_or_test

--- a/src/main/resources/migrations/0001_create_table_webhooks.sql
+++ b/src/main/resources/migrations/0001_create_table_webhooks.sql
@@ -2,17 +2,15 @@
 
 --changeset uk.gov.pay:create-table-webhooks
 
-CREATE TYPE live_or_test AS ENUM('LIVE', 'TEST');
-
 CREATE table webhooks (
     id SERIAL PRIMARY KEY,
     created_at TIMESTAMP WITHOUT TIME ZONE NOT NULL,
     external_id VARCHAR(30) NOT NULL,
     service_id VARCHAR(30) NOT NULL,
-    type live_or_test NOT NULL,
+    live BOOLEAN NOT NULL,
     callback_url VARCHAR(2048) NOT NULL,
     description TEXT,
     status VARCHAR(32) NOT NULL
 )
 
---rollback DROP table webhooks; DROP type live_or_test
+--rollback DROP table webhooks

--- a/src/test/java/uk/gov/pay/extension/AppWithPostgresExtension.java
+++ b/src/test/java/uk/gov/pay/extension/AppWithPostgresExtension.java
@@ -9,8 +9,8 @@ import org.junit.jupiter.api.extension.BeforeAllCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import uk.gov.pay.webhooks.WebhooksApp;
-import uk.gov.pay.webhooks.WebhooksConfiguration;
+import uk.gov.pay.webhooks.app.WebhooksApp;
+import uk.gov.pay.webhooks.app.WebhooksConfig;
 
 import java.util.List;
 
@@ -25,7 +25,7 @@ public class AppWithPostgresExtension implements BeforeAllCallback, AfterAllCall
 
     private static String CONFIG_PATH = resourceFilePath("config/test-config.yaml");
     private final Jdbi jdbi;
-    private DropwizardAppExtension<WebhooksConfiguration> dropwizardAppExtension;
+    private DropwizardAppExtension<WebhooksConfig> dropwizardAppExtension;
 
     public AppWithPostgresExtension() {
         this(new ConfigOverride[0]);
@@ -77,7 +77,7 @@ public class AppWithPostgresExtension implements BeforeAllCallback, AfterAllCall
         return newConfigOverride.toArray(new ConfigOverride[0]);
     }
 
-    public DropwizardAppExtension<WebhooksConfiguration> getAppRule() {
+    public DropwizardAppExtension<WebhooksConfig> getAppRule() {
         return dropwizardAppExtension;
     }
 

--- a/src/test/java/uk/gov/pay/extension/AppWithPostgresExtension.java
+++ b/src/test/java/uk/gov/pay/extension/AppWithPostgresExtension.java
@@ -1,0 +1,90 @@
+package uk.gov.pay.extension;
+
+import io.dropwizard.testing.ConfigOverride;
+import io.dropwizard.testing.junit5.DropwizardAppExtension;
+import org.jdbi.v3.core.Jdbi;
+import org.jdbi.v3.sqlobject.SqlObjectPlugin;
+import org.junit.jupiter.api.extension.AfterAllCallback;
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import uk.gov.pay.webhooks.WebhooksApp;
+import uk.gov.pay.webhooks.WebhooksConfiguration;
+
+import java.util.List;
+
+import static com.google.common.collect.Lists.newArrayList;
+import static io.dropwizard.testing.ConfigOverride.config;
+import static io.dropwizard.testing.ResourceHelpers.resourceFilePath;
+import static uk.gov.pay.rule.PostgresTestDocker.*;
+
+public class AppWithPostgresExtension implements BeforeAllCallback, AfterAllCallback {
+
+    private static final Logger logger = LoggerFactory.getLogger(AppWithPostgresExtension.class);
+
+    private static String CONFIG_PATH = resourceFilePath("config/test-config.yaml");
+    private final Jdbi jdbi;
+    private DropwizardAppExtension<WebhooksConfiguration> dropwizardAppExtension;
+
+    public AppWithPostgresExtension() {
+        this(new ConfigOverride[0]);
+    }
+
+    public AppWithPostgresExtension(ConfigOverride... configOverrides) {
+        getOrCreate();
+
+
+        ConfigOverride[] newConfigOverrides = overrideDatabaseConfig(configOverrides);
+        newConfigOverrides = overrideSqsConfig(newConfigOverrides);
+
+        dropwizardAppExtension = new DropwizardAppExtension<>(WebhooksApp.class,
+                CONFIG_PATH, newConfigOverrides);
+
+        try {
+            // starts dropwizard application. This is required as we don't use DropwizardExtensionsSupport (which starts application)
+            // due to config overrides we need at runtime for database, sqs and any custom configuration needed for tests
+            dropwizardAppExtension.before();
+        } catch (Exception e) {
+            logger.error("Exception starting application - {}", e.getMessage());
+            throw new RuntimeException(e);
+        }
+
+        jdbi = Jdbi.create(getConnectionUrl(), getDbUsername(), getDbPassword());
+        jdbi.installPlugin(new SqlObjectPlugin());
+    }
+
+    @Override
+    public void beforeAll(ExtensionContext context) throws Exception {
+        dropwizardAppExtension.getApplication().run("db", "migrate", CONFIG_PATH);
+    }
+
+    @Override
+    public void afterAll(ExtensionContext context) {
+        dropwizardAppExtension.after();
+    }
+
+    private ConfigOverride[] overrideDatabaseConfig(ConfigOverride[] configOverrides) {
+        List<ConfigOverride> newConfigOverride = newArrayList(configOverrides);
+        newConfigOverride.add(config("database.url", getConnectionUrl()));
+        newConfigOverride.add(config("database.user", getDbUsername()));
+        newConfigOverride.add(config("database.password", getDbPassword()));
+        return newConfigOverride.toArray(new ConfigOverride[0]);
+    }
+
+    private ConfigOverride[] overrideSqsConfig(ConfigOverride[] configOverrides) {
+        List<ConfigOverride> newConfigOverride = newArrayList(configOverrides);
+        return newConfigOverride.toArray(new ConfigOverride[0]);
+    }
+
+    public DropwizardAppExtension<WebhooksConfiguration> getAppRule() {
+        return dropwizardAppExtension;
+    }
+
+    public Jdbi getJdbi() {
+        return jdbi;
+    }
+    
+}
+
+

--- a/src/test/java/uk/gov/pay/rule/PostgresTestDocker.java
+++ b/src/test/java/uk/gov/pay/rule/PostgresTestDocker.java
@@ -1,23 +1,12 @@
 package uk.gov.pay.rule;
 
-import io.dropwizard.testing.ConfigOverride;
-import io.dropwizard.testing.junit.DropwizardAppRule;
-import org.junit.rules.ExternalResource;
-import org.junit.rules.RuleChain;
-import org.junit.runner.Description;
-import org.junit.runners.model.Statement;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.GenericContainer;
-import uk.gov.pay.webhooks.WebhooksConfiguration;
 
 import java.sql.Connection;
 import java.sql.SQLException;
-import java.util.List;
 
-import static com.google.common.collect.Lists.newArrayList;
-import static io.dropwizard.testing.ConfigOverride.config;
-import static io.dropwizard.testing.ResourceHelpers.resourceFilePath;
 import static java.sql.DriverManager.getConnection;
 
 public class PostgresTestDocker {

--- a/src/test/java/uk/gov/pay/rule/PostgresTestDocker.java
+++ b/src/test/java/uk/gov/pay/rule/PostgresTestDocker.java
@@ -1,0 +1,86 @@
+package uk.gov.pay.rule;
+
+import io.dropwizard.testing.ConfigOverride;
+import io.dropwizard.testing.junit.DropwizardAppRule;
+import org.junit.rules.ExternalResource;
+import org.junit.rules.RuleChain;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.containers.GenericContainer;
+import uk.gov.pay.webhooks.WebhooksConfiguration;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.List;
+
+import static com.google.common.collect.Lists.newArrayList;
+import static io.dropwizard.testing.ConfigOverride.config;
+import static io.dropwizard.testing.ResourceHelpers.resourceFilePath;
+import static java.sql.DriverManager.getConnection;
+
+public class PostgresTestDocker {
+
+    private static final Logger logger = LoggerFactory.getLogger(PostgresTestDocker.class);
+
+    private static final String DB_NAME = "webhooks_test";
+    private static final String DB_USERNAME = "test";
+    private static final String DB_PASSWORD = "test";
+    private static GenericContainer container;
+
+    public static void getOrCreate() {
+        try {
+            if (container == null) {
+                logger.info("Creating Postgres Container");
+
+                container = new GenericContainer("postgres:13.4");
+                container.addExposedPort(5432);
+
+                container.addEnv("POSTGRES_USER", DB_USERNAME);
+                container.addEnv("POSTGRES_PASSWORD", DB_PASSWORD);
+
+                container.start();
+
+                //todo: add DB health check
+                Thread.sleep(5000);
+                createDatabase(DB_NAME);
+            }
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public static String getConnectionUrl() {
+        return "jdbc:postgresql://localhost:" + container.getMappedPort(5432) + "/";
+    }
+
+    public static void stopContainer() {
+        container.stop();
+        container = null;
+    }
+
+    private static void createDatabase(final String dbName) {
+        final String dbUser = getDbUsername();
+
+        try (Connection connection = getConnection(getConnectionUrl(), dbUser, getDbPassword())) {
+            connection.createStatement().execute("CREATE DATABASE " + dbName + " WITH owner=" + dbUser + " TEMPLATE postgres");
+            connection.createStatement().execute("GRANT ALL PRIVILEGES ON DATABASE " + dbName + " TO " + dbUser);
+            connection.createStatement().execute("CREATE EXTENSION IF NOT EXISTS pg_trgm");
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    static String getDbUri() {
+        return getConnectionUrl() + DB_NAME;
+    }
+
+    public static String getDbPassword() {
+        return DB_PASSWORD;
+    }
+
+    public static String getDbUsername() {
+        return DB_USERNAME;
+    }
+}

--- a/src/test/java/uk/gov/pay/rule/PostgresTestDocker.java
+++ b/src/test/java/uk/gov/pay/rule/PostgresTestDocker.java
@@ -31,7 +31,6 @@ public class PostgresTestDocker {
 
                 container.start();
 
-                //todo: add DB health check
                 Thread.sleep(5000);
                 createDatabase(DB_NAME);
             }

--- a/src/test/java/uk/gov/pay/webhooks/healthcheck/HealthCheckResourceIT.java
+++ b/src/test/java/uk/gov/pay/webhooks/healthcheck/HealthCheckResourceIT.java
@@ -20,7 +20,9 @@ public class HealthCheckResourceIT {
                 .accept(ContentType.JSON)
                 .get("healthcheck")
                 .then()
-                .statusCode(200).body("healthy", equalTo("true"));
+                .statusCode(200)
+                .body("[0].deadlocks.healthy", equalTo(true))
+                .body("[1].ping.healthy", equalTo(true));
     }
 
 }

--- a/src/test/java/uk/gov/pay/webhooks/healthcheck/HealthCheckResourceIT.java
+++ b/src/test/java/uk/gov/pay/webhooks/healthcheck/HealthCheckResourceIT.java
@@ -21,8 +21,9 @@ public class HealthCheckResourceIT {
                 .get("healthcheck")
                 .then()
                 .statusCode(200)
-                .body("[0].deadlocks.healthy", equalTo(true))
-                .body("[1].ping.healthy", equalTo(true));
+                .body("[0].database.healthy", equalTo(true))
+                .body("[1].deadlocks.healthy", equalTo(true))
+                .body("[2].ping.healthy", equalTo(true));
     }
 
 }

--- a/src/test/java/uk/gov/pay/webhooks/healthcheck/HealthCheckResourceIT.java
+++ b/src/test/java/uk/gov/pay/webhooks/healthcheck/HealthCheckResourceIT.java
@@ -1,0 +1,26 @@
+package uk.gov.pay.webhooks.healthcheck;
+
+import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import uk.gov.pay.extension.AppWithPostgresExtension;
+
+import static org.hamcrest.Matchers.equalTo;
+
+public class HealthCheckResourceIT {
+    @RegisterExtension
+    public static AppWithPostgresExtension app = new AppWithPostgresExtension();
+
+    @Test
+    public void HealthCheckIsHealthyTest(){
+        RestAssured.given().port(app.getAppRule().getLocalPort())
+                .contentType(ContentType.JSON)
+                .when()
+                .accept(ContentType.JSON)
+                .get("healthcheck")
+                .then()
+                .statusCode(200).body("healthy", equalTo("true"));
+    }
+
+}

--- a/src/test/resources/config/test-config.yaml
+++ b/src/test/resources/config/test-config.yaml
@@ -1,0 +1,29 @@
+database:
+  driverClass: org.postgresql.Driver
+  user: ${DB_USER}
+  password: ${DB_PASSWORD}
+  url: jdbc:postgresql://${DB_HOST}:5432/webhooks?sslfactory=org.postgresql.ssl.DefaultJavaSSLFactory&${DB_SSL_OPTION}
+
+  # the maximum amount of time to wait on an empty pool before throwing an exception
+  maxWaitForConnection: 1s
+
+  # the SQL query to run when validating a connection's liveness
+  validationQuery: "SELECT '1'"
+
+  # the timeout before a connection validation queries fail
+  validationQueryTimeout: 3s
+
+  # the minimum number of connections to keep open
+  minSize: 8
+
+  # the maximum number of connections to keep open
+  maxSize: 32
+
+  # whether or not idle connections should be validated
+  checkConnectionWhileIdle: false
+
+  # the amount of time to sleep between runs of the idle connection validation, abandoned cleaner and idle pool resizing
+  evictionInterval: 10s
+
+  # the minimum amount of time an connection must sit idle in the pool before it is eligible for eviction
+  minIdleTime: 1 minute


### PR DESCRIPTION
Adds dependencies required to setup, configure and run migrations on a Postgres database: 
* dropwizard core migrations
* postgres driver

Sets up dependency injection in line with other apps (using Guice) to set the standard and clean up existing healthcheck endpoint. 

Adds first database migration to setup a simple table.

Adds standard commons database healtcheck with assertion on healthy database connection.

Sets up test environment to run tests against an actual database
* JUnit5
* testcontainers
* hamcreset matchers
* reset assured