### PR TITLE
PP-8443 Add Jackson validation to webhook resource

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -132,6 +132,12 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-junit-jupiter</artifactId>
+            <version>3.12.4</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
             <version>${junit5.version}</version>

--- a/src/main/java/uk/gov/pay/webhooks/webhook/CreateWebhookRequest.java
+++ b/src/main/java/uk/gov/pay/webhooks/webhook/CreateWebhookRequest.java
@@ -3,16 +3,25 @@ package uk.gov.pay.webhooks.webhook;
 import com.fasterxml.jackson.databind.PropertyNamingStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
-// responsible for: 
-// - jackson serialiation/ validation from query params (POST BODY)
-// - providing data for the entity to construct itself FROM (creation)
+import javax.validation.constraints.NotEmpty;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
+
 @JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
-public class WebhookDTO {
+public class CreateWebhookRequest { 
+    @NotEmpty
+    @Size(max = 30)
     private String serviceId;
-    private String callbackUrl;
-    private boolean live;
-    private String description;
+
+    @NotNull
+    private Boolean live;
     
+    @NotEmpty
+    @Size(max = 2048)
+    private String callbackUrl;
+    
+    private String description;
+
     public String getServiceId() {
         return serviceId;
     }

--- a/src/main/java/uk/gov/pay/webhooks/webhook/WebhookResource.java
+++ b/src/main/java/uk/gov/pay/webhooks/webhook/WebhookResource.java
@@ -5,9 +5,12 @@ import uk.gov.pay.webhooks.webhook.entity.WebhookEntity;
 import uk.gov.pay.webhooks.webhook.entity.dao.WebhookDao;
 
 import javax.inject.Inject;
+import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
 
 @Path("/v1/webhook")
 public class WebhookResource {
@@ -21,7 +24,8 @@ public class WebhookResource {
     
     @UnitOfWork
     @POST
-    public long createWebhook(@NotNull WebhookDTO webhookRequest) {
+    @Produces(MediaType.APPLICATION_JSON)
+    public long createWebhook(@NotNull @Valid CreateWebhookRequest webhookRequest) {
         var webhook = WebhookEntity.from(webhookRequest);
         return webhookDao.create(webhook);
     }

--- a/src/main/java/uk/gov/pay/webhooks/webhook/entity/WebhookEntity.java
+++ b/src/main/java/uk/gov/pay/webhooks/webhook/entity/WebhookEntity.java
@@ -1,7 +1,6 @@
 package uk.gov.pay.webhooks.webhook.entity;
 
-import uk.gov.pay.webhooks.webhook.WebhookDTO;
-
+import uk.gov.pay.webhooks.webhook.CreateWebhookRequest;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
@@ -44,12 +43,12 @@ public class WebhookEntity {
     @Enumerated(EnumType.STRING)
     private WebhookStatus status;
 
-    public static WebhookEntity from(WebhookDTO webhookDTO) {
+    public static WebhookEntity from(CreateWebhookRequest createWebhookRequest) {
         var entity = new WebhookEntity();
-        entity.setDescription(webhookDTO.getDescription());
-        entity.setCallbackUrl(webhookDTO.getCallbackUrl());
-        entity.setServiceId(webhookDTO.getServiceId());
-        entity.setLive(webhookDTO.isLive());
+        entity.setDescription(createWebhookRequest.getDescription());
+        entity.setCallbackUrl(createWebhookRequest.getCallbackUrl());
+        entity.setServiceId(createWebhookRequest.getServiceId());
+        entity.setLive(createWebhookRequest.isLive());
         entity.setCreatedDate(Date.from(Instant.now()));
         entity.setStatus(WebhookStatus.ACTIVE);
         entity.setExternalId(new BigInteger(130, new SecureRandom()).toString(32));

--- a/src/test/java/uk/gov/pay/webhooks/webhook/WebhookResourceTest.java
+++ b/src/test/java/uk/gov/pay/webhooks/webhook/WebhookResourceTest.java
@@ -1,0 +1,75 @@
+package uk.gov.pay.webhooks.webhook;
+
+import io.dropwizard.testing.junit5.DropwizardExtensionsSupport;
+import io.dropwizard.testing.junit5.ResourceExtension;
+import org.junit.Before;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import uk.gov.pay.webhooks.webhook.entity.WebhookEntity;
+import uk.gov.pay.webhooks.webhook.entity.dao.WebhookDao;
+
+import javax.ws.rs.client.Entity;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(DropwizardExtensionsSupport.class)
+public class WebhookResourceTest {
+   WebhookDao webhookDao = mock(WebhookDao.class);
+
+    public final ResourceExtension resources = ResourceExtension.builder()
+            .addResource(new WebhookResource(webhookDao))
+            .build();
+
+    @Before
+    public void setUp() {
+        when(webhookDao.create(any(WebhookEntity.class))).thenReturn(1L);
+    }
+
+    @Test
+    public void createWebhookWithValidParams() {
+        var json = """
+                {
+                    "service_id": "some-service-id",
+                    "callback_url": "https://some-callback-url.com",
+                    "live": true
+                }
+                """;
+        var response = resources
+                .target("/v1/webhook")
+                .request()
+                .post(Entity.json(json));
+
+        assertThat(response.getStatus(), is(200));
+    }
+
+    @Test
+    public void createWebhookWithMissingParamsRejected() {
+        var response = resources
+                .target("/v1/webhook")
+                .request()
+                .post(Entity.json(""));
+
+        assertThat(response.getStatus(), is(422));
+    }
+
+    @Test
+    public void createWebhookWithTooLongParamsRejected() {
+        var json = """
+                {
+                    "service_id": "some-service-id-that-is-way-toooooo-loooooooong",
+                    "callback_url": "https://some-callback-url.com",
+                    "live": true
+                }
+                """;
+        var response = resources
+                .target("/v1/webhook")
+                .request()
+                .post(Entity.json(json));
+
+        assertThat(response.getStatus(), is(422));
+    }
+}


### PR DESCRIPTION
Rename generic DTO to describe it as the serialiser for creating webhook
requests.

Build webhook entities from the create webhook request.

Add Jackson/ Javax annotations to the serialiser and resource to ensure
the required values are set, and are within correct constraints.

Unit test the resource layer for validations.