### PR TITLE
PP-8443 add subscription persistence

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -149,6 +149,12 @@
             <version>4.4.0</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <version>1.2.140</version> <!-- ex: 1.2.140 -->
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/uk/gov/pay/webhooks/app/WebhooksApp.java
+++ b/src/main/java/uk/gov/pay/webhooks/app/WebhooksApp.java
@@ -12,6 +12,7 @@ import io.dropwizard.setup.Bootstrap;
 import io.dropwizard.setup.Environment;
 import uk.gov.pay.webhooks.healthcheck.HealthCheckResource;
 import uk.gov.pay.webhooks.healthcheck.Ping;
+import uk.gov.pay.webhooks.eventtype.dao.EventTypeEntity;
 import uk.gov.pay.webhooks.webhook.resource.WebhookResource;
 import uk.gov.pay.webhooks.webhook.dao.entity.WebhookEntity;
 import uk.gov.service.payments.commons.utils.healthchecks.DatabaseHealthCheck;
@@ -21,7 +22,10 @@ public class WebhooksApp extends Application<WebhooksConfig> {
         new WebhooksApp().run(args);
     }
     
-    private HibernateBundle<WebhooksConfig> hibernate = new HibernateBundle<>(WebhookEntity.class) {
+    private HibernateBundle<WebhooksConfig> hibernate = new HibernateBundle<>(
+            WebhookEntity.class,
+            EventTypeEntity.class
+    ) {
         @Override
         public DataSourceFactory getDataSourceFactory(WebhooksConfig configuration) {
             return configuration.getDataSourceFactory();

--- a/src/main/java/uk/gov/pay/webhooks/eventtype/EventTypeName.java
+++ b/src/main/java/uk/gov/pay/webhooks/eventtype/EventTypeName.java
@@ -1,0 +1,24 @@
+package uk.gov.pay.webhooks.eventtype;
+
+import java.util.stream.Stream;
+
+public enum EventTypeName {
+    CARD_PAYMENT_CAPTURED("card_payment_captured");
+    
+    private final String name;
+    
+    EventTypeName(String name) {
+        this.name = name;
+    }
+
+    public static EventTypeName of(String name) {
+        return Stream.of(EventTypeName.values())
+                .filter(p -> p.getName().equals(name))
+                .findFirst()
+                .orElseThrow(IllegalArgumentException::new);
+    }
+
+    public String getName() {
+        return this.name;
+    }
+}

--- a/src/main/java/uk/gov/pay/webhooks/eventtype/dao/EventTypeDao.java
+++ b/src/main/java/uk/gov/pay/webhooks/eventtype/dao/EventTypeDao.java
@@ -1,0 +1,22 @@
+package uk.gov.pay.webhooks.eventtype.dao;
+
+import io.dropwizard.hibernate.AbstractDAO;
+import org.hibernate.SessionFactory;
+import uk.gov.pay.webhooks.eventtype.EventTypeName;
+
+import javax.inject.Inject;
+import java.util.Optional;
+
+public class EventTypeDao extends AbstractDAO<EventTypeEntity> {
+
+    @Inject
+    public EventTypeDao(SessionFactory factory) {
+        super(factory);
+    }
+
+    public Optional<EventTypeEntity> findByName(EventTypeName eventTypeName) {
+        return Optional.ofNullable(namedTypedQuery(EventTypeEntity.GET_BY_NAME)
+                .setParameter("name", eventTypeName.getName())
+                .getSingleResult());
+    }
+}

--- a/src/main/java/uk/gov/pay/webhooks/eventtype/dao/EventTypeEntity.java
+++ b/src/main/java/uk/gov/pay/webhooks/eventtype/dao/EventTypeEntity.java
@@ -1,0 +1,60 @@
+package uk.gov.pay.webhooks.eventtype.dao;
+
+import uk.gov.pay.webhooks.eventtype.EventTypeName;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.NamedQuery;
+import javax.persistence.PostLoad;
+import javax.persistence.PrePersist;
+import javax.persistence.SequenceGenerator;
+import javax.persistence.Table;
+import javax.persistence.Transient;
+
+@NamedQuery(
+        name = EventTypeEntity.GET_BY_NAME,
+        query = "select e from EventTypeEntity e where name = :name"
+)
+@Entity
+@SequenceGenerator(name="event_types_id_seq", sequenceName = "event_types_id_seq", allocationSize = 1)
+@Table(name = "event_types")
+public class EventTypeEntity {
+    public static final String GET_BY_NAME = "EventTypeEntity.get_by_name";
+    //for JPA
+    public EventTypeEntity() {}
+    
+    public EventTypeEntity(EventTypeName name) {
+        this.name = name;
+    }
+    
+    @Id
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "event_types_id_seq")
+    private Long id;
+    
+    @Transient
+    private EventTypeName name;
+    
+    @Column(name = "name")
+    private String nameValue;
+
+    public EventTypeName getName() {
+        return name;
+    }
+
+    @PostLoad
+    void fillTransient() {
+        if (nameValue != null) {
+            this.name = EventTypeName.of(nameValue);
+        }
+    }
+
+    @PrePersist
+    void fillPersistent() {
+        if (name != null) {
+            this.nameValue = name.getName();
+        }
+    }
+}

--- a/src/main/java/uk/gov/pay/webhooks/webhook/dao/entity/WebhookEntity.java
+++ b/src/main/java/uk/gov/pay/webhooks/webhook/dao/entity/WebhookEntity.java
@@ -1,7 +1,9 @@
 package uk.gov.pay.webhooks.webhook.dao.entity;
 
+import uk.gov.pay.webhooks.eventtype.dao.EventTypeEntity;
 import uk.gov.pay.webhooks.webhook.resource.CreateWebhookRequest;
 
+import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
@@ -9,15 +11,21 @@ import javax.persistence.Enumerated;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.JoinTable;
 import javax.persistence.NamedQuery;
+import javax.persistence.OneToMany;
 import javax.persistence.SequenceGenerator;
 import javax.persistence.Table;
 import java.math.BigInteger;
 import java.security.SecureRandom;
 import java.time.Instant;
 import java.util.Date;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 
- 
+
 @NamedQuery(
     name = WebhookEntity.GET_BY_EXTERNAL_ID,
     query = "select p from WebhookEntity p where externalId = :externalId"
@@ -47,6 +55,12 @@ public class WebhookEntity {
     private String callbackUrl;
     
     private String description;
+    
+    @OneToMany(cascade = CascadeType.ALL)
+    @JoinTable(name="webhook_subscriptions",
+            joinColumns=@JoinColumn(name="webhook_id", referencedColumnName="id"),
+            inverseJoinColumns=@JoinColumn(name="event_type_id", referencedColumnName="id"))
+    Set<EventTypeEntity> subscriptions = new HashSet<>();
 
     
     @Enumerated(EnumType.STRING)
@@ -93,6 +107,10 @@ public class WebhookEntity {
         return status;
     }
 
+    public Set<EventTypeEntity> getSubscriptions() {
+        return subscriptions;
+    }
+
     private void setExternalId(String externalId) {
         this.externalId = externalId;
     }
@@ -119,5 +137,13 @@ public class WebhookEntity {
 
     public void setCreatedDate(Date instant) {
         this.createdDate = instant;
+    }
+
+    public void addSubscription(EventTypeEntity eventTypeEntity) {
+        this.subscriptions.add(eventTypeEntity);
+    }
+
+    public void addSubscriptions(List<EventTypeEntity> subscriptions) {
+        subscriptions.forEach(this::addSubscription);
     }
 }

--- a/src/main/resources/migrations/0002_create_table_event_types.sql
+++ b/src/main/resources/migrations/0002_create_table_event_types.sql
@@ -1,0 +1,12 @@
+--liquibase formatted sql
+
+--changeset uk.gov.pay:create-table-event_types
+
+CREATE table event_types (
+    id SERIAL PRIMARY KEY,
+    name VARCHAR(64) NOT NULL
+);
+
+INSERT INTO event_types(name) VALUES (('card_payment_captured'));
+
+--rollback DROP table event_types

--- a/src/main/resources/migrations/0003_create_table_webhook_subscriptions.sql
+++ b/src/main/resources/migrations/0003_create_table_webhook_subscriptions.sql
@@ -1,0 +1,13 @@
+--liquibase formatted sql
+
+--changeset uk.gov.pay:create-table-webhook_subscriptions
+
+CREATE table webhook_subscriptions (
+    webhook_id INT,
+    event_type_id INT
+);
+
+ALTER TABLE webhook_subscriptions ADD CONSTRAINT fk_webhook_id FOREIGN KEY (webhook_id) REFERENCES webhooks (id) ON DELETE CASCADE;
+ALTER TABLE webhook_subscriptions ADD CONSTRAINT fk_event_type_id FOREIGN KEY (event_type_id) REFERENCES event_types (id) ON DELETE CASCADE;
+
+--rollback DROP table webhook_subscriptions

--- a/src/test/java/uk/gov/pay/webhooks/webhook/dao/WebhookDaoTest.java
+++ b/src/test/java/uk/gov/pay/webhooks/webhook/dao/WebhookDaoTest.java
@@ -1,0 +1,47 @@
+package uk.gov.pay.webhooks.webhook.dao;
+
+import io.dropwizard.testing.junit5.DAOTestExtension;
+import io.dropwizard.testing.junit5.DropwizardExtensionsSupport;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import uk.gov.pay.webhooks.eventtype.EventTypeName;
+import uk.gov.pay.webhooks.eventtype.dao.EventTypeEntity;
+import uk.gov.pay.webhooks.webhook.dao.entity.WebhookEntity;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.any;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.iterableWithSize;
+
+@ExtendWith(DropwizardExtensionsSupport.class)
+public class WebhookDaoTest {
+
+    public DAOTestExtension database = DAOTestExtension.newBuilder()
+            .addEntityClass(WebhookEntity.class)
+            .addEntityClass(EventTypeEntity.class)
+            .build();
+
+    private WebhookDao webhookDao;
+
+    @BeforeEach
+    public void setUp() {
+        webhookDao = new WebhookDao(database.getSessionFactory());
+    }
+
+    @Test
+    public void persistsSubscriptions() {
+        
+        WebhookEntity persisted = database.inTransaction(() -> {
+            WebhookEntity webhookEntity = new WebhookEntity();
+            EventTypeEntity eventTypeEntity = new EventTypeEntity(EventTypeName.CARD_PAYMENT_CAPTURED);
+            webhookEntity.addSubscription(eventTypeEntity);
+            return webhookDao.create(webhookEntity);
+        });
+
+        assertThat(persisted.getSubscriptions(), iterableWithSize(1));
+        assertThat(persisted.getSubscriptions(), containsInAnyOrder(any(EventTypeEntity.class)));
+        assertThat(persisted.getSubscriptions().iterator().next().getName(), is(EventTypeName.CARD_PAYMENT_CAPTURED));
+    }
+}


### PR DESCRIPTION
Adds migrations and JPA things for event subscriptions.

As agreed we will use a join table to map webhooks to event
types. Ihave modelled inJPA as one to many because I don't think
we will ever care about tracing back from one event type
to see all the webhooks subscribed.
The migration includes the creation of a single event type
(card_payment_captured). This is largely to get things off
the ground and am happy to rename etc.
I have used an enum to model the name of the event type,
and then used some slightly fancy @transient logic to
automatically go from Enum to string and back. This means
we can use nice type safe enum through the business logic
and have it serialised to db correctly.
I have used a Dropwixard DAO test to test persistence layer
logic. I will add full integration test coverage
once resource end of things is done.