### PR TITLE
PP-8814 Database migration to add webhooks_messages table

### DIFF
--- a/src/main/resources/migrations/0004_create_table_webhook_messages.sql
+++ b/src/main/resources/migrations/0004_create_table_webhook_messages.sql
@@ -1,0 +1,17 @@
+--liquibase formatted sql
+
+--changeset uk.gov.pay:create-table-webhook_messages
+
+CREATE table webhook_messages (
+    id BIGSERIAL PRIMARY KEY,
+    external_id VARCHAR(30) NOT NULL,
+    created_date TIMESTAMP WITH TIME ZONE NOT NULL,
+    webhook_id INT NOT NULL,
+    event_date TIMESTAMP WITH TIME ZONE NOT NULL,
+    event_type INT NOT NULL
+);
+
+ALTER TABLE webhook_messages ADD CONSTRAINT fk_webhook_message_webhook_id FOREIGN KEY (webhook_id) REFERENCES webhooks (id);
+ALTER TABLE webhook_messages ADD CONSTRAINT fk_webhook_message_event_type_id FOREIGN KEY (event_type) REFERENCES event_types (id);
+
+--rollback DROP table webhook_messages


### PR DESCRIPTION
A webhook message is a representation of what we will actually send to a service that has a webhook configured with a subscription to a particular event, combining data from the event itself and the transaction to which the event relates.