### PR TITLE
PP-8443 Get Webhook resource

### DIFF
--- a/src/main/java/uk/gov/pay/webhooks/app/WebhooksApp.java
+++ b/src/main/java/uk/gov/pay/webhooks/app/WebhooksApp.java
@@ -13,7 +13,7 @@ import io.dropwizard.setup.Environment;
 import uk.gov.pay.webhooks.healthcheck.HealthCheckResource;
 import uk.gov.pay.webhooks.healthcheck.Ping;
 import uk.gov.pay.webhooks.webhook.WebhookResource;
-import uk.gov.pay.webhooks.webhook.entity.WebhookEntity;
+import uk.gov.pay.webhooks.webhook.entity.Webhook;
 import uk.gov.service.payments.commons.utils.healthchecks.DatabaseHealthCheck;
 
 public class WebhooksApp extends Application<WebhooksConfig> {
@@ -21,7 +21,7 @@ public class WebhooksApp extends Application<WebhooksConfig> {
         new WebhooksApp().run(args);
     }
     
-    private HibernateBundle<WebhooksConfig> hibernate = new HibernateBundle<>(WebhookEntity.class) {
+    private HibernateBundle<WebhooksConfig> hibernate = new HibernateBundle<>(Webhook.class) {
         @Override
         public DataSourceFactory getDataSourceFactory(WebhooksConfig configuration) {
             return configuration.getDataSourceFactory();

--- a/src/main/java/uk/gov/pay/webhooks/webhook/WebhookResource.java
+++ b/src/main/java/uk/gov/pay/webhooks/webhook/WebhookResource.java
@@ -1,18 +1,25 @@
 package uk.gov.pay.webhooks.webhook;
 
 import io.dropwizard.hibernate.UnitOfWork;
-import uk.gov.pay.webhooks.webhook.entity.WebhookEntity;
+import uk.gov.pay.webhooks.webhook.entity.Webhook;
 import uk.gov.pay.webhooks.webhook.entity.dao.WebhookDao;
 
 import javax.inject.Inject;
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
+import javax.ws.rs.NotFoundException;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
-import javax.ws.rs.core.MediaType;
+
+import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 
 @Path("/v1/webhook")
+@Consumes(APPLICATION_JSON)
+@Produces(APPLICATION_JSON)
 public class WebhookResource {
     
     private final WebhookDao webhookDao;
@@ -24,9 +31,17 @@ public class WebhookResource {
     
     @UnitOfWork
     @POST
-    @Produces(MediaType.APPLICATION_JSON)
-    public long createWebhook(@NotNull @Valid CreateWebhookRequest webhookRequest) {
-        var webhook = WebhookEntity.from(webhookRequest);
+    public Webhook createWebhook(@NotNull @Valid CreateWebhookRequest webhookRequest) {
+        var webhook = Webhook.from(webhookRequest);
         return webhookDao.create(webhook);
+    }
+    
+    @UnitOfWork
+    @GET
+    @Path("/{externalId}")
+    public Webhook getWebhookByExternalId(@PathParam ("externalId")@NotNull @Valid String externalId) {
+        return webhookDao
+                .findByExternalId(externalId)
+                .orElseThrow(NotFoundException::new);
     }
 }

--- a/src/main/java/uk/gov/pay/webhooks/webhook/entity/Webhook.java
+++ b/src/main/java/uk/gov/pay/webhooks/webhook/entity/Webhook.java
@@ -1,6 +1,10 @@
 package uk.gov.pay.webhooks.webhook.entity;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import uk.gov.pay.webhooks.webhook.CreateWebhookRequest;
+
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
@@ -8,6 +12,7 @@ import javax.persistence.Enumerated;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.NamedQuery;
 import javax.persistence.SequenceGenerator;
 import javax.persistence.Table;
 import java.math.BigInteger;
@@ -15,36 +20,50 @@ import java.security.SecureRandom;
 import java.time.Instant;
 import java.util.Date;
 
+ 
+@NamedQuery(
+    name = Webhook.GET_BY_EXTERNAL_ID,
+    query = "select p from Webhook p where externalId = :externalId"
+)
 @Entity
+@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
 @SequenceGenerator(name="webhooks_id_seq", sequenceName = "webhooks_id_seq", allocationSize = 1)
 @Table(name = "webhooks")
-public class WebhookEntity {
+public class Webhook {
+    public static final String GET_BY_EXTERNAL_ID = "Webhook.get_webhook_by_external_id";
 
     @Id
     @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "webhooks_id_seq")
     private Long id;
-
+    
+    @JsonProperty
     @Column(name = "created_date")
     private Date createdDate;
-
+    
+    @JsonProperty
     @Column(name = "external_id")
     private String externalId;
 
+    @JsonProperty
     @Column(name = "service_id")
     private String serviceId;
 
+    @JsonProperty
     private boolean live;
 
+    @JsonProperty
     @Column(name = "callback_url")
     private String callbackUrl;
 
+    @JsonProperty
     private String description;
 
+    @JsonProperty
     @Enumerated(EnumType.STRING)
     private WebhookStatus status;
 
-    public static WebhookEntity from(CreateWebhookRequest createWebhookRequest) {
-        var entity = new WebhookEntity();
+    public static Webhook from(CreateWebhookRequest createWebhookRequest) {
+        var entity = new Webhook();
         entity.setDescription(createWebhookRequest.getDescription());
         entity.setCallbackUrl(createWebhookRequest.getCallbackUrl());
         entity.setServiceId(createWebhookRequest.getServiceId());
@@ -53,6 +72,35 @@ public class WebhookEntity {
         entity.setStatus(WebhookStatus.ACTIVE);
         entity.setExternalId(new BigInteger(130, new SecureRandom()).toString(32));
         return entity;
+    }
+
+    public Date getCreatedDate() {
+        return createdDate;
+    }
+
+    @JsonProperty
+    public String getExternalId() {
+        return externalId;
+    }
+
+    public String getServiceId() {
+        return serviceId;
+    }
+
+    public boolean isLive() {
+        return live;
+    }
+
+    public String getCallbackUrl() {
+        return callbackUrl;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public WebhookStatus getStatus() {
+        return status;
     }
 
     private void setExternalId(String externalId) {
@@ -86,5 +134,4 @@ public class WebhookEntity {
     public Long getId() {
         return id;
     }
-
 }

--- a/src/main/java/uk/gov/pay/webhooks/webhook/entity/dao/WebhookDao.java
+++ b/src/main/java/uk/gov/pay/webhooks/webhook/entity/dao/WebhookDao.java
@@ -2,23 +2,26 @@ package uk.gov.pay.webhooks.webhook.entity.dao;
 
 import io.dropwizard.hibernate.AbstractDAO;
 import org.hibernate.SessionFactory;
-import uk.gov.pay.webhooks.webhook.entity.WebhookEntity;
+import uk.gov.pay.webhooks.webhook.entity.Webhook;
 
 import javax.inject.Inject;
+import java.util.Optional;
 
-public class WebhookDao extends AbstractDAO<WebhookEntity> {
+public class WebhookDao extends AbstractDAO<Webhook> {
     
     @Inject
     public WebhookDao(SessionFactory factory) {
         super(factory);
     }
 
-    public WebhookEntity findById(Long id) {
-        return get(id);
+    public Webhook create(Webhook webhook) {
+        persist(webhook);
+        return webhook;
     }
 
-    public long create(WebhookEntity webhook) {
-        return persist(webhook).getId();
+    public Optional<Webhook> findByExternalId(String webhookExternalId) {
+        return Optional.ofNullable(namedTypedQuery(Webhook.GET_BY_EXTERNAL_ID)
+                .setParameter("externalId", webhookExternalId)
+                .getSingleResult());
     }
-
 }

--- a/src/test/java/uk/gov/pay/webhooks/webhook/WebhookResourceIT.java
+++ b/src/test/java/uk/gov/pay/webhooks/webhook/WebhookResourceIT.java
@@ -6,8 +6,11 @@ import uk.gov.pay.extension.AppWithPostgresExtension;
 
 import javax.ws.rs.core.Response;
 
+import java.util.Map;
+
 import static io.restassured.RestAssured.given;
 import static io.restassured.http.ContentType.JSON;
+import static org.hamcrest.CoreMatchers.is;
 
 
 public class WebhookResourceIT {
@@ -16,7 +19,7 @@ public class WebhookResourceIT {
     private Integer port = app.getAppRule().getLocalPort();
 
     @Test
-    public void shouldCreateAWebhook() {
+    public void shouldCreateAndRetrieveAWebhook() {
         var json = """
                 {
                   "service_id": "test_service_id",
@@ -26,11 +29,30 @@ public class WebhookResourceIT {
                 }
                 """;
 
-        given().port(port)
+        var response = given().port(port)
                 .contentType(JSON)
                 .body(json)
                 .post("/v1/webhook")
                 .then()
-                .statusCode(Response.Status.OK.getStatusCode());
+                .statusCode(Response.Status.OK.getStatusCode())
+                .body("service_id", is("test_service_id"))
+                .body("live", is(true))
+                .body("callback_url", is("https://example.com"))
+                .body("description", is("description"))
+                .extract().as(Map.class);
+        
+        var externalId = response.get("external_id");
+
+        
+        given().port(port)
+                .contentType(JSON)
+                .get("/v1/webhook/%s".formatted(externalId))
+                .then()
+                .statusCode(Response.Status.OK.getStatusCode())
+                .statusCode(Response.Status.OK.getStatusCode())
+                .body("service_id", is("test_service_id"))
+                .body("live", is(true))
+                .body("callback_url", is("https://example.com"))
+                .body("description", is("description"));
     }
 }


### PR DESCRIPTION
Adds ability to get webhook by external id.

Controversial things what I have done:

- renamed webhook entity to `Webhook` and used
this both as jpa entity and jackson response.
I think domain is currently sufficiently simple
that this is ok, and I reallly don't like writing
lots of things to change stuff from one pojo to
another. Happy to hear other opinions

- used named typed query and defined this on
Webhook entity. To my eye this makes everything
a bit cleaner and I like that queries are defined
with entity, and then DAO is responsible for
executing and handling result. Open to discuss this.

- removed mocking of Webhook thing from resource test:
this was breaking Jackson serialisation, and seems
unnecessary

- written one big WebhookResourceIT that posts to API
then retrieves from API. Seems like a nice test to have for now
and avoids need to squirt things in to DB to set up. May not
be sustainable.