### PR TITLE
PP-8814 Filter internal events and build webhook message

### DIFF
--- a/src/main/java/uk/gov/pay/webhooks/app/WebhooksModule.java
+++ b/src/main/java/uk/gov/pay/webhooks/app/WebhooksModule.java
@@ -1,9 +1,14 @@
 package uk.gov.pay.webhooks.app;
 
 import com.google.inject.AbstractModule;
+import com.google.inject.Provides;
 import io.dropwizard.hibernate.HibernateBundle;
 import io.dropwizard.setup.Environment;
 import org.hibernate.SessionFactory;
+import uk.gov.pay.webhooks.util.ExternalIdGenerator;
+
+import javax.inject.Singleton;
+import java.time.InstantSource;
 
 public class WebhooksModule extends AbstractModule {
     private final WebhooksConfig configuration;
@@ -22,4 +27,17 @@ public class WebhooksModule extends AbstractModule {
         bind(Environment.class).toInstance(environment);
         bind(SessionFactory.class).toInstance(hibernate.getSessionFactory());
     }
+
+    @Provides
+    @Singleton
+    public InstantSource instantSource() {
+        return InstantSource.system();
+    }
+
+    @Provides
+    @Singleton
+    public ExternalIdGenerator externalIdGenerator() {
+        return new ExternalIdGenerator();
+    }
+
 }

--- a/src/main/java/uk/gov/pay/webhooks/message/EventMapper.java
+++ b/src/main/java/uk/gov/pay/webhooks/message/EventMapper.java
@@ -1,0 +1,20 @@
+package uk.gov.pay.webhooks.message;
+
+import uk.gov.pay.webhooks.eventtype.EventTypeName;
+
+import java.util.Map;
+import java.util.Optional;
+
+public class EventMapper {
+    private static final Map<String, EventTypeName> internalToWebhook = Map.of(
+            "CAPTURE_CONFIRMED", EventTypeName.CARD_PAYMENT_CAPTURED
+    );
+
+    private static final Map<EventTypeName, String> webhookToInternal = Map.of(
+            EventTypeName.CARD_PAYMENT_CAPTURED, "CAPTURE_CONFIRMED"
+    );
+
+    public static Optional<String> getInternalEventNameFor(EventTypeName webhookEventTypeName) {
+        return Optional.ofNullable(webhookToInternal.get(webhookEventTypeName));
+    }
+}

--- a/src/main/java/uk/gov/pay/webhooks/message/WebhookMessageService.java
+++ b/src/main/java/uk/gov/pay/webhooks/message/WebhookMessageService.java
@@ -1,0 +1,76 @@
+package uk.gov.pay.webhooks.message;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import uk.gov.pay.webhooks.eventtype.EventTypeName;
+import uk.gov.pay.webhooks.eventtype.dao.EventTypeDao;
+import uk.gov.pay.webhooks.ledger.LedgerService;
+import uk.gov.pay.webhooks.ledger.model.LedgerTransaction;
+import uk.gov.pay.webhooks.message.dao.WebhookMessageDao;
+import uk.gov.pay.webhooks.message.dao.entity.WebhookMessageEntity;
+import uk.gov.pay.webhooks.queue.InternalEvent;
+import uk.gov.pay.webhooks.util.ExternalIdGenerator;
+import uk.gov.pay.webhooks.webhook.WebhookService;
+import uk.gov.pay.webhooks.webhook.dao.entity.WebhookEntity;
+
+import javax.inject.Inject;
+import java.io.IOException;
+import java.time.InstantSource;
+import java.util.Date;
+
+public class WebhookMessageService {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(WebhookMessageService.class);
+
+    private final WebhookService webhookService;
+    private final LedgerService ledgerService;
+    private final EventTypeDao eventTypeDao;
+    private final InstantSource instantSource;
+    private final ExternalIdGenerator externalIdGenerator;
+    private final ObjectMapper objectMapper;
+    private final WebhookMessageDao webhookMessageDao;
+
+    @Inject
+    public WebhookMessageService(WebhookService webhookService,
+                                 LedgerService ledgerService, 
+                                 EventTypeDao eventTypeDao,
+                                 InstantSource instantSource,
+                                 ExternalIdGenerator externalIdGenerator,
+                                 ObjectMapper objectMapper,
+                                 WebhookMessageDao webhookMessageDao) {
+        this.webhookService = webhookService;
+        this.ledgerService = ledgerService;
+        this.eventTypeDao = eventTypeDao;
+        this.instantSource = instantSource;
+        this.externalIdGenerator = externalIdGenerator;
+        this.objectMapper = objectMapper;
+        this.webhookMessageDao = webhookMessageDao;
+    }
+    
+    public void handleInternalEvent(InternalEvent event) throws IOException, InterruptedException {
+        var subscribedWebhooks = webhookService.getWebhooksSubscribedToEvent(event);
+
+        if (!subscribedWebhooks.isEmpty()) {
+            LedgerTransaction ledgerTransaction = ledgerService.getTransaction(event.resourceExternalId()).orElseThrow(IllegalArgumentException::new);
+            subscribedWebhooks
+                    .stream()
+                    .map(webhook -> buildWebhookMessage(webhook, event, ledgerTransaction))
+                    .forEach(webhookMessageDao::create);
+        }
+    }
+
+    private WebhookMessageEntity buildWebhookMessage(WebhookEntity webhook, InternalEvent event, LedgerTransaction ledgerTransaction) {
+        JsonNode resource = objectMapper.valueToTree(ledgerTransaction); // will probably need some more transformation
+
+        var webhookMessageEntity = new WebhookMessageEntity();
+        webhookMessageEntity.setExternalId(externalIdGenerator.newExternalId());
+        webhookMessageEntity.setCreatedDate(Date.from(instantSource.instant()));
+        webhookMessageEntity.setWebhookEntity(webhook);
+        webhookMessageEntity.setEventDate(Date.from(event.eventDate().toInstant()));
+        webhookMessageEntity.setEventType(eventTypeDao.findByName(EventTypeName.of(event.eventType())).orElseThrow(IllegalArgumentException::new));
+        webhookMessageEntity.setResource(resource);
+        return webhookMessageEntity;
+    }
+}

--- a/src/main/java/uk/gov/pay/webhooks/message/dao/WebhookMessageDao.java
+++ b/src/main/java/uk/gov/pay/webhooks/message/dao/WebhookMessageDao.java
@@ -1,0 +1,20 @@
+package uk.gov.pay.webhooks.message.dao;
+
+import io.dropwizard.hibernate.AbstractDAO;
+import org.hibernate.SessionFactory;
+import uk.gov.pay.webhooks.message.dao.entity.WebhookMessageEntity;
+
+import javax.inject.Inject;
+
+public class WebhookMessageDao extends AbstractDAO<WebhookMessageEntity> {
+
+    @Inject
+    public WebhookMessageDao(SessionFactory factory) {
+        super(factory);
+        }
+        
+    public WebhookMessageEntity create(WebhookMessageEntity webhookMessage) {
+        persist(webhookMessage);
+        return webhookMessage;
+    }
+}

--- a/src/main/java/uk/gov/pay/webhooks/message/dao/entity/WebhookMessageEntity.java
+++ b/src/main/java/uk/gov/pay/webhooks/message/dao/entity/WebhookMessageEntity.java
@@ -1,6 +1,6 @@
 package uk.gov.pay.webhooks.message.dao.entity;
 
-import uk.gov.pay.webhooks.eventtype.EventTypeName;
+import com.fasterxml.jackson.databind.JsonNode;
 import uk.gov.pay.webhooks.eventtype.dao.EventTypeEntity;
 import uk.gov.pay.webhooks.webhook.dao.entity.WebhookEntity;
 
@@ -11,11 +11,8 @@ import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
-import javax.persistence.NamedQuery;
 import javax.persistence.SequenceGenerator;
 import javax.persistence.Table;
-import javax.persistence.Transient;
-import java.time.OffsetDateTime;
 import java.util.Date;
 
 @Entity
@@ -45,5 +42,55 @@ public class WebhookMessageEntity {
     @ManyToOne
     @JoinColumn(name = "event_type", updatable = false)
     private EventTypeEntity eventType;
+    
+    @Column(name = "resource")
+    private JsonNode resource;
 
+    public String getExternalId() {
+        return externalId;
+    }
+
+    public void setExternalId(String externalId) {
+        this.externalId = externalId;
+    }
+
+    public Date getCreatedDate() {
+        return createdDate;
+    }
+
+    public void setCreatedDate(Date createdDate) {
+        this.createdDate = createdDate;
+    }
+
+    public WebhookEntity getWebhookEntity() {
+        return webhookEntity;
+    }
+
+    public void setWebhookEntity(WebhookEntity webhookEntity) {
+        this.webhookEntity = webhookEntity;
+    }
+
+    public Date getEventDate() {
+        return eventDate;
+    }
+
+    public void setEventDate(Date eventDate) {
+        this.eventDate = eventDate;
+    }
+
+    public EventTypeEntity getEventType() {
+        return eventType;
+    }
+
+    public void setEventType(EventTypeEntity eventType) {
+        this.eventType = eventType;
+    }
+
+    public JsonNode getResource() {
+        return resource;
+    }
+
+    public void setResource(JsonNode resource) {
+        this.resource = resource;
+    }
 }

--- a/src/main/java/uk/gov/pay/webhooks/queue/InternalEvent.java
+++ b/src/main/java/uk/gov/pay/webhooks/queue/InternalEvent.java
@@ -1,0 +1,14 @@
+package uk.gov.pay.webhooks.queue;
+
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import uk.gov.service.payments.commons.api.json.MicrosecondPrecisionDateTimeSerializer;
+
+import java.time.ZonedDateTime;
+
+public record InternalEvent(
+        String eventType,
+        String serviceId,
+        Boolean live,
+        String resourceExternalId,
+        @JsonSerialize(using = MicrosecondPrecisionDateTimeSerializer.class) ZonedDateTime eventDate
+        ) {}

--- a/src/main/java/uk/gov/pay/webhooks/util/ExternalIdGenerator.java
+++ b/src/main/java/uk/gov/pay/webhooks/util/ExternalIdGenerator.java
@@ -1,0 +1,14 @@
+package uk.gov.pay.webhooks.util;
+
+import java.math.BigInteger;
+import java.security.SecureRandom;
+
+public class ExternalIdGenerator {
+
+    private static final SecureRandom SECURE_RANDOM = new SecureRandom();
+
+    public String newExternalId() {
+        return new BigInteger(130, SECURE_RANDOM).toString(32);
+    }
+
+}

--- a/src/main/java/uk/gov/pay/webhooks/webhook/dao/WebhookDao.java
+++ b/src/main/java/uk/gov/pay/webhooks/webhook/dao/WebhookDao.java
@@ -29,14 +29,12 @@ public class WebhookDao extends AbstractDAO<WebhookEntity> {
                     .findFirst();
     }
 
-    
-public List<WebhookEntity> list(boolean live, String serviceId) {
+    public List<WebhookEntity> list(boolean live, String serviceId) {
         return namedTypedQuery(WebhookEntity.LIST_BY_LIVE_AND_SERVICE_ID)
         .setParameter("serviceId", serviceId)
         .setParameter("live", live)
         .getResultList();
     }
-    
 
     public List<WebhookEntity> list(boolean live) {
         return  namedTypedQuery(WebhookEntity.LIST_BY_LIVE)

--- a/src/main/java/uk/gov/pay/webhooks/webhook/dao/entity/WebhookEntity.java
+++ b/src/main/java/uk/gov/pay/webhooks/webhook/dao/entity/WebhookEntity.java
@@ -17,8 +17,6 @@ import javax.persistence.NamedQuery;
 import javax.persistence.OneToMany;
 import javax.persistence.SequenceGenerator;
 import javax.persistence.Table;
-import java.math.BigInteger;
-import java.security.SecureRandom;
 import java.time.Instant;
 import java.util.Date;
 import java.util.HashSet;
@@ -78,15 +76,15 @@ public class WebhookEntity {
     @Enumerated(EnumType.STRING)
     private WebhookStatus status;
 
-    public static WebhookEntity from(CreateWebhookRequest createWebhookRequest) {
+    public static WebhookEntity from(CreateWebhookRequest createWebhookRequest, String externalId, Instant createdDate) {
         var entity = new WebhookEntity();
         entity.setDescription(createWebhookRequest.description());
         entity.setCallbackUrl(createWebhookRequest.callbackUrl());
         entity.setServiceId(createWebhookRequest.serviceId());
         entity.setLive(createWebhookRequest.live());
-        entity.setCreatedDate(Date.from(Instant.now()));
+        entity.setCreatedDate(Date.from(createdDate));
         entity.setStatus(WebhookStatus.ACTIVE);
-        entity.setExternalId(new BigInteger(130, new SecureRandom()).toString(32));
+        entity.setExternalId(externalId);
         return entity;
     }
 

--- a/src/main/resources/migrations/0004_create_table_webhook_messages.sql
+++ b/src/main/resources/migrations/0004_create_table_webhook_messages.sql
@@ -8,7 +8,8 @@ CREATE table webhook_messages (
     created_date TIMESTAMP WITH TIME ZONE NOT NULL,
     webhook_id INT NOT NULL,
     event_date TIMESTAMP WITH TIME ZONE NOT NULL,
-    event_type INT NOT NULL
+    event_type INT NOT NULL,
+    resource JSONB NOT NULL
 );
 
 ALTER TABLE webhook_messages ADD CONSTRAINT fk_webhook_message_webhook_id FOREIGN KEY (webhook_id) REFERENCES webhooks (id);


### PR DESCRIPTION
Adds webhook message service with method `handleInternalEvent`
that will be used to process incoming internal events.
At the moment the method finds webhooks subscribed to
the event, and then for each such webhook builds a webhook
message (including fetching transaction from ledger),
and stores it.

I have added a test for the filtering, but will leave off
writing an integration test until we have this working end
to end.