### PR TITLE
PP-8849: provision signing key

### DIFF
--- a/src/main/java/uk/gov/pay/webhooks/app/WebhooksModule.java
+++ b/src/main/java/uk/gov/pay/webhooks/app/WebhooksModule.java
@@ -5,7 +5,7 @@ import com.google.inject.Provides;
 import io.dropwizard.hibernate.HibernateBundle;
 import io.dropwizard.setup.Environment;
 import org.hibernate.SessionFactory;
-import uk.gov.pay.webhooks.util.ExternalIdGenerator;
+import uk.gov.pay.webhooks.util.IdGenerator;
 
 import javax.inject.Singleton;
 import java.time.InstantSource;
@@ -36,8 +36,8 @@ public class WebhooksModule extends AbstractModule {
 
     @Provides
     @Singleton
-    public ExternalIdGenerator externalIdGenerator() {
-        return new ExternalIdGenerator();
+    public IdGenerator externalIdGenerator() {
+        return new IdGenerator();
     }
 
 }

--- a/src/main/java/uk/gov/pay/webhooks/message/WebhookMessageService.java
+++ b/src/main/java/uk/gov/pay/webhooks/message/WebhookMessageService.java
@@ -11,7 +11,7 @@ import uk.gov.pay.webhooks.ledger.model.LedgerTransaction;
 import uk.gov.pay.webhooks.message.dao.WebhookMessageDao;
 import uk.gov.pay.webhooks.message.dao.entity.WebhookMessageEntity;
 import uk.gov.pay.webhooks.queue.InternalEvent;
-import uk.gov.pay.webhooks.util.ExternalIdGenerator;
+import uk.gov.pay.webhooks.util.IdGenerator;
 import uk.gov.pay.webhooks.webhook.WebhookService;
 import uk.gov.pay.webhooks.webhook.dao.entity.WebhookEntity;
 
@@ -28,7 +28,7 @@ public class WebhookMessageService {
     private final LedgerService ledgerService;
     private final EventTypeDao eventTypeDao;
     private final InstantSource instantSource;
-    private final ExternalIdGenerator externalIdGenerator;
+    private final IdGenerator idGenerator;
     private final ObjectMapper objectMapper;
     private final WebhookMessageDao webhookMessageDao;
 
@@ -37,14 +37,14 @@ public class WebhookMessageService {
                                  LedgerService ledgerService, 
                                  EventTypeDao eventTypeDao,
                                  InstantSource instantSource,
-                                 ExternalIdGenerator externalIdGenerator,
+                                 IdGenerator idGenerator,
                                  ObjectMapper objectMapper,
                                  WebhookMessageDao webhookMessageDao) {
         this.webhookService = webhookService;
         this.ledgerService = ledgerService;
         this.eventTypeDao = eventTypeDao;
         this.instantSource = instantSource;
-        this.externalIdGenerator = externalIdGenerator;
+        this.idGenerator = idGenerator;
         this.objectMapper = objectMapper;
         this.webhookMessageDao = webhookMessageDao;
     }
@@ -65,7 +65,7 @@ public class WebhookMessageService {
         JsonNode resource = objectMapper.valueToTree(ledgerTransaction); // will probably need some more transformation
 
         var webhookMessageEntity = new WebhookMessageEntity();
-        webhookMessageEntity.setExternalId(externalIdGenerator.newExternalId());
+        webhookMessageEntity.setExternalId(idGenerator.newExternalId());
         webhookMessageEntity.setCreatedDate(Date.from(instantSource.instant()));
         webhookMessageEntity.setWebhookEntity(webhook);
         webhookMessageEntity.setEventDate(Date.from(event.eventDate().toInstant()));

--- a/src/main/java/uk/gov/pay/webhooks/util/IdGenerator.java
+++ b/src/main/java/uk/gov/pay/webhooks/util/IdGenerator.java
@@ -3,12 +3,18 @@ package uk.gov.pay.webhooks.util;
 import java.math.BigInteger;
 import java.security.SecureRandom;
 
-public class ExternalIdGenerator {
+public class IdGenerator {
 
     private static final SecureRandom SECURE_RANDOM = new SecureRandom();
+    private static final String PREFIX_TEST = "webhook_test_";
+    private static final String PREFIX_LIVE = "webhook_live_";
 
     public String newExternalId() {
         return new BigInteger(130, SECURE_RANDOM).toString(32);
+    }
+
+    public String newWebhookSigningKey(boolean live) {
+        return (live ? PREFIX_LIVE : PREFIX_TEST) + newExternalId();
     }
 
 }

--- a/src/main/java/uk/gov/pay/webhooks/webhook/dao/entity/WebhookEntity.java
+++ b/src/main/java/uk/gov/pay/webhooks/webhook/dao/entity/WebhookEntity.java
@@ -75,8 +75,11 @@ public class WebhookEntity {
     
     @Enumerated(EnumType.STRING)
     private WebhookStatus status;
+    
+    @Column(name = "signing_key")
+    private String signingKey;
 
-    public static WebhookEntity from(CreateWebhookRequest createWebhookRequest, String externalId, Instant createdDate) {
+    public static WebhookEntity from(CreateWebhookRequest createWebhookRequest, String externalId, Instant createdDate, String webhookSigningKey) {
         var entity = new WebhookEntity();
         entity.setDescription(createWebhookRequest.description());
         entity.setCallbackUrl(createWebhookRequest.callbackUrl());
@@ -85,6 +88,7 @@ public class WebhookEntity {
         entity.setCreatedDate(Date.from(createdDate));
         entity.setStatus(WebhookStatus.ACTIVE);
         entity.setExternalId(externalId);
+        entity.setSigningKey(webhookSigningKey);
         return entity;
     }
 
@@ -117,6 +121,10 @@ public class WebhookEntity {
         return status;
     }
 
+    public String getSigningKey() {
+        return signingKey;
+    }
+
     public Set<EventTypeEntity> getSubscriptions() {
         return subscriptions;
     }
@@ -147,6 +155,10 @@ public class WebhookEntity {
 
     public void setCreatedDate(Date instant) {
         this.createdDate = instant;
+    }
+    
+    public void setSigningKey(String signingKey) {
+        this.signingKey = signingKey;
     }
 
     public void addSubscription(EventTypeEntity eventTypeEntity) {

--- a/src/main/java/uk/gov/pay/webhooks/webhook/resource/SigningKeyResponse.java
+++ b/src/main/java/uk/gov/pay/webhooks/webhook/resource/SigningKeyResponse.java
@@ -1,0 +1,5 @@
+package uk.gov.pay.webhooks.webhook.resource;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record SigningKeyResponse(@JsonProperty("signing_key") String signingKey) {};

--- a/src/main/java/uk/gov/pay/webhooks/webhook/resource/WebhookResource.java
+++ b/src/main/java/uk/gov/pay/webhooks/webhook/resource/WebhookResource.java
@@ -59,6 +59,30 @@ public class WebhookResource {
                 .orElseThrow(NotFoundException::new);
     }
 
+
+    @UnitOfWork
+    @GET
+    @Path("/{externalId}/signing-key")
+    public SigningKeyResponse getSigningKeyByExternalId(@PathParam("externalId") @NotNull String externalId,
+                                                        @QueryParam("service_id") @NotNull String serviceId) {
+        return webhookService
+                .findByExternalId(externalId, serviceId)
+                .map(WebhookEntity::getSigningKey)
+                .map(SigningKeyResponse::new)
+                .orElseThrow(NotFoundException::new);
+    }
+    
+    @UnitOfWork
+    @POST
+    @Path("/{externalId}/signing-key")
+    public SigningKeyResponse regenerateSigningKey(@PathParam("externalId") @NotNull String externalId,
+                                                   @QueryParam("service_id") @NotNull String serviceId) {
+        return webhookService.regenerateSigningKey(externalId, serviceId)
+                .map(WebhookEntity::getSigningKey)
+                .map(SigningKeyResponse::new)
+                .orElseThrow(NotFoundException::new);
+    }
+
     @UnitOfWork
     @GET
     public List<WebhookResponse> getWebhooks(@NotNull @QueryParam("live") Boolean live,

--- a/src/main/resources/migrations/0001_create_table_webhooks.sql
+++ b/src/main/resources/migrations/0001_create_table_webhooks.sql
@@ -6,6 +6,7 @@ CREATE table webhooks (
     id SERIAL PRIMARY KEY,
     created_date TIMESTAMP WITHOUT TIME ZONE NOT NULL,
     external_id VARCHAR(30) NOT NULL,
+    signing_key VARCHAR(39) NOT NULL,
     service_id VARCHAR(32) NOT NULL,
     live BOOLEAN NOT NULL,
     callback_url VARCHAR(2048) NOT NULL,

--- a/src/test/java/uk/gov/pay/webhooks/webhook/resource/WebhookSigningKeyIT.java
+++ b/src/test/java/uk/gov/pay/webhooks/webhook/resource/WebhookSigningKeyIT.java
@@ -1,0 +1,90 @@
+package uk.gov.pay.webhooks.webhook.resource;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import uk.gov.pay.extension.AppWithPostgresExtension;
+import uk.gov.pay.webhooks.util.DatabaseTestHelper;
+
+import java.util.Map;
+
+import static io.restassured.RestAssured.given;
+import static io.restassured.http.ContentType.JSON;
+import static org.hamcrest.CoreMatchers.allOf;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.startsWith;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.anyOf;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.hasLength;
+import static org.hamcrest.Matchers.lessThanOrEqualTo;
+import static org.hamcrest.Matchers.not;
+
+public class WebhookSigningKeyIT {
+    @RegisterExtension
+    public static AppWithPostgresExtension app = new AppWithPostgresExtension();
+    private Integer port = app.getAppRule().getLocalPort();
+    private DatabaseTestHelper dbHelper;
+
+    @BeforeEach
+    public void setUp() {
+        dbHelper = DatabaseTestHelper.aDatabaseTestHelper(app.getJdbi());
+        dbHelper.truncateAllData();
+    }
+    
+    @Test
+    public void shouldGetThenRegenerateSigningKey() {
+        var json = """
+                {
+                  "service_id": "test_service_id",
+                  "live": true,
+                  "callback_url": "https://example.com",
+                  "description": "description",
+                  "subscriptions": ["card_payment_captured"]
+                }
+                """;
+        var response = given().port(port)
+                .contentType(JSON)
+                .body(json)
+                .post("/v1/webhook")
+                .then()
+                .statusCode(200)
+                .extract()
+                .as(Map.class);
+
+        var externalId = response.get("external_id");
+        var serviceId = response.get("service_id");
+        
+        var signingKeyResponse = given().port(port)
+                .contentType(JSON)
+                .get("/v1/webhook/%s/signing-key?service_id=%s".formatted(externalId, serviceId))
+                .then()
+                .statusCode(200)
+                .body("signing_key", startsWith("webhook_live_"))
+                .extract()
+                .as(Map.class);
+
+        var originalSigningKey = signingKeyResponse.get("signing_key");
+        assertThat(originalSigningKey.toString().length(), allOf(lessThanOrEqualTo(39), greaterThan(30))); //occasionally a shorter string is generated
+
+        var regeneratePostResponse = given().port(port)
+                .contentType(JSON)
+                .post("/v1/webhook/%s/signing-key?service_id=%s".formatted(externalId, serviceId))
+                .then()
+                .statusCode(200)
+                .body("signing_key", not(originalSigningKey))
+                .body("signing_key", startsWith("webhook_live_"))
+                .extract()
+                .as(Map.class);
+
+        var regeneratedSigningKey = regeneratePostResponse.get("signing_key");
+        assertThat(regeneratedSigningKey.toString().length(), allOf(lessThanOrEqualTo(39), greaterThan(30))); //occasionally a shorter string is generated
+
+        given().port(port)
+                .contentType(JSON)
+                .get("/v1/webhook/%s/signing-key?service_id=%s".formatted(externalId, serviceId))
+                .then()
+                .statusCode(200)
+                .body("signing_key", equalTo(regeneratedSigningKey));
+    }
+}


### PR DESCRIPTION
Sets a signing key when a Webhook is created
Provides get endpoint to retrieve signing key at: `GET /{externalId}/signing-key`
Provides post endpoint to reset signing key at: `POST /{externalId}/signing-key`

Note: As this changes an existing migration you will need to nuke your database to test locally.