### PR TITLE
PP-8507: add list unfiltered query parameter

### DIFF
--- a/src/main/java/uk/gov/pay/webhooks/webhook/WebhookService.java
+++ b/src/main/java/uk/gov/pay/webhooks/webhook/WebhookService.java
@@ -1,6 +1,5 @@
 package uk.gov.pay.webhooks.webhook;
 
-import uk.gov.pay.webhooks.eventtype.EventTypeName;
 import uk.gov.pay.webhooks.eventtype.dao.EventTypeDao;
 import uk.gov.pay.webhooks.eventtype.dao.EventTypeEntity;
 import uk.gov.pay.webhooks.webhook.dao.WebhookDao;
@@ -42,5 +41,10 @@ public class WebhookService {
     
     public List<WebhookEntity> list(boolean live, String serviceId) {
         return webhookDao.list(live, serviceId);
-    }
+    }      
+    
+    public List<WebhookEntity> list(boolean live) {
+        return webhookDao.list(live);
+    }    
+    
 }

--- a/src/main/java/uk/gov/pay/webhooks/webhook/dao/WebhookDao.java
+++ b/src/main/java/uk/gov/pay/webhooks/webhook/dao/WebhookDao.java
@@ -29,10 +29,18 @@ public class WebhookDao extends AbstractDAO<WebhookEntity> {
                     .findFirst();
     }
 
-    public List<WebhookEntity> list(boolean live, String serviceId) {
+    
+public List<WebhookEntity> list(boolean live, String serviceId) {
         return namedTypedQuery(WebhookEntity.LIST_BY_LIVE_AND_SERVICE_ID)
+        .setParameter("serviceId", serviceId)
+        .setParameter("live", live)
+        .getResultList();
+    }
+    
+
+    public List<WebhookEntity> list(boolean live) {
+        return  namedTypedQuery(WebhookEntity.LIST_BY_LIVE)
                 .setParameter("live", live)
-                .setParameter("serviceId", serviceId)
                 .getResultList();
     }
 }

--- a/src/main/java/uk/gov/pay/webhooks/webhook/dao/entity/WebhookEntity.java
+++ b/src/main/java/uk/gov/pay/webhooks/webhook/dao/entity/WebhookEntity.java
@@ -35,12 +35,18 @@ import java.util.Set;
     name = WebhookEntity.LIST_BY_LIVE_AND_SERVICE_ID,
     query = "select p from WebhookEntity p where live = :live and serviceId = :serviceId"
 )
+
+@NamedQuery(
+    name = WebhookEntity.LIST_BY_LIVE,
+    query = "select p from WebhookEntity p where live = :live"
+)
 @Entity
 @SequenceGenerator(name="webhooks_id_seq", sequenceName = "webhooks_id_seq", allocationSize = 1)
 @Table(name = "webhooks")
 public class WebhookEntity {
     public static final String GET_BY_EXTERNAL_ID_AND_SERVICE_ID = "Webhook.get_webhook_by_external_id_and_service_id";
-    public static final String LIST_BY_LIVE_AND_SERVICE_ID = "Webhook.list_webhooks";
+    public static final String LIST_BY_LIVE_AND_SERVICE_ID = "Webhook.list_webhooks_by_live_and_service_id";
+    public static final String LIST_BY_LIVE = "Webhook.list_webhooks_by_live";
 
     @Id
     @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "webhooks_id_seq")

--- a/src/test/java/uk/gov/pay/webhooks/webhook/dao/WebhookDaoTest.java
+++ b/src/test/java/uk/gov/pay/webhooks/webhook/dao/WebhookDaoTest.java
@@ -124,4 +124,45 @@ public class WebhookDaoTest {
             assertThat(webhookDao.list(true, "service-id-2"), iterableWithSize(0));
     }    
     
+    @Test
+    public void listsAllWebhooks() {
+        database.inTransaction(() -> {
+            WebhookEntity webhookEntityServiceOne = new WebhookEntity();
+            webhookEntityServiceOne.setLive(true);
+            webhookEntityServiceOne.setServiceId("service-id-1");
+            webhookDao.create(webhookEntityServiceOne);
+
+            WebhookEntity webhookEntityServiceTwo = new WebhookEntity();
+            webhookEntityServiceTwo.setLive(true);
+            webhookEntityServiceTwo.setServiceId("service-id-2");
+            webhookDao.create(webhookEntityServiceTwo);
+        }); 
+            
+        assertThat(webhookDao.list(true), iterableWithSize(2));
+    }
+
+    @Test
+    public void listsAllWebhooksFilteredByLive() {
+        database.inTransaction(() -> {
+            WebhookEntity webhookEntityLiveTrue = new WebhookEntity();
+            webhookEntityLiveTrue.setLive(true);
+            webhookEntityLiveTrue.setServiceId("service-id");
+            webhookDao.create(webhookEntityLiveTrue);
+
+            WebhookEntity webhookEntityLiveFalse = new WebhookEntity();
+            webhookEntityLiveFalse.setLive(false);
+            webhookEntityLiveFalse.setServiceId("service-id");
+            webhookDao.create(webhookEntityLiveFalse);            
+            
+            WebhookEntity webhookEntityLiveFalseTwo = new WebhookEntity();
+            webhookEntityLiveFalseTwo.setLive(false);
+            webhookEntityLiveFalseTwo.setServiceId("service-id-2");
+            webhookDao.create(webhookEntityLiveFalseTwo);
+        });
+        var response = webhookDao.list(false);
+        assertThat(response, iterableWithSize(2));
+        response.forEach(webhookEntity -> 
+                assertThat(webhookEntity.isLive(), equalTo(false)));
+    }
+        
 }

--- a/src/test/java/uk/gov/pay/webhooks/webhook/resource/WebhookResourceTest.java
+++ b/src/test/java/uk/gov/pay/webhooks/webhook/resource/WebhookResourceTest.java
@@ -16,7 +16,6 @@ import uk.gov.pay.webhooks.webhook.dao.entity.WebhookEntity;
 
 import javax.ws.rs.client.Entity;
 import java.time.Instant;
-import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
@@ -232,5 +231,35 @@ public class WebhookResourceTest {
                 .request()
                 .get();
         assertThat(response.getStatus(), is(400));
+    }    
+    
+    @Test
+    public void getWebhooksRequestWithServiceIdAndOverrideShould400() throws JsonProcessingException {
+        var response = resources
+                .target("/v1/webhook")
+                .queryParam("service_id", existingServiceId)
+                .queryParam("live", true)
+                .queryParam("override_service_id_restriction", true)
+                .request()
+                .get();
+        var objectMapper = new ObjectMapper();
+        Map<String, String> responseBody = objectMapper.readValue(response.readEntity(String.class), new TypeReference<>() {
+        });
+        assertThat(response.getStatus(), is(400));
+        assertThat(responseBody.get("message"), is("service_id not permitted when using override_service_id_restriction"));
+    }    
+    
+    @Test
+    public void getWebhooksRequestWithLiveParamOnlyShould400() throws JsonProcessingException {
+        var response = resources
+                .target("/v1/webhook")
+                .queryParam("live", true)
+                .request()
+                .get();
+        var objectMapper = new ObjectMapper();
+        Map<String, String> responseBody = objectMapper.readValue(response.readEntity(String.class), new TypeReference<>() {
+        });
+        assertThat(response.getStatus(), is(400));
+        assertThat(responseBody.get("message"), is("either service_id or override_service_id_restriction query parameter must be provided"));
     }
 }


### PR DESCRIPTION
setting `override_service_id_restriction=true` query parameter on `/webhook` to list all webhooks (filtered by live status).

Note, this is intended for use by admin interfaces e.g. Toolbox.