### PR TITLE
PP-8506 require serviceId when getting single webhook

### DIFF
--- a/src/main/java/uk/gov/pay/webhooks/webhook/WebhookService.java
+++ b/src/main/java/uk/gov/pay/webhooks/webhook/WebhookService.java
@@ -36,7 +36,7 @@ public class WebhookService {
         return webhookEntity;
     }
 
-    public Optional<WebhookEntity> findByExternalId(String externalId) {
-        return webhookDao.findByExternalId(externalId);
+    public Optional<WebhookEntity> findByExternalId(String externalId, String serviceId) {
+        return webhookDao.findByExternalId(externalId, serviceId);
     }
 }

--- a/src/main/java/uk/gov/pay/webhooks/webhook/dao/WebhookDao.java
+++ b/src/main/java/uk/gov/pay/webhooks/webhook/dao/WebhookDao.java
@@ -19,9 +19,10 @@ public class WebhookDao extends AbstractDAO<WebhookEntity> {
         return webhook;
     }
 
-    public Optional<WebhookEntity> findByExternalId(String webhookExternalId) {
-        return Optional.ofNullable(namedTypedQuery(WebhookEntity.GET_BY_EXTERNAL_ID)
+    public Optional<WebhookEntity> findByExternalId(String webhookExternalId, String serviceId) {
+        return Optional.ofNullable(namedTypedQuery(WebhookEntity.GET_BY_EXTERNAL_ID_AND_SERVICE_ID)
                 .setParameter("externalId", webhookExternalId)
+                .setParameter("serviceId", serviceId)
                 .getSingleResult());
     }
 }

--- a/src/main/java/uk/gov/pay/webhooks/webhook/dao/entity/WebhookEntity.java
+++ b/src/main/java/uk/gov/pay/webhooks/webhook/dao/entity/WebhookEntity.java
@@ -27,14 +27,14 @@ import java.util.Set;
 
 
 @NamedQuery(
-    name = WebhookEntity.GET_BY_EXTERNAL_ID,
-    query = "select p from WebhookEntity p where externalId = :externalId"
+    name = WebhookEntity.GET_BY_EXTERNAL_ID_AND_SERVICE_ID,
+    query = "select p from WebhookEntity p where externalId = :externalId and serviceId = :serviceId"
 )
 @Entity
 @SequenceGenerator(name="webhooks_id_seq", sequenceName = "webhooks_id_seq", allocationSize = 1)
 @Table(name = "webhooks")
 public class WebhookEntity {
-    public static final String GET_BY_EXTERNAL_ID = "Webhook.get_webhook_by_external_id";
+    public static final String GET_BY_EXTERNAL_ID_AND_SERVICE_ID = "Webhook.get_webhook_by_external_id_and_service_id";
 
     @Id
     @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "webhooks_id_seq")

--- a/src/main/java/uk/gov/pay/webhooks/webhook/resource/WebhookResource.java
+++ b/src/main/java/uk/gov/pay/webhooks/webhook/resource/WebhookResource.java
@@ -14,6 +14,7 @@ import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
 
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 
@@ -39,9 +40,10 @@ public class WebhookResource {
     @UnitOfWork
     @GET
     @Path("/{externalId}")
-    public WebhookResponse getWebhookByExternalId(@PathParam("externalId") @NotNull String externalId) {
+    public WebhookResponse getWebhookByExternalId(@PathParam("externalId") @NotNull String externalId,
+                                                  @QueryParam("service_id") @NotNull String serviceId) {
         return webhookService
-                .findByExternalId(externalId)
+                .findByExternalId(externalId, serviceId)
                 .map(WebhookResponse::from)
                 .orElseThrow(NotFoundException::new);
     }

--- a/src/test/java/uk/gov/pay/webhooks/webhook/resource/WebhookResourceIT.java
+++ b/src/test/java/uk/gov/pay/webhooks/webhook/resource/WebhookResourceIT.java
@@ -46,10 +46,11 @@ public class WebhookResourceIT {
                 .as(Map.class);
         
         var externalId = response.get("external_id");
+        var serviceId = response.get("service_id");
         
         given().port(port)
                 .contentType(JSON)
-                .get("/v1/webhook/%s".formatted(externalId))
+                .get("/v1/webhook/%s?service_id=%s".formatted(externalId, serviceId))
                 .then()
                 .statusCode(Response.Status.OK.getStatusCode())
                 .body("service_id", is("test_service_id"))


### PR DESCRIPTION
We want to make this additional check in line with similar endpoints on other microservices to ensure the frontend cannot accidentally get a webhook from a different service.