### PR TITLE
PP-8443 add subscriptions to webhook resource

### DIFF
--- a/src/main/java/uk/gov/pay/webhooks/eventtype/EventTypeName.java
+++ b/src/main/java/uk/gov/pay/webhooks/eventtype/EventTypeName.java
@@ -1,8 +1,11 @@
 package uk.gov.pay.webhooks.eventtype;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 import java.util.stream.Stream;
 
 public enum EventTypeName {
+    @JsonProperty("card_payment_captured")
     CARD_PAYMENT_CAPTURED("card_payment_captured");
     
     private final String name;
@@ -13,7 +16,7 @@ public enum EventTypeName {
 
     public static EventTypeName of(String name) {
         return Stream.of(EventTypeName.values())
-                .filter(p -> p.getName().equals(name))
+                .filter(n -> n.getName().equals(name))
                 .findFirst()
                 .orElseThrow(IllegalArgumentException::new);
     }

--- a/src/main/java/uk/gov/pay/webhooks/webhook/WebhookService.java
+++ b/src/main/java/uk/gov/pay/webhooks/webhook/WebhookService.java
@@ -1,0 +1,42 @@
+package uk.gov.pay.webhooks.webhook;
+
+import uk.gov.pay.webhooks.eventtype.EventTypeName;
+import uk.gov.pay.webhooks.eventtype.dao.EventTypeDao;
+import uk.gov.pay.webhooks.eventtype.dao.EventTypeEntity;
+import uk.gov.pay.webhooks.webhook.dao.WebhookDao;
+import uk.gov.pay.webhooks.webhook.dao.entity.WebhookEntity;
+import uk.gov.pay.webhooks.webhook.resource.CreateWebhookRequest;
+
+import javax.inject.Inject;
+import java.util.List;
+import java.util.Optional;
+
+public class WebhookService {
+    WebhookDao webhookDao;
+    
+    EventTypeDao eventTypeDao;
+
+    @Inject
+    public WebhookService(WebhookDao webhookDao, EventTypeDao eventTypeDao) {
+        this.webhookDao = webhookDao;
+        this.eventTypeDao = eventTypeDao;
+    }
+
+    public WebhookEntity createWebhook(CreateWebhookRequest createWebhookRequest) {
+        var webhookEntity = WebhookEntity.from(createWebhookRequest);
+        if (createWebhookRequest.subscriptions() != null) {
+            List<EventTypeEntity> subscribedEventTypes = createWebhookRequest.subscriptions().stream()
+                    .map(eventTypeName -> eventTypeDao.findByName(eventTypeName))
+                    .flatMap(Optional::stream)
+                    .toList();
+            webhookEntity.addSubscriptions(subscribedEventTypes);
+        }
+        webhookDao.create(webhookEntity);
+        
+        return webhookEntity;
+    }
+
+    public Optional<WebhookEntity> findByExternalId(String externalId) {
+        return webhookDao.findByExternalId(externalId);
+    }
+}

--- a/src/main/java/uk/gov/pay/webhooks/webhook/resource/CreateWebhookRequest.java
+++ b/src/main/java/uk/gov/pay/webhooks/webhook/resource/CreateWebhookRequest.java
@@ -1,14 +1,18 @@
 package uk.gov.pay.webhooks.webhook.resource;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import uk.gov.pay.webhooks.eventtype.EventTypeName;
+import uk.gov.pay.webhooks.eventtype.dao.EventTypeEntity;
 
 import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
+import java.util.List;
 
 public record CreateWebhookRequest(
         @JsonProperty("service_id") @NotEmpty @Size(max = 30) String serviceId,
         @JsonProperty("live") @NotNull Boolean live,
         @JsonProperty("callback_url") @NotEmpty @Size(max = 2048) String callbackUrl,
-        @JsonProperty("description") String description
+        @JsonProperty("description") String description,
+        @JsonProperty("subscriptions") List<EventTypeName> subscriptions
 ) {}

--- a/src/main/java/uk/gov/pay/webhooks/webhook/resource/WebhookResource.java
+++ b/src/main/java/uk/gov/pay/webhooks/webhook/resource/WebhookResource.java
@@ -1,19 +1,19 @@
 package uk.gov.pay.webhooks.webhook.resource;
 
 import io.dropwizard.hibernate.UnitOfWork;
+import uk.gov.pay.webhooks.webhook.WebhookService;
 import uk.gov.pay.webhooks.webhook.dao.entity.WebhookEntity;
-import uk.gov.pay.webhooks.webhook.dao.WebhookDao;
 
 import javax.inject.Inject;
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 import javax.ws.rs.Consumes;
-import javax.ws.rs.Produces;
 import javax.ws.rs.GET;
-import javax.ws.rs.POST;
 import javax.ws.rs.NotFoundException;
+import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
 
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 
@@ -22,17 +22,17 @@ import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 @Produces(APPLICATION_JSON)
 public class WebhookResource {
     
-    private final WebhookDao webhookDao;
+    private final WebhookService webhookService;
     
     @Inject
-    public WebhookResource(WebhookDao webhookDao) {
-        this.webhookDao = webhookDao;
+    public WebhookResource(WebhookService webhookService) {
+        this.webhookService = webhookService;
     }
     
     @UnitOfWork
     @POST
     public WebhookResponse createWebhook(@NotNull @Valid CreateWebhookRequest webhookRequest) {
-        var webhookEntity = webhookDao.create(WebhookEntity.from(webhookRequest));
+        WebhookEntity webhookEntity = webhookService.createWebhook(webhookRequest);
         return WebhookResponse.from(webhookEntity);
     }
     
@@ -40,7 +40,7 @@ public class WebhookResource {
     @GET
     @Path("/{externalId}")
     public WebhookResponse getWebhookByExternalId(@PathParam("externalId") @NotNull String externalId) {
-        return webhookDao
+        return webhookService
                 .findByExternalId(externalId)
                 .map(WebhookResponse::from)
                 .orElseThrow(NotFoundException::new);

--- a/src/main/java/uk/gov/pay/webhooks/webhook/resource/WebhookResponse.java
+++ b/src/main/java/uk/gov/pay/webhooks/webhook/resource/WebhookResponse.java
@@ -1,8 +1,12 @@
 package uk.gov.pay.webhooks.webhook.resource;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import uk.gov.pay.webhooks.eventtype.EventTypeName;
+import uk.gov.pay.webhooks.eventtype.dao.EventTypeEntity;
 import uk.gov.pay.webhooks.webhook.dao.entity.WebhookEntity;
 import uk.gov.pay.webhooks.webhook.dao.entity.WebhookStatus;
+
+import java.util.List;
 
 public record WebhookResponse(
         @JsonProperty("service_id") String serviceId,
@@ -11,7 +15,8 @@ public record WebhookResponse(
         @JsonProperty("description") String description,
         @JsonProperty("external_id") String externalId,
         @JsonProperty("status") WebhookStatus status,
-        @JsonProperty("created_date") String createdDate
+        @JsonProperty("created_date") String createdDate,
+        @JsonProperty("subscriptions") List<EventTypeName> subscriptions
 ) {
     public static WebhookResponse from(WebhookEntity webhookEntity) {
         return new WebhookResponse(
@@ -21,7 +26,10 @@ public record WebhookResponse(
                 webhookEntity.getDescription(),
                 webhookEntity.getExternalId(),
                 webhookEntity.getStatus(),
-                webhookEntity.getCreatedDate().toString()
+                webhookEntity.getCreatedDate().toString(),
+                webhookEntity.getSubscriptions().stream()
+                        .map(EventTypeEntity::getName)
+                        .toList()
         );
     }
 }

--- a/src/test/java/uk/gov/pay/webhooks/webhook/WebhookServiceTest.java
+++ b/src/test/java/uk/gov/pay/webhooks/webhook/WebhookServiceTest.java
@@ -1,0 +1,90 @@
+package uk.gov.pay.webhooks.webhook;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import uk.gov.pay.webhooks.eventtype.EventTypeName;
+import uk.gov.pay.webhooks.eventtype.dao.EventTypeDao;
+import uk.gov.pay.webhooks.eventtype.dao.EventTypeEntity;
+import uk.gov.pay.webhooks.webhook.dao.WebhookDao;
+import uk.gov.pay.webhooks.webhook.dao.entity.WebhookEntity;
+import uk.gov.pay.webhooks.webhook.resource.CreateWebhookRequest;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertThrows;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class WebhookServiceTest {
+    private WebhookDao webhookDao = mock(WebhookDao.class);
+    private EventTypeDao eventTypeDao = mock(EventTypeDao.class);
+    private WebhookService webhookService;
+    private String serviceId = "test_service_id";
+    private String callbackUrl = "test_callback_url";
+    private boolean live = true;
+    private String description = "test_description";
+    
+    @BeforeEach
+    public void setUp() {
+        webhookService = new WebhookService(webhookDao, eventTypeDao);
+    }
+
+    @Test
+    public void shouldCallWebhookDaoWithAllSetAttributes() {
+        EventTypeEntity eventTypeEntity = new EventTypeEntity(EventTypeName.CARD_PAYMENT_CAPTURED);
+        when(eventTypeDao.findByName(eq(EventTypeName.CARD_PAYMENT_CAPTURED)))
+                .thenReturn(Optional.of(eventTypeEntity));
+        
+        var createWebhookRequest = new CreateWebhookRequest(
+                serviceId,
+                live,
+                callbackUrl,
+                description,
+                List.of(EventTypeName.CARD_PAYMENT_CAPTURED)
+        );
+
+        webhookService.createWebhook(createWebhookRequest);
+
+        ArgumentCaptor<WebhookEntity> argumentCaptor = ArgumentCaptor.forClass(WebhookEntity.class);
+        verify(webhookDao).create(argumentCaptor.capture());
+        WebhookEntity captured = argumentCaptor.getAllValues().get(0);
+
+        assertThat(
+                captured.getSubscriptions()
+                        .iterator().next().getName().getName(),
+                is("card_payment_captured")
+        );
+        assertThat(captured.getServiceId(), is(serviceId));
+        assertThat(captured.getCallbackUrl(), is(callbackUrl));
+        assertThat(captured.getDescription(), is(description));
+        assertThat(captured.isLive(), is(live));
+    }
+
+    @Test
+    public void shouldCallWebhookDaoWithOnlyRequiredAttributes() {
+        var createWebhookRequest = new CreateWebhookRequest(
+                serviceId,
+                live,
+                callbackUrl,
+                null,
+                null
+        );
+
+        webhookService.createWebhook(createWebhookRequest);
+
+        ArgumentCaptor<WebhookEntity> argumentCaptor = ArgumentCaptor.forClass(WebhookEntity.class);
+        verify(webhookDao).create(argumentCaptor.capture());
+        WebhookEntity captured = argumentCaptor.getAllValues().get(0);
+
+        assertThat(captured.getServiceId(), is(serviceId));
+        assertThat(captured.getCallbackUrl(), is(callbackUrl));
+        assertThat(captured.isLive(), is(live));    
+    }
+}
+

--- a/src/test/java/uk/gov/pay/webhooks/webhook/resource/WebhookResourceIT.java
+++ b/src/test/java/uk/gov/pay/webhooks/webhook/resource/WebhookResourceIT.java
@@ -1,16 +1,16 @@
-package uk.gov.pay.webhooks.webhook;
+package uk.gov.pay.webhooks.webhook.resource;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import uk.gov.pay.extension.AppWithPostgresExtension;
 
 import javax.ws.rs.core.Response;
-
 import java.util.Map;
 
 import static io.restassured.RestAssured.given;
 import static io.restassured.http.ContentType.JSON;
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.Matchers.containsInAnyOrder;
 
 
 public class WebhookResourceIT {
@@ -25,7 +25,8 @@ public class WebhookResourceIT {
                   "service_id": "test_service_id",
                   "live": true,
                   "callback_url": "https://example.com",
-                  "description": "description"
+                  "description": "description",
+                  "subscriptions": ["card_payment_captured"]
                 }
                 """;
 
@@ -40,6 +41,7 @@ public class WebhookResourceIT {
                 .body("callback_url", is("https://example.com"))
                 .body("description", is("description"))
                 .body("status", is("ACTIVE"))
+                .body("subscriptions", containsInAnyOrder("card_payment_captured"))
                 .extract()
                 .as(Map.class);
         
@@ -54,6 +56,7 @@ public class WebhookResourceIT {
                 .body("live", is(true))
                 .body("callback_url", is("https://example.com"))
                 .body("description", is("description"))
-                .body("status", is("ACTIVE"));
+                .body("status", is("ACTIVE"))
+                .body("subscriptions", containsInAnyOrder("card_payment_captured"));
     }
 }


### PR DESCRIPTION
Adds functionality to set webhook subscriptions on
webhook creation, and retrieve subscriptions as part of
webhook.

I have used a webhook service to encapsulate the small
amount of business logic needed to deal with subscriptions.

There is probably more to do on validation, but using
an enum for event type names gets us a lot of the way
there.