### PR TITLE
PP-8443 Switch from EclipseLink to Hibernate

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,6 +23,8 @@
         <testcontainers.version>1.16.0</testcontainers.version>
         <pay-java-commons.version>1.0.20210914101116</pay-java-commons.version>
         <mainClass>uk.gov.pay.webhooks.app.WebhooksApp</mainClass>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
     </properties>
 
     <dependencyManagement>
@@ -60,8 +62,18 @@
             </exclusions>
         </dependency>
         <dependency>
+            <groupId>io.dropwizard</groupId>
+            <artifactId>dropwizard-hibernate</artifactId>
+            <version>${dropwizard.version}</version>
+        </dependency>
+        <dependency>
             <groupId>com.google.inject</groupId>
             <artifactId>guice</artifactId>
+            <version>5.0.1</version>
+        </dependency>
+        <dependency>
+            <groupId>com.google.inject.extensions</groupId>
+            <artifactId>guice-persist</artifactId>
             <version>5.0.1</version>
         </dependency>
         <dependency>
@@ -83,6 +95,11 @@
         <dependency>
             <groupId>uk.gov.service.payments</groupId>
             <artifactId>utils</artifactId>
+            <version>${pay-java-commons.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>uk.gov.service.payments</groupId>
+            <artifactId>model</artifactId>
             <version>${pay-java-commons.version}</version>
         </dependency>
         <!-- test dependencies -->

--- a/src/main/java/uk/gov/pay/webhooks/app/WebhooksApp.java
+++ b/src/main/java/uk/gov/pay/webhooks/app/WebhooksApp.java
@@ -1,31 +1,42 @@
 package uk.gov.pay.webhooks.app;
 
+import com.google.inject.Guice;
+import com.google.inject.Injector;
 import io.dropwizard.Application;
 import io.dropwizard.configuration.EnvironmentVariableSubstitutor;
 import io.dropwizard.configuration.SubstitutingSourceProvider;
 import io.dropwizard.db.DataSourceFactory;
+import io.dropwizard.hibernate.HibernateBundle;
 import io.dropwizard.migrations.MigrationsBundle;
 import io.dropwizard.setup.Bootstrap;
 import io.dropwizard.setup.Environment;
 import uk.gov.pay.webhooks.healthcheck.HealthCheckResource;
 import uk.gov.pay.webhooks.healthcheck.Ping;
-import com.google.inject.Guice;
-import com.google.inject.Injector;
+import uk.gov.pay.webhooks.webhook.WebhookResource;
+import uk.gov.pay.webhooks.webhook.entity.WebhookEntity;
 import uk.gov.service.payments.commons.utils.healthchecks.DatabaseHealthCheck;
 
 public class WebhooksApp extends Application<WebhooksConfig> {
     public static void main(String[] args) throws Exception {
         new WebhooksApp().run(args);
     }
+    
+    private HibernateBundle<WebhooksConfig> hibernate = new HibernateBundle<>(WebhookEntity.class) {
+        @Override
+        public DataSourceFactory getDataSourceFactory(WebhooksConfig configuration) {
+            return configuration.getDataSourceFactory();
+        }
+    };
 
-@Override
-public void run(WebhooksConfig configuration,
-                Environment environment) {
-        final Injector injector = Guice.createInjector(new WebhooksModule(configuration, environment));
+    @Override
+    public void run(WebhooksConfig configuration,
+                    Environment environment) {
+        final Injector injector = Guice.createInjector(new WebhooksModule(configuration, environment, hibernate));
 
         environment.healthChecks().register("ping", new Ping());
         environment.healthChecks().register("database", new DatabaseHealthCheck(configuration.getDataSourceFactory()));
         environment.jersey().register(injector.getInstance(HealthCheckResource.class));
+        environment.jersey().register(injector.getInstance(WebhookResource.class));
     }
 
     @Override
@@ -41,6 +52,9 @@ public void run(WebhooksConfig configuration,
                 return configuration.getDataSourceFactory();
             }
         });
+
+        bootstrap.addBundle(hibernate);
     }
+
 
 }

--- a/src/main/java/uk/gov/pay/webhooks/app/WebhooksModule.java
+++ b/src/main/java/uk/gov/pay/webhooks/app/WebhooksModule.java
@@ -1,20 +1,25 @@
 package uk.gov.pay.webhooks.app;
 
 import com.google.inject.AbstractModule;
+import io.dropwizard.hibernate.HibernateBundle;
 import io.dropwizard.setup.Environment;
+import org.hibernate.SessionFactory;
 
 public class WebhooksModule extends AbstractModule {
     private final WebhooksConfig configuration;
     private final Environment environment;
+    private final HibernateBundle<WebhooksConfig> hibernate;
 
-    public WebhooksModule(final WebhooksConfig configuration, final Environment environment) {
+    public WebhooksModule(final WebhooksConfig configuration, final Environment environment, HibernateBundle<WebhooksConfig> hibernate) {
         this.configuration = configuration;
         this.environment = environment;
+        this.hibernate = hibernate;
     }
 
     @Override
     protected void configure() {
         bind(WebhooksConfig.class).toInstance(configuration);
         bind(Environment.class).toInstance(environment);
+        bind(SessionFactory.class).toInstance(hibernate.getSessionFactory());
     }
 }

--- a/src/main/java/uk/gov/pay/webhooks/webhook/WebhookDTO.java
+++ b/src/main/java/uk/gov/pay/webhooks/webhook/WebhookDTO.java
@@ -1,0 +1,31 @@
+package uk.gov.pay.webhooks.webhook;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+// responsible for: 
+// - jackson serialiation/ validation from query params (POST BODY)
+// - providing data for the entity to construct itself FROM (creation)
+@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+public class WebhookDTO {
+    private String serviceId;
+    private String callbackUrl;
+    private boolean live;
+    private String description;
+    
+    public String getServiceId() {
+        return serviceId;
+    }
+
+    public String getCallbackUrl() {
+        return callbackUrl;
+    }
+
+    public boolean isLive() {
+        return live;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+}

--- a/src/main/java/uk/gov/pay/webhooks/webhook/WebhookResource.java
+++ b/src/main/java/uk/gov/pay/webhooks/webhook/WebhookResource.java
@@ -1,0 +1,28 @@
+package uk.gov.pay.webhooks.webhook;
+
+import io.dropwizard.hibernate.UnitOfWork;
+import uk.gov.pay.webhooks.webhook.entity.WebhookEntity;
+import uk.gov.pay.webhooks.webhook.entity.dao.WebhookDao;
+
+import javax.inject.Inject;
+import javax.validation.constraints.NotNull;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+
+@Path("/v1/webhook")
+public class WebhookResource {
+    
+    private final WebhookDao webhookDao;
+    
+    @Inject
+    public WebhookResource(WebhookDao webhookDao) {
+        this.webhookDao = webhookDao;
+    }
+    
+    @UnitOfWork
+    @POST
+    public long createWebhook(@NotNull WebhookDTO webhookRequest) {
+        var webhook = WebhookEntity.from(webhookRequest);
+        return webhookDao.create(webhook);
+    }
+}

--- a/src/main/java/uk/gov/pay/webhooks/webhook/entity/WebhookEntity.java
+++ b/src/main/java/uk/gov/pay/webhooks/webhook/entity/WebhookEntity.java
@@ -1,0 +1,91 @@
+package uk.gov.pay.webhooks.webhook.entity;
+
+import uk.gov.pay.webhooks.webhook.WebhookDTO;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.SequenceGenerator;
+import javax.persistence.Table;
+import java.math.BigInteger;
+import java.security.SecureRandom;
+import java.time.Instant;
+import java.util.Date;
+
+@Entity
+@SequenceGenerator(name="webhooks_id_seq", sequenceName = "webhooks_id_seq", allocationSize = 1)
+@Table(name = "webhooks")
+public class WebhookEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "webhooks_id_seq")
+    private Long id;
+
+    @Column(name = "created_date")
+    private Date createdDate;
+
+    @Column(name = "external_id")
+    private String externalId;
+
+    @Column(name = "service_id")
+    private String serviceId;
+
+    private boolean live;
+
+    @Column(name = "callback_url")
+    private String callbackUrl;
+
+    private String description;
+
+    @Enumerated(EnumType.STRING)
+    private WebhookStatus status;
+
+    public static WebhookEntity from(WebhookDTO webhookDTO) {
+        var entity = new WebhookEntity();
+        entity.setDescription(webhookDTO.getDescription());
+        entity.setCallbackUrl(webhookDTO.getCallbackUrl());
+        entity.setServiceId(webhookDTO.getServiceId());
+        entity.setLive(webhookDTO.isLive());
+        entity.setCreatedDate(Date.from(Instant.now()));
+        entity.setStatus(WebhookStatus.ACTIVE);
+        entity.setExternalId(new BigInteger(130, new SecureRandom()).toString(32));
+        return entity;
+    }
+
+    private void setExternalId(String externalId) {
+        this.externalId = externalId;
+    }
+
+    private void setStatus(WebhookStatus status) {
+        this.status = status;
+    }
+
+    public void setServiceId(String serviceId) {
+        this.serviceId = serviceId;
+    }
+
+    public void setLive(boolean live) {
+        this.live = live;
+    }
+
+    public void setCallbackUrl(String callbackUrl) {
+        this.callbackUrl = callbackUrl;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public void setCreatedDate(Date instant) {
+        this.createdDate = instant;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+}

--- a/src/main/java/uk/gov/pay/webhooks/webhook/entity/WebhookStatus.java
+++ b/src/main/java/uk/gov/pay/webhooks/webhook/entity/WebhookStatus.java
@@ -1,0 +1,7 @@
+package uk.gov.pay.webhooks.webhook.entity;
+
+public enum WebhookStatus {
+
+    ACTIVE, INACTIVE;
+
+}

--- a/src/main/java/uk/gov/pay/webhooks/webhook/entity/dao/WebhookDao.java
+++ b/src/main/java/uk/gov/pay/webhooks/webhook/entity/dao/WebhookDao.java
@@ -1,0 +1,24 @@
+package uk.gov.pay.webhooks.webhook.entity.dao;
+
+import io.dropwizard.hibernate.AbstractDAO;
+import org.hibernate.SessionFactory;
+import uk.gov.pay.webhooks.webhook.entity.WebhookEntity;
+
+import javax.inject.Inject;
+
+public class WebhookDao extends AbstractDAO<WebhookEntity> {
+    
+    @Inject
+    public WebhookDao(SessionFactory factory) {
+        super(factory);
+    }
+
+    public WebhookEntity findById(Long id) {
+        return get(id);
+    }
+
+    public long create(WebhookEntity webhook) {
+        return persist(webhook).getId();
+    }
+
+}

--- a/src/main/resources/migrations/0001_create_table_webhooks.sql
+++ b/src/main/resources/migrations/0001_create_table_webhooks.sql
@@ -4,7 +4,7 @@
 
 CREATE table webhooks (
     id SERIAL PRIMARY KEY,
-    created_at TIMESTAMP WITHOUT TIME ZONE NOT NULL,
+    created_date TIMESTAMP WITHOUT TIME ZONE NOT NULL,
     external_id VARCHAR(30) NOT NULL,
     service_id VARCHAR(30) NOT NULL,
     live BOOLEAN NOT NULL,

--- a/src/test/java/uk/gov/pay/webhooks/healthcheck/HealthCheckResourceIT.java
+++ b/src/test/java/uk/gov/pay/webhooks/healthcheck/HealthCheckResourceIT.java
@@ -23,7 +23,8 @@ public class HealthCheckResourceIT {
                 .statusCode(200)
                 .body("[0].database.healthy", equalTo(true))
                 .body("[1].deadlocks.healthy", equalTo(true))
-                .body("[2].ping.healthy", equalTo(true));
+                .body("[2].hibernate.healthy", equalTo(true))
+                .body("[3].ping.healthy", equalTo(true));
     }
 
 }

--- a/src/test/java/uk/gov/pay/webhooks/webhook/WebhookResourceIT.java
+++ b/src/test/java/uk/gov/pay/webhooks/webhook/WebhookResourceIT.java
@@ -1,0 +1,36 @@
+package uk.gov.pay.webhooks.webhook;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import uk.gov.pay.extension.AppWithPostgresExtension;
+
+import javax.ws.rs.core.Response;
+
+import static io.restassured.RestAssured.given;
+import static io.restassured.http.ContentType.JSON;
+
+
+public class WebhookResourceIT {
+    @RegisterExtension
+    public static AppWithPostgresExtension app = new AppWithPostgresExtension();
+    private Integer port = app.getAppRule().getLocalPort();
+
+    @Test
+    public void shouldCreateAWebhook() {
+        var json = """
+                {
+                  "service_id": "test_service_id",
+                  "live": true,
+                  "callback_url": "https://example.com",
+                  "description": "description"
+                }
+                """;
+
+        given().port(port)
+                .contentType(JSON)
+                .body(json)
+                .post("/v1/webhook")
+                .then()
+                .statusCode(Response.Status.OK.getStatusCode());
+    }
+}

--- a/src/test/resources/config/test-config.yaml
+++ b/src/test/resources/config/test-config.yaml
@@ -4,6 +4,10 @@ database:
   password: ${DB_PASSWORD}
   url: jdbc:postgresql://${DB_HOST}:5432/webhooks?sslfactory=org.postgresql.ssl.DefaultJavaSSLFactory&${DB_SSL_OPTION}
 
+  properties:
+    charSet: UTF-8
+    hibernate.dialect: org.hibernate.dialect.PostgreSQLDialect
+
   # the maximum amount of time to wait on an empty pool before throwing an exception
   maxWaitForConnection: 1s
 


### PR DESCRIPTION
Dropwizard default JPA implementation is Hibernate.

We were having problems using EL with Java 17 in Dropwizard. Hibernate works quite straightforwardly - `WebhookResourceIT` is a passing test using new Hibernate things.

with @mrlumbu, @sfount