### PR TITLE
PP-8813 Send webhook message with signature header

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
             <dependency>
                 <groupId>org.junit</groupId>
                 <artifactId>junit-bom</artifactId>
-                <version>5.8.1</version>
+                <version>5.8.2</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
@@ -150,7 +150,7 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-junit-jupiter</artifactId>
-            <version>4.0.0</version>
+            <version>4.1.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/main/java/uk/gov/pay/webhooks/message/WebhookMessageSender.java
+++ b/src/main/java/uk/gov/pay/webhooks/message/WebhookMessageSender.java
@@ -1,0 +1,49 @@
+package uk.gov.pay.webhooks.message;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import uk.gov.pay.webhooks.message.dao.entity.WebhookMessageEntity;
+
+import javax.inject.Inject;
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.security.InvalidKeyException;
+import java.time.Duration;
+
+public class WebhookMessageSender {
+
+    public static final String SIGNATURE_HEADER_NAME = "Pay-Signature";
+    public static final Duration TIMEOUT = Duration.ofSeconds(5);
+
+    private final HttpClient httpClient;
+    private final WebhookMessageSignatureGenerator webhookMessageSignatureGenerator;
+    private final ObjectMapper objectMapper;
+
+    @Inject
+    public WebhookMessageSender(HttpClient httpClient,
+                                ObjectMapper objectMapper,
+                                WebhookMessageSignatureGenerator webhookMessageSignatureGenerator) {
+        this.httpClient = httpClient;
+        this.webhookMessageSignatureGenerator = webhookMessageSignatureGenerator;
+        this.objectMapper = objectMapper;
+    }
+
+    public HttpResponse<String> sendWebhookMessage(WebhookMessageEntity webhookMessage) throws IOException, InterruptedException, InvalidKeyException {
+        URI uri = URI.create(webhookMessage.getWebhookEntity().getCallbackUrl());
+        String body = objectMapper.writeValueAsString(webhookMessage.getResource());
+        String signingKey = webhookMessage.getWebhookEntity().getSigningKey();
+        String signature = webhookMessageSignatureGenerator.generate(body, signingKey);
+
+        var httpRequest = HttpRequest.newBuilder(uri)
+                .timeout(TIMEOUT)
+                .header("Content-Type", "application/json")
+                .header(SIGNATURE_HEADER_NAME, signature)
+                .POST(HttpRequest.BodyPublishers.ofString(body))
+                .build();
+
+        return httpClient.send(httpRequest, HttpResponse.BodyHandlers.ofString());
+    }
+
+}

--- a/src/main/java/uk/gov/pay/webhooks/message/WebhookMessageSignatureGenerator.java
+++ b/src/main/java/uk/gov/pay/webhooks/message/WebhookMessageSignatureGenerator.java
@@ -1,0 +1,31 @@
+package uk.gov.pay.webhooks.message;
+
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+import java.util.HexFormat;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+public class WebhookMessageSignatureGenerator {
+
+    private static final String HMAC_SHA256 = "HmacSHA256";
+
+    public String generate(String body, String signingKey) throws InvalidKeyException {
+        Mac mac = getMac();
+        mac.init(new SecretKeySpec(signingKey.getBytes(UTF_8), HMAC_SHA256));
+        byte[] signature = mac.doFinal(body.getBytes(UTF_8));
+        return HexFormat.of().formatHex(signature);
+    }
+
+    private static Mac getMac() {
+        try {
+            return Mac.getInstance(HMAC_SHA256);
+        } catch (NoSuchAlgorithmException e) {
+            assert false : "This can never happen";
+            throw new IllegalStateException(e);
+        }
+    }
+
+}

--- a/src/test/java/uk/gov/pay/webhooks/message/WebhookMessageSenderTest.java
+++ b/src/test/java/uk/gov/pay/webhooks/message/WebhookMessageSenderTest.java
@@ -1,0 +1,112 @@
+package uk.gov.pay.webhooks.message;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.pay.webhooks.message.dao.entity.WebhookMessageEntity;
+import uk.gov.pay.webhooks.webhook.dao.entity.WebhookEntity;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.security.InvalidKeyException;
+import java.util.Optional;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static uk.gov.pay.webhooks.message.WebhookMessageSender.SIGNATURE_HEADER_NAME;
+import static uk.gov.pay.webhooks.message.WebhookMessageSender.TIMEOUT;
+
+@ExtendWith(MockitoExtension.class)
+class WebhookMessageSenderTest {
+
+    private static final String PAYLOAD = """
+            {
+                "json": "and",
+                "the": "argonauts"
+            }
+            """;
+
+    private static final URI CALLBACK_URL = URI.create("http://www.callbackurl.test/webhook-handler");
+    private static final String SIGNING_KEY = "Signing key";
+    private static final String SIGNATURE = "Signature";
+
+    @Mock
+    private HttpClient mockHttpClient;
+
+    @Mock
+    private WebhookMessageSignatureGenerator mockWebhookMessageSignatureGenerator;
+
+    @Mock
+    private HttpResponse<String> mockHttpResponse;
+    
+    private final ObjectMapper objectMapper = new ObjectMapper();
+    private WebhookMessageSender webhookMessageSender;
+    private WebhookMessageEntity webhookMessageEntity;
+    private WebhookEntity webhookEntity;
+    private JsonNode jsonPayload;
+
+    @BeforeEach
+    void setUp() throws JsonProcessingException, InvalidKeyException {
+        jsonPayload = objectMapper.readTree(PAYLOAD);
+
+        webhookEntity = new WebhookEntity(); 
+        webhookEntity.setCallbackUrl(CALLBACK_URL.toString());
+        webhookEntity.setSigningKey(SIGNING_KEY);
+
+        webhookMessageEntity = new WebhookMessageEntity();
+        webhookMessageEntity.setWebhookEntity(webhookEntity);
+        webhookMessageEntity.setResource(jsonPayload);
+
+        given(mockWebhookMessageSignatureGenerator.generate(jsonPayload.toString(), SIGNING_KEY)).willReturn(SIGNATURE);
+
+        webhookMessageSender = new WebhookMessageSender(mockHttpClient, objectMapper, mockWebhookMessageSignatureGenerator);
+    }
+
+    @Test
+    void constructsHttpRequestAndReturnsHttpResponse() throws IOException, InvalidKeyException, InterruptedException {
+        var httpRequestArgumentCaptor = ArgumentCaptor.forClass(HttpRequest.class);
+        given(mockHttpClient.send(httpRequestArgumentCaptor.capture(), eq(HttpResponse.BodyHandlers.ofString()))).willReturn(mockHttpResponse);
+
+        HttpResponse<String> result = webhookMessageSender.sendWebhookMessage(webhookMessageEntity);
+
+        HttpRequest httpRequest = httpRequestArgumentCaptor.getValue();
+        assertThat(httpRequest.uri(), is(CALLBACK_URL));
+        assertThat(httpRequest.timeout(), is(Optional.of(TIMEOUT)));
+        assertThat(httpRequest.headers().firstValue("Content-Type"), is(Optional.of("application/json")));
+        assertThat(httpRequest.headers().firstValue(SIGNATURE_HEADER_NAME), is(Optional.of(SIGNATURE)));
+
+        assertThat(result, is(mockHttpResponse));
+    }
+
+    @Test
+    void propagatesIOException() throws IOException, InterruptedException {
+        given(mockHttpClient.send(any(HttpRequest.class), eq(HttpResponse.BodyHandlers.ofString()))).willThrow(IOException.class);
+        assertThrows(IOException.class, () -> webhookMessageSender.sendWebhookMessage(webhookMessageEntity));
+    }
+
+    @Test
+    void propagatesInterruptedException() throws IOException, InterruptedException {
+        given(mockHttpClient.send(any(HttpRequest.class), eq(HttpResponse.BodyHandlers.ofString()))).willThrow(InterruptedException.class);
+        assertThrows(InterruptedException.class, () -> webhookMessageSender.sendWebhookMessage(webhookMessageEntity));
+    }
+
+    @Test
+    void propagatesInvalidKeyException() throws InvalidKeyException {
+        given(mockWebhookMessageSignatureGenerator.generate(jsonPayload.toString(), SIGNING_KEY)).willThrow(InvalidKeyException.class);
+        assertThrows(InvalidKeyException.class, () -> webhookMessageSender.sendWebhookMessage(webhookMessageEntity));
+    }
+
+}

--- a/src/test/java/uk/gov/pay/webhooks/message/WebhookMessageSignatureGeneratorTest.java
+++ b/src/test/java/uk/gov/pay/webhooks/message/WebhookMessageSignatureGeneratorTest.java
@@ -1,0 +1,20 @@
+package uk.gov.pay.webhooks.message;
+
+import org.junit.jupiter.api.Test;
+
+import java.security.InvalidKeyException;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+
+class WebhookMessageSignatureGeneratorTest {
+
+    private final WebhookMessageSignatureGenerator signatureGenerator = new WebhookMessageSignatureGenerator();
+
+    @Test
+    void generatesSignature() throws InvalidKeyException {
+        String signature = signatureGenerator.generate("We captured a £10 payment! 💷", "This is my secret key! 🔑");
+        assertThat(signature, is("a678c8326237dc08acabed4ec3948ee82f94c4b35cdc44b68f26fa8ef595efff")); // pragma: allowlist secret
+    }
+
+}


### PR DESCRIPTION
Not-yet-hooked-up-to-anything code to send a webhook message to the configured callback URL. The request includes an HTTP header of the following form:

```
Pay-Signature: <SHA-256 HMAC of body using configured secret>
```

The expected signature in `WebhookMessageSignatureGenerator` has been verified using two online HMAC generators.

`WebhookMessageSender` just concerns itself with sending the webhook. The response (which may have an HTTP status code indicating an error) is returned to the caller and exceptions are allowed to propagate. The future calling code will do something sensible to handle any errors.