### PR TITLE
PP-8506: Fix 500 exception if no result found

### DIFF
--- a/src/main/java/uk/gov/pay/webhooks/webhook/dao/WebhookDao.java
+++ b/src/main/java/uk/gov/pay/webhooks/webhook/dao/WebhookDao.java
@@ -20,9 +20,11 @@ public class WebhookDao extends AbstractDAO<WebhookEntity> {
     }
 
     public Optional<WebhookEntity> findByExternalId(String webhookExternalId, String serviceId) {
-        return Optional.ofNullable(namedTypedQuery(WebhookEntity.GET_BY_EXTERNAL_ID_AND_SERVICE_ID)
-                .setParameter("externalId", webhookExternalId)
-                .setParameter("serviceId", serviceId)
-                .getSingleResult());
+            return namedTypedQuery(WebhookEntity.GET_BY_EXTERNAL_ID_AND_SERVICE_ID)
+                    .setParameter("externalId", webhookExternalId)
+                    .setParameter("serviceId", serviceId)
+                    .getResultList()
+                    .stream()
+                    .findFirst();
     }
 }

--- a/src/test/java/uk/gov/pay/webhooks/webhook/dao/WebhookDaoTest.java
+++ b/src/test/java/uk/gov/pay/webhooks/webhook/dao/WebhookDaoTest.java
@@ -9,9 +9,12 @@ import uk.gov.pay.webhooks.eventtype.EventTypeName;
 import uk.gov.pay.webhooks.eventtype.dao.EventTypeEntity;
 import uk.gov.pay.webhooks.webhook.dao.entity.WebhookEntity;
 
+import java.util.Optional;
+
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.any;
 import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.iterableWithSize;
 
@@ -43,5 +46,10 @@ public class WebhookDaoTest {
         assertThat(persisted.getSubscriptions(), iterableWithSize(1));
         assertThat(persisted.getSubscriptions(), containsInAnyOrder(any(EventTypeEntity.class)));
         assertThat(persisted.getSubscriptions().iterator().next().getName(), is(EventTypeName.CARD_PAYMENT_CAPTURED));
+    }
+    
+    @Test
+    public void notFoundEntityReturnsEmptyOption(){
+        assertThat(webhookDao.findByExternalId("foo", "bar").isEmpty(), equalTo(true));
     }
 }

--- a/src/test/java/uk/gov/pay/webhooks/webhook/resource/WebhookResourceIT.java
+++ b/src/test/java/uk/gov/pay/webhooks/webhook/resource/WebhookResourceIT.java
@@ -60,4 +60,14 @@ public class WebhookResourceIT {
                 .body("status", is("ACTIVE"))
                 .body("subscriptions", containsInAnyOrder("card_payment_captured"));
     }
+    
+    @Test
+    public void notFoundShouldReturn404() {
+        given().port(port)
+                .contentType(JSON)
+                .get("/v1/webhook/not-real-external-id?service_id=not-real-service-id")
+                .then()
+                .statusCode(Response.Status.NOT_FOUND.getStatusCode());
+    }
+    
 }


### PR DESCRIPTION
Previously we were erroneously returning a 500 when no result found.

Catching the exception should cause the desired 404 to occur. This is discussed here https://stackoverflow.com/a/2003015/238230

We didn't catch it previously, as the test we had: https://github.com/alphagov/pay-webhooks/blob/202df6b411fc43b89b1b4add52cb0d4bfdfcda7c/src/test/java/uk/gov/pay/webhooks/webhook/resource/WebhookResourceTest.java#L136 used a fixture which assumed an empty Optional was returned. 