### PR TITLE
PP-8986: Add integration test for receiving SQS message

### DIFF
--- a/src/test/java/uk/gov/pay/rule/SqsTestDocker.java
+++ b/src/test/java/uk/gov/pay/rule/SqsTestDocker.java
@@ -1,0 +1,78 @@
+package uk.gov.pay.rule;
+
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.client.builder.AwsClientBuilder;
+import com.amazonaws.services.sqs.AmazonSQS;
+import com.amazonaws.services.sqs.AmazonSQSClientBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
+
+public class SqsTestDocker {
+    private static final Logger logger = LoggerFactory.getLogger(SqsTestDocker.class);
+
+        private static GenericContainer sqsContainer;
+
+        public static AmazonSQS initialise(String... queues) {
+            try {
+                createContainer();
+                return createQueues(queues);
+            } catch (Exception e) {
+                logger.error("Exception initialising SQS Container - {}", e.getMessage());
+                throw new RuntimeException(e);
+            }
+        }
+
+        private static void createContainer() {
+            if (sqsContainer == null) {
+                logger.info("Creating SQS Container");
+
+                sqsContainer = new GenericContainer("roribio16/alpine-sqs")
+                        .withExposedPorts(9324)
+                        .waitingFor(Wait.forHttp("/?Action=GetQueueUrl&QueueName=default"));
+
+                sqsContainer.start();
+            }
+        }
+
+        public static void stopContainer() {
+            sqsContainer.stop();
+            sqsContainer = null;
+        }
+
+        private static AmazonSQS createQueues(String... queues) {
+            AmazonSQS amazonSQS = getSqsClient();
+            if (queues != null) {
+                for (String queue : queues) {
+                    amazonSQS.createQueue(queue);
+                }
+            }
+
+            return amazonSQS;
+        }
+
+        public static String getQueueUrl(String queueName) {
+            return getEndpoint() + "/queue/" + queueName;
+        }
+
+        public static String getEndpoint() {
+            return "http://localhost:" + sqsContainer.getMappedPort(9324);
+        }
+
+        private static AmazonSQS getSqsClient() {
+            // random credentials required by AWS SDK to build SQS client
+            BasicAWSCredentials awsCreds = new BasicAWSCredentials("x", "x");
+
+            return AmazonSQSClientBuilder.standard()
+                    .withCredentials(new AWSStaticCredentialsProvider(awsCreds))
+                    .withEndpointConfiguration(
+                            new AwsClientBuilder.EndpointConfiguration(
+                                    getEndpoint(),
+                                    "region-1"
+                            ))
+                    .withRequestHandlers()
+                    .build();
+        }
+}

--- a/src/test/java/uk/gov/pay/webhooks/healthcheck/HealthCheckResourceIT.java
+++ b/src/test/java/uk/gov/pay/webhooks/healthcheck/HealthCheckResourceIT.java
@@ -4,13 +4,13 @@ import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
-import uk.gov.pay.extension.AppWithPostgresExtension;
+import uk.gov.pay.extension.AppWithPostgresAndSqsExtension;
 
 import static org.hamcrest.Matchers.equalTo;
 
 public class HealthCheckResourceIT {
     @RegisterExtension
-    public static AppWithPostgresExtension app = new AppWithPostgresExtension();
+    public static AppWithPostgresAndSqsExtension app = new AppWithPostgresAndSqsExtension();
 
     @Test
     public void HealthCheckIsHealthyTest(){

--- a/src/test/java/uk/gov/pay/webhooks/queue/EventQueueIT.java
+++ b/src/test/java/uk/gov/pay/webhooks/queue/EventQueueIT.java
@@ -1,11 +1,13 @@
 package uk.gov.pay.webhooks.queue;
 
 import com.amazonaws.services.sqs.AmazonSQS;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import uk.gov.pay.extension.AppWithPostgresAndSqsExtension;
 import uk.gov.pay.rule.SqsTestDocker;
+import uk.gov.pay.webhooks.app.QueueMessageReceiverConfig;
 import uk.gov.pay.webhooks.app.SqsConfig;
 import uk.gov.pay.webhooks.app.WebhooksConfig;
 import uk.gov.pay.webhooks.queue.sqs.QueueException;
@@ -30,7 +32,7 @@ public class EventQueueIT {
     }
 
     @Test
-    public void shouldGetReceiveMessageFromTheQueue() throws QueueException {
+    public void shouldReceiveMessageFromTheQueue() throws QueueException {
         client.sendMessage(SqsTestDocker.getQueueUrl("event-queue"), "");
 
         SqsConfig sqsConfig = mock(SqsConfig.class);
@@ -43,7 +45,39 @@ public class EventQueueIT {
 
         List<QueueMessage> result = sqsQueueService.receiveMessages(SqsTestDocker.getQueueUrl("event-queue"), "All");
         assertFalse(result.isEmpty());
+        
     }
+    
+    @Test
+    public void shouldConvertValidMessageFromQueueToEventMessage() throws QueueException {
+        
+        var sqsMessage = """
+                {
+                	"serviceId": "my-id",
+                	"live": true,
+                	"timestamp": "2018-03-12T16:25:01.123456Z",
+                	"resource_external_id": "3uwuyr38rry",
+                	"eventType": "PAYMENT_CREATED",
+                	"event_details": {
+                		"example_event_details_field": "and its value"
+                	}
+                }""";
+        client.sendMessage(SqsTestDocker.getQueueUrl("event-queue"), sqsMessage);
 
+        SqsConfig sqsConfig = mock(SqsConfig.class);
+        when(sqsConfig.getMessageMaximumBatchSize()).thenReturn(10);
+        when(sqsConfig.getMessageMaximumWaitTimeInSeconds()).thenReturn(1);
+        when(sqsConfig.getEventQueueUrl()).thenReturn(SqsTestDocker.getQueueUrl("event-queue"));
+        QueueMessageReceiverConfig queueReceiverConfig = mock(QueueMessageReceiverConfig.class);
+        when(queueReceiverConfig.getMessageRetryDelayInSeconds()).thenReturn(10);
+        WebhooksConfig mockConfig = mock(WebhooksConfig.class);
+        when(mockConfig.getSqsConfig()).thenReturn(sqsConfig);
+        when(mockConfig.getQueueMessageReceiverConfig()).thenReturn(queueReceiverConfig);
 
+        SqsQueueService sqsQueueService = new SqsQueueService(client, mockConfig);
+        EventQueue eventQueue = new EventQueue(sqsQueueService, mockConfig, new ObjectMapper());
+
+        List<EventMessage> result = eventQueue.retrieveEvents();
+        assertFalse(result.isEmpty());
+    }
 }

--- a/src/test/java/uk/gov/pay/webhooks/queue/EventQueueIT.java
+++ b/src/test/java/uk/gov/pay/webhooks/queue/EventQueueIT.java
@@ -1,0 +1,49 @@
+package uk.gov.pay.webhooks.queue;
+
+import com.amazonaws.services.sqs.AmazonSQS;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import uk.gov.pay.extension.AppWithPostgresAndSqsExtension;
+import uk.gov.pay.rule.SqsTestDocker;
+import uk.gov.pay.webhooks.app.SqsConfig;
+import uk.gov.pay.webhooks.app.WebhooksConfig;
+import uk.gov.pay.webhooks.queue.sqs.QueueException;
+import uk.gov.pay.webhooks.queue.sqs.QueueMessage;
+import uk.gov.pay.webhooks.queue.sqs.SqsQueueService;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class EventQueueIT {
+
+    @RegisterExtension
+    public static AppWithPostgresAndSqsExtension rule = new AppWithPostgresAndSqsExtension();
+    private AmazonSQS client;
+
+    @BeforeEach
+    public void setUp() {
+        client = rule.getSqsClient();
+    }
+
+    @Test
+    public void shouldGetReceiveMessageFromTheQueue() throws QueueException {
+        client.sendMessage(SqsTestDocker.getQueueUrl("event-queue"), "");
+
+        SqsConfig sqsConfig = mock(SqsConfig.class);
+        when(sqsConfig.getMessageMaximumBatchSize()).thenReturn(10);
+        when(sqsConfig.getMessageMaximumWaitTimeInSeconds()).thenReturn(1);
+        WebhooksConfig mockConfig = mock(WebhooksConfig.class);
+        when(mockConfig.getSqsConfig()).thenReturn(sqsConfig);
+
+        SqsQueueService sqsQueueService = new SqsQueueService(client, mockConfig);
+
+        List<QueueMessage> result = sqsQueueService.receiveMessages(SqsTestDocker.getQueueUrl("event-queue"), "All");
+        assertFalse(result.isEmpty());
+    }
+
+
+}

--- a/src/test/java/uk/gov/pay/webhooks/webhook/resource/WebhookListIT.java
+++ b/src/test/java/uk/gov/pay/webhooks/webhook/resource/WebhookListIT.java
@@ -5,7 +5,7 @@ import com.fasterxml.jackson.databind.node.TextNode;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
-import uk.gov.pay.extension.AppWithPostgresExtension;
+import uk.gov.pay.extension.AppWithPostgresAndSqsExtension;
 import uk.gov.pay.webhooks.util.DatabaseTestHelper;
 
 import java.util.LinkedHashMap;
@@ -21,7 +21,7 @@ import static org.hamcrest.collection.IsIterableContainingInAnyOrder.containsInA
 
 public class WebhookListIT {
     @RegisterExtension
-    public static AppWithPostgresExtension app = new AppWithPostgresExtension();
+    public static AppWithPostgresAndSqsExtension app = new AppWithPostgresAndSqsExtension();
     private Integer port = app.getAppRule().getLocalPort();
     private DatabaseTestHelper dbHelper;
 

--- a/src/test/java/uk/gov/pay/webhooks/webhook/resource/WebhookResourceIT.java
+++ b/src/test/java/uk/gov/pay/webhooks/webhook/resource/WebhookResourceIT.java
@@ -3,9 +3,8 @@ package uk.gov.pay.webhooks.webhook.resource;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
-import uk.gov.pay.extension.AppWithPostgresExtension;
+import uk.gov.pay.extension.AppWithPostgresAndSqsExtension;
 import uk.gov.pay.webhooks.util.DatabaseTestHelper;
-import uk.gov.pay.webhooks.webhook.dao.WebhookDao;
 
 import javax.ws.rs.core.Response;
 import java.util.Map;
@@ -18,7 +17,7 @@ import static org.hamcrest.Matchers.containsInAnyOrder;
 
 public class WebhookResourceIT {
     @RegisterExtension
-    public static AppWithPostgresExtension app = new AppWithPostgresExtension();
+    public static AppWithPostgresAndSqsExtension app = new AppWithPostgresAndSqsExtension();
     private Integer port = app.getAppRule().getLocalPort();
     private DatabaseTestHelper dbHelper;
 

--- a/src/test/java/uk/gov/pay/webhooks/webhook/resource/WebhookSigningKeyIT.java
+++ b/src/test/java/uk/gov/pay/webhooks/webhook/resource/WebhookSigningKeyIT.java
@@ -3,7 +3,7 @@ package uk.gov.pay.webhooks.webhook.resource;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
-import uk.gov.pay.extension.AppWithPostgresExtension;
+import uk.gov.pay.extension.AppWithPostgresAndSqsExtension;
 import uk.gov.pay.webhooks.util.DatabaseTestHelper;
 
 import java.util.Map;
@@ -16,13 +16,12 @@ import static org.hamcrest.CoreMatchers.startsWith;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.anyOf;
 import static org.hamcrest.Matchers.greaterThan;
-import static org.hamcrest.Matchers.hasLength;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
 import static org.hamcrest.Matchers.not;
 
 public class WebhookSigningKeyIT {
     @RegisterExtension
-    public static AppWithPostgresExtension app = new AppWithPostgresExtension();
+    public static AppWithPostgresAndSqsExtension app = new AppWithPostgresAndSqsExtension();
     private Integer port = app.getAppRule().getLocalPort();
     private DatabaseTestHelper dbHelper;
 

--- a/src/test/java/uk/gov/pay/webhooks/webhook/resource/WebhookUpdateIT.java
+++ b/src/test/java/uk/gov/pay/webhooks/webhook/resource/WebhookUpdateIT.java
@@ -5,7 +5,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
-import uk.gov.pay.extension.AppWithPostgresExtension;
+import uk.gov.pay.extension.AppWithPostgresAndSqsExtension;
 import uk.gov.pay.webhooks.util.DatabaseTestHelper;
 
 import java.util.Map;
@@ -19,7 +19,7 @@ import static org.hamcrest.Matchers.containsInAnyOrder;
 
 public class WebhookUpdateIT {
     @RegisterExtension
-    public static AppWithPostgresExtension app = new AppWithPostgresExtension();
+    public static AppWithPostgresAndSqsExtension app = new AppWithPostgresAndSqsExtension();
     private Integer port = app.getAppRule().getLocalPort();
     private DatabaseTestHelper dbHelper;
 


### PR DESCRIPTION
This adds an integration test (and associated test harness based on that in Ledger) for the SQS receiving functionality added in #31 

It is anticipated we can also use this functionality in future as part of a more complete end-to-end webhooks integration test.