### PR TITLE
BAU Allow webhooks logs to go through to Splunk

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -74,6 +74,10 @@
         </dependency>
         <dependency>
             <groupId>io.dropwizard</groupId>
+            <artifactId>dropwizard-json-logging</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.dropwizard</groupId>
             <artifactId>dropwizard-migrations</artifactId>
             <exclusions>
                 <exclusion>
@@ -137,6 +141,11 @@
         <dependency>
             <groupId>uk.gov.service.payments</groupId>
             <artifactId>model</artifactId>
+            <version>${pay-java-commons.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>uk.gov.service.payments</groupId>
+            <artifactId>logging</artifactId>
             <version>${pay-java-commons.version}</version>
         </dependency>
 

--- a/src/main/java/uk/gov/pay/webhooks/app/WebhooksApp.java
+++ b/src/main/java/uk/gov/pay/webhooks/app/WebhooksApp.java
@@ -24,6 +24,8 @@ import uk.gov.pay.webhooks.queue.QueueMessageReceiver;
 import uk.gov.pay.webhooks.webhook.dao.entity.WebhookEntity;
 import uk.gov.pay.webhooks.webhook.resource.WebhookResource;
 import uk.gov.service.payments.commons.utils.healthchecks.DatabaseHealthCheck;
+import uk.gov.service.payments.logging.GovUkPayDropwizardRequestJsonLogLayoutFactory;
+import uk.gov.service.payments.logging.LogstashConsoleAppenderFactory;
 
 public class WebhooksApp extends Application<WebhooksConfig> {
     public static void main(String[] args) throws Exception {
@@ -73,6 +75,8 @@ public class WebhooksApp extends Application<WebhooksConfig> {
         });
 
         bootstrap.addBundle(hibernate);
+        bootstrap.getObjectMapper().getSubtypeResolver().registerSubtypes(LogstashConsoleAppenderFactory.class);
+        bootstrap.getObjectMapper().getSubtypeResolver().registerSubtypes(GovUkPayDropwizardRequestJsonLogLayoutFactory.class);
     }
 
 }

--- a/src/main/resources/config/config.yaml
+++ b/src/main/resources/config/config.yaml
@@ -2,10 +2,23 @@ server:
   applicationConnectors:
     - type: http
       port: ${PORT:-8080}
+  requestLog:
+    appenders:
+      - type: console
+        layout:
+          type: govuk-pay-access-json
+          additionalFields:
+            container: "webhooks"
+            environment: ${ENVIRONMENT}
 logging:
   level: INFO
-  loggers:
-    uk.gov.pay: DEBUG
+  appenders:
+    - type: logstash-console
+      threshold: ALL
+      target: stdout
+      customFields:
+        container: "webhooks"
+        environment: ${ENVIRONMENT}
 database:
   driverClass: org.postgresql.Driver
   user: ${DB_USER}


### PR DESCRIPTION
The lambda responsible for ingesting output from fargate instances
requires an `environment` attribute to be set (using commons structured
logging). This sets the `environment` and `container` attributes for all
messages logged by the service which will allow these lines to be
ingested.