### PR TITLE
BAU GitHub Action for integration tests

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,0 +1,31 @@
+name: Github Actions Tests
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  integration-tests:
+    name: Integration tests
+    runs-on: ubuntu-18.04
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK 17
+        uses: actions/setup-java@v2
+        with:
+          java-version: '17'
+          distribution: 'adopt'
+      - name: Cache Maven packages
+        uses: actions/cache@v2
+        with:
+          path: ~/.m2
+          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-m2
+      - name: Run integration tests
+        run: mvn clean verify


### PR DESCRIPTION
Depends on https://github.com/alphagov/pay-webhooks/pull/4

Use JDK 17 as specified in the pom file.

Run on standard Ubuntu base, similar to unit tests run by other repos.

Output of action should be the result of `mvn clean integration-test`.