### PR TITLE
PP-8507: Add explicit ordering by created_date DESC

### DIFF
--- a/src/main/java/uk/gov/pay/webhooks/webhook/dao/entity/WebhookEntity.java
+++ b/src/main/java/uk/gov/pay/webhooks/webhook/dao/entity/WebhookEntity.java
@@ -33,12 +33,12 @@ import java.util.Set;
 
 @NamedQuery(
     name = WebhookEntity.LIST_BY_LIVE_AND_SERVICE_ID,
-    query = "select p from WebhookEntity p where live = :live and serviceId = :serviceId"
+    query = "select p from WebhookEntity p where live = :live and serviceId = :serviceId order by created_date DESC"
 )
 
 @NamedQuery(
     name = WebhookEntity.LIST_BY_LIVE,
-    query = "select p from WebhookEntity p where live = :live"
+    query = "select p from WebhookEntity p where live = :live order by created_date DESC"
 )
 @Entity
 @SequenceGenerator(name="webhooks_id_seq", sequenceName = "webhooks_id_seq", allocationSize = 1)

--- a/src/test/java/uk/gov/pay/webhooks/webhook/dao/WebhookDaoTest.java
+++ b/src/test/java/uk/gov/pay/webhooks/webhook/dao/WebhookDaoTest.java
@@ -9,8 +9,12 @@ import uk.gov.pay.webhooks.eventtype.EventTypeName;
 import uk.gov.pay.webhooks.eventtype.dao.EventTypeEntity;
 import uk.gov.pay.webhooks.webhook.dao.entity.WebhookEntity;
 
+import java.time.Instant;
+import java.util.Date;
+
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.any;
+import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
@@ -139,6 +143,26 @@ public class WebhookDaoTest {
         }); 
             
         assertThat(webhookDao.list(true), iterableWithSize(2));
+    }    
+    
+    @Test
+    public void listsAllWebhooksOrderedByCreatedDate() {
+        database.inTransaction(() -> {
+            WebhookEntity webhookEntityServiceOne = new WebhookEntity();
+            webhookEntityServiceOne.setLive(true);
+            webhookEntityServiceOne.setServiceId("service-id-1");
+            webhookEntityServiceOne.setCreatedDate(Date.from(Instant.parse("2007-12-03T10:15:30.00Z")));
+            webhookDao.create(webhookEntityServiceOne);
+
+            WebhookEntity webhookEntityServiceTwo = new WebhookEntity();
+            webhookEntityServiceTwo.setLive(true);
+            webhookEntityServiceTwo.setServiceId("service-id-newer-created-date");
+            webhookEntityServiceTwo.setCreatedDate(Date.from(Instant.parse("2020-12-03T10:15:30.00Z")));
+            webhookDao.create(webhookEntityServiceTwo);
+        });
+
+        assertThat(webhookDao.list(true).stream().map(WebhookEntity::getCreatedDate).toList(),
+                contains((Date.from(Instant.parse("2020-12-03T10:15:30.00Z"))),(Date.from(Instant.parse("2007-12-03T10:15:30.00Z")))));
     }
 
     @Test


### PR DESCRIPTION
Previously we did not have an explicit sort order. This now sorts by created date DESC in common with other apps.