### PR TITLE
PP-9001: Extract attempt sending logic in separate SendAttempter class

### DIFF
--- a/src/main/java/uk/gov/pay/webhooks/app/WebhooksModule.java
+++ b/src/main/java/uk/gov/pay/webhooks/app/WebhooksModule.java
@@ -5,11 +5,14 @@ import com.amazonaws.auth.BasicAWSCredentials;
 import com.amazonaws.client.builder.AwsClientBuilder;
 import com.amazonaws.services.sqs.AmazonSQS;
 import com.amazonaws.services.sqs.AmazonSQSClientBuilder;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.inject.AbstractModule;
 import com.google.inject.Provides;
 import io.dropwizard.hibernate.HibernateBundle;
 import io.dropwizard.setup.Environment;
 import org.hibernate.SessionFactory;
+import uk.gov.pay.webhooks.message.WebhookMessageSender;
+import uk.gov.pay.webhooks.message.WebhookMessageSignatureGenerator;
 import uk.gov.pay.webhooks.util.IdGenerator;
 
 import javax.inject.Singleton;
@@ -51,6 +54,13 @@ public class WebhooksModule extends AbstractModule {
     @Singleton
     public HttpClient httpClient() {
         return HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(5)).build();
+    }
+
+    @Provides
+    @Singleton
+    public WebhookMessageSender webhookMessageSender() {
+        return new WebhookMessageSender(httpClient(), new ObjectMapper(),
+                new WebhookMessageSignatureGenerator());
     }
 
     @Provides

--- a/src/main/java/uk/gov/pay/webhooks/deliveryqueue/managed/SendAttempter.java
+++ b/src/main/java/uk/gov/pay/webhooks/deliveryqueue/managed/SendAttempter.java
@@ -1,0 +1,92 @@
+package uk.gov.pay.webhooks.deliveryqueue.managed;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import uk.gov.pay.webhooks.deliveryqueue.dao.WebhookDeliveryQueueDao;
+import uk.gov.pay.webhooks.deliveryqueue.dao.WebhookDeliveryQueueEntity;
+import uk.gov.pay.webhooks.message.WebhookMessageSender;
+
+import javax.inject.Inject;
+import javax.ws.rs.core.Response;
+import java.io.IOException;
+import java.net.http.HttpTimeoutException;
+import java.security.InvalidKeyException;
+import java.time.Duration;
+import java.time.InstantSource;
+import java.time.temporal.ChronoUnit;
+import java.util.Date;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public class SendAttempter {
+    private static final Logger LOGGER = LoggerFactory.getLogger(SendAttempter.class);
+    private WebhookDeliveryQueueDao webhookDeliveryQueueDao;
+    private InstantSource instantSource;
+    private WebhookMessageSender webhookMessageSender;
+
+    @Inject
+    public SendAttempter(WebhookDeliveryQueueDao webhookDeliveryQueueDao, InstantSource instantSource, WebhookMessageSender webhookMessageSender) {
+        this.webhookDeliveryQueueDao = webhookDeliveryQueueDao;
+        this.instantSource = instantSource;
+        this.webhookMessageSender = webhookMessageSender;
+    }
+
+    public void attemptSend(WebhookDeliveryQueueEntity queueItem) {
+        var retryCount = webhookDeliveryQueueDao.countFailed(queueItem.getWebhookMessageEntity());
+
+        try {
+            LOGGER.info("Attempting to send Webhook ID %s to %s".formatted(queueItem.getWebhookMessageEntity().getExternalId(), queueItem.getWebhookMessageEntity().getWebhookEntity().getCallbackUrl()));
+            var response = webhookMessageSender.sendWebhookMessage(queueItem.getWebhookMessageEntity());
+
+            var statusCode = response.statusCode();
+            if (statusCode >= 200 && statusCode <= 299) {
+                LOGGER.info("Message attempt succeeded with %s".formatted(statusCode));
+                webhookDeliveryQueueDao.recordResult(queueItem, getReasonFromStatusCode(statusCode), statusCode, WebhookDeliveryQueueEntity.DeliveryStatus.SUCCESSFUL);
+            } else {
+                LOGGER.info("Message attempt failed with %s".formatted(statusCode));
+                webhookDeliveryQueueDao.recordResult(queueItem, getReasonFromStatusCode(statusCode), statusCode, WebhookDeliveryQueueEntity.DeliveryStatus.FAILED);
+                enqueueRetry(queueItem, nextRetryIn(retryCount));
+            }
+        } catch (HttpTimeoutException e) {
+            LOGGER.info("HTTP timeout exception %s".formatted(e.toString()));
+            webhookDeliveryQueueDao.recordResult(queueItem, "HTTP Timeout after 5 seconds", null, WebhookDeliveryQueueEntity.DeliveryStatus.FAILED);
+            enqueueRetry(queueItem, nextRetryIn(retryCount));
+        } catch (IOException | InterruptedException | InvalidKeyException e) {
+            LOGGER.warn("Exception %s attempting to send webhook message ID: %s".formatted(e.getMessage(), queueItem.getWebhookMessageEntity().getExternalId()));
+            webhookDeliveryQueueDao.recordResult(queueItem, e.getMessage(), null, WebhookDeliveryQueueEntity.DeliveryStatus.FAILED);
+            enqueueRetry(queueItem, nextRetryIn(retryCount));
+        } catch (Exception e) {
+            // handle all exceptions at this level to make sure that the retry mechanism is allowed to work as designed
+            // allowing errors passed this point (not guaranteeing an update) would allow perpetual failures 
+            LOGGER.warn("Unexpected exception %s attempting to send webhook message ID: %s".formatted(e.getMessage(), queueItem.getWebhookMessageEntity().getExternalId()));
+            webhookDeliveryQueueDao.recordResult(queueItem, "Unknown error", null, WebhookDeliveryQueueEntity.DeliveryStatus.FAILED);
+            enqueueRetry(queueItem, nextRetryIn(retryCount));
+        }
+    }
+
+    private void enqueueRetry(WebhookDeliveryQueueEntity queueItem, Duration nextRetryIn) {
+        Optional.ofNullable(nextRetryIn).ifPresent(
+                retryDelay -> webhookDeliveryQueueDao.enqueueFrom(queueItem.getWebhookMessageEntity(), WebhookDeliveryQueueEntity.DeliveryStatus.PENDING, Date.from(instantSource.instant().plus(retryDelay)))
+        );
+    }
+
+    private Duration nextRetryIn(Long retryCount) {
+        return switch (Math.toIntExact(retryCount)) {
+            case 0 -> Duration.of(60, ChronoUnit.SECONDS);
+            case 1 -> Duration.of(5, ChronoUnit.MINUTES);
+            case 2 -> Duration.of(1, ChronoUnit.HOURS);
+            case 3 -> Duration.of(1, ChronoUnit.DAYS);
+            case 4 -> Duration.of(2, ChronoUnit.DAYS);
+            default -> null;
+        };
+    }
+    
+    private String getReasonFromStatusCode(int statusCode) {
+        return Stream.of(String.valueOf(statusCode), Response.Status.fromStatusCode(statusCode).getReasonPhrase())
+                .filter(Objects::nonNull)
+                .collect(Collectors.joining(" "));
+    }
+}

--- a/src/main/java/uk/gov/pay/webhooks/deliveryqueue/managed/WebhookMessageSendingQueueProcessor.java
+++ b/src/main/java/uk/gov/pay/webhooks/deliveryqueue/managed/WebhookMessageSendingQueueProcessor.java
@@ -1,6 +1,5 @@
 package uk.gov.pay.webhooks.deliveryqueue.managed;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.dropwizard.lifecycle.Managed;
 import io.dropwizard.setup.Environment;
 import org.hibernate.Session;
@@ -12,16 +11,9 @@ import org.slf4j.LoggerFactory;
 import uk.gov.pay.webhooks.deliveryqueue.dao.WebhookDeliveryQueueDao;
 import uk.gov.pay.webhooks.deliveryqueue.dao.WebhookDeliveryQueueEntity;
 import uk.gov.pay.webhooks.message.WebhookMessageSender;
-import uk.gov.pay.webhooks.message.WebhookMessageSignatureGenerator;
 
 import javax.inject.Inject;
-import java.io.IOException;
-import java.net.http.HttpClient;
-import java.net.http.HttpTimeoutException;
-import java.security.InvalidKeyException;
-import java.time.Duration;
 import java.time.InstantSource;
-import java.time.temporal.ChronoUnit;
 import java.util.Date;
 import java.util.Optional;
 import java.util.concurrent.ScheduledExecutorService;
@@ -34,24 +26,21 @@ public class WebhookMessageSendingQueueProcessor implements Managed {
     private final InstantSource instantSource;
     private final SessionFactory sessionFactory;
     private final ScheduledExecutorService scheduledExecutorService;
-    private final ObjectMapper objectMapper;
-    private final WebhookMessageSignatureGenerator webhookMessageSignatureGenerator;
-    private final HttpClient httpClient;
+    private final SendAttempter sendAttempter;
     
     @Inject
-    public WebhookMessageSendingQueueProcessor(Environment environment, WebhookDeliveryQueueDao webhookDeliveryQueueDao, ObjectMapper objectMapper, InstantSource instantSource, SessionFactory sessionFactory, WebhookMessageSignatureGenerator webhookMessageSignatureGenerator, HttpClient httpClient) {
+    public WebhookMessageSendingQueueProcessor(Environment environment, WebhookDeliveryQueueDao webhookDeliveryQueueDao, InstantSource instantSource, SessionFactory sessionFactory, WebhookMessageSender webhookMessageSender) {
         this.webhookDeliveryQueueDao = webhookDeliveryQueueDao;
         this.instantSource = instantSource;
         this.sessionFactory = sessionFactory;
-        this.objectMapper = objectMapper;
-        this.webhookMessageSignatureGenerator = webhookMessageSignatureGenerator;
 
         scheduledExecutorService = environment
                 .lifecycle()
                 .scheduledExecutorService("retries")
                 .threads(1)
                 .build();
-        this.httpClient = httpClient;
+
+        sendAttempter = new SendAttempter(webhookDeliveryQueueDao, instantSource, webhookMessageSender);
     }
 
     @Override
@@ -85,7 +74,7 @@ public class WebhookMessageSendingQueueProcessor implements Managed {
         Transaction transaction = session.beginTransaction();
         try {
             Optional<WebhookDeliveryQueueEntity> maybeQueueItem = webhookDeliveryQueueDao.nextToSend(Date.from(instantSource.instant()));
-            maybeQueueItem.ifPresent(item -> new SendAttempter(webhookDeliveryQueueDao, instantSource, new WebhookMessageSender(httpClient, objectMapper, webhookMessageSignatureGenerator)).attemptSend(item));
+            maybeQueueItem.ifPresent(sendAttempter::attemptSend);
             transaction.commit();
         } catch (Exception e) {
             LOGGER.warn("Unexpected exception when polling queue  %s: ".formatted(e.getMessage()));

--- a/src/main/java/uk/gov/pay/webhooks/deliveryqueue/managed/WebhookMessageSendingQueueProcessor.java
+++ b/src/main/java/uk/gov/pay/webhooks/deliveryqueue/managed/WebhookMessageSendingQueueProcessor.java
@@ -72,57 +72,7 @@ public class WebhookMessageSendingQueueProcessor implements Managed {
             e.printStackTrace();
         }
     }
-
-    private void attemptSend(WebhookDeliveryQueueEntity queueItem) {
-        var retryCount = webhookDeliveryQueueDao.countFailed(queueItem.getWebhookMessageEntity());
-
-        var webhookMessageSender = new WebhookMessageSender(httpClient, objectMapper, webhookMessageSignatureGenerator);
-        try {
-            LOGGER.info("Attempting to send Webhook ID %s to %s".formatted(queueItem.getWebhookMessageEntity().getExternalId(), queueItem.getWebhookMessageEntity().getWebhookEntity().getCallbackUrl()));
-            var response = webhookMessageSender.sendWebhookMessage(queueItem.getWebhookMessageEntity());
-
-            var statusCode = response.statusCode();
-            if (statusCode >= 200 && statusCode <= 299) {
-                LOGGER.info("Message attempt succeeded with %s".formatted(statusCode));
-                webhookDeliveryQueueDao.recordResult(queueItem, String.valueOf(statusCode), statusCode, WebhookDeliveryQueueEntity.DeliveryStatus.SUCCESSFUL);
-            } else {
-                LOGGER.info("Message attempt failed with %s".formatted(statusCode));
-                webhookDeliveryQueueDao.recordResult(queueItem, String.valueOf(statusCode), statusCode, WebhookDeliveryQueueEntity.DeliveryStatus.FAILED);
-                enqueueRetry(queueItem, nextRetryIn(retryCount));
-            }
-        } catch (HttpTimeoutException e) {
-            LOGGER.info("HTTP timeout exception %s".formatted(e.toString()));
-            webhookDeliveryQueueDao.recordResult(queueItem, "HTTP Timeout after 5 seconds", null, WebhookDeliveryQueueEntity.DeliveryStatus.FAILED);
-            enqueueRetry(queueItem, nextRetryIn(retryCount));
-        } catch (IOException | InterruptedException | InvalidKeyException e) {
-            LOGGER.warn("Exception %s attempting to send webhook message ID: %s".formatted(e.getMessage(), queueItem.getWebhookMessageEntity().getExternalId()));
-            webhookDeliveryQueueDao.recordResult(queueItem, e.getMessage(), null, WebhookDeliveryQueueEntity.DeliveryStatus.FAILED);
-            enqueueRetry(queueItem, nextRetryIn(retryCount));
-        } catch (Exception e) {
-            // handle all exceptions at this level to make sure that the retry mechanism is allowed to work as designed
-            // allowing errors passed this point (not guaranteeing an update) would allow perpetual failures 
-            LOGGER.warn("Unexpected exception %s attempting to send webhook message ID: %s".formatted(e.getMessage(), queueItem.getWebhookMessageEntity().getExternalId()));
-            webhookDeliveryQueueDao.recordResult(queueItem, "Unknown error", null, WebhookDeliveryQueueEntity.DeliveryStatus.FAILED);
-            enqueueRetry(queueItem, nextRetryIn(retryCount));
-        }
-    }
-
-    private void enqueueRetry(WebhookDeliveryQueueEntity queueItem, Duration nextRetryIn) {
-        Optional.ofNullable(nextRetryIn).ifPresent(
-                retryDelay -> webhookDeliveryQueueDao.enqueueFrom(queueItem.getWebhookMessageEntity(), WebhookDeliveryQueueEntity.DeliveryStatus.PENDING, Date.from(instantSource.instant().plus(retryDelay)))
-        );
-    }
     
-    private Duration nextRetryIn(Long retryCount) {
-        return switch (Math.toIntExact(retryCount)) {
-            case 0 -> Duration.of(60, ChronoUnit.SECONDS);
-            case 1 -> Duration.of(5, ChronoUnit.MINUTES);
-            case 2 -> Duration.of(1, ChronoUnit.HOURS);
-            case 3 -> Duration.of(1, ChronoUnit.DAYS);
-            case 4 -> Duration.of(2, ChronoUnit.DAYS);
-            default -> null;
-        };  
-    }
 
     @Override
     public void stop() {
@@ -135,7 +85,7 @@ public class WebhookMessageSendingQueueProcessor implements Managed {
         Transaction transaction = session.beginTransaction();
         try {
             Optional<WebhookDeliveryQueueEntity> maybeQueueItem = webhookDeliveryQueueDao.nextToSend(Date.from(instantSource.instant()));
-            maybeQueueItem.ifPresent(this::attemptSend);
+            maybeQueueItem.ifPresent(item -> new SendAttempter(webhookDeliveryQueueDao, instantSource, new WebhookMessageSender(httpClient, objectMapper, webhookMessageSignatureGenerator)).attemptSend(item));
             transaction.commit();
         } catch (Exception e) {
             LOGGER.warn("Unexpected exception when polling queue  %s: ".formatted(e.getMessage()));

--- a/src/test/java/uk/gov/pay/webhooks/deliveryqueue/managed/SendAttempterTest.java
+++ b/src/test/java/uk/gov/pay/webhooks/deliveryqueue/managed/SendAttempterTest.java
@@ -1,0 +1,123 @@
+package uk.gov.pay.webhooks.deliveryqueue.managed;
+
+import io.dropwizard.testing.junit5.DAOTestExtension;
+import io.dropwizard.testing.junit5.DropwizardExtensionsSupport;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.pay.webhooks.deliveryqueue.dao.WebhookDeliveryQueueDao;
+import uk.gov.pay.webhooks.deliveryqueue.dao.WebhookDeliveryQueueEntity;
+import uk.gov.pay.webhooks.eventtype.dao.EventTypeEntity;
+import uk.gov.pay.webhooks.message.WebhookMessageSender;
+import uk.gov.pay.webhooks.message.dao.WebhookMessageDao;
+import uk.gov.pay.webhooks.message.dao.entity.WebhookMessageEntity;
+import uk.gov.pay.webhooks.webhook.dao.WebhookDao;
+import uk.gov.pay.webhooks.webhook.dao.entity.WebhookEntity;
+
+import java.io.IOException;
+import java.net.http.HttpResponse;
+import java.net.http.HttpTimeoutException;
+import java.security.InvalidKeyException;
+import java.time.Instant;
+import java.time.InstantSource;
+import java.util.Date;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.hamcrest.Matchers.is;
+
+@ExtendWith(MockitoExtension.class)
+@ExtendWith(DropwizardExtensionsSupport.class)
+class SendAttempterTest {
+
+    public DAOTestExtension database = DAOTestExtension.newBuilder()
+            .addEntityClass(EventTypeEntity.class)
+            .addEntityClass(WebhookMessageEntity.class)
+            .addEntityClass(WebhookEntity.class)
+            .addEntityClass(WebhookDeliveryQueueEntity.class)
+            .build();
+
+    private WebhookDeliveryQueueDao webhookDeliveryQueueDao;
+    private InstantSource instantSource;
+    private WebhookMessageDao webhookMessageDao;
+    private WebhookDao webhookDao;
+    private WebhookMessageEntity webhookMessageEntity;
+    
+    @Mock
+    private WebhookMessageSender mockWebhookMessageSender;
+    
+    @Mock
+    private HttpResponse mockHttpResponse;
+            
+    @BeforeEach
+    void setUp(){
+        instantSource = InstantSource.fixed(Instant.now());
+        webhookMessageDao = new WebhookMessageDao(database.getSessionFactory());
+        webhookDao = new WebhookDao(database.getSessionFactory());
+        webhookDeliveryQueueDao = new WebhookDeliveryQueueDao(database.getSessionFactory(), instantSource);
+        webhookMessageEntity = new WebhookMessageEntity();
+        WebhookEntity webhookEntity = new WebhookEntity();
+        webhookEntity.setLive(true);
+        webhookEntity.setServiceId("service-id-1");
+        webhookEntity.setCreatedDate(Date.from(Instant.parse("2007-12-03T10:15:30.00Z")));
+        webhookEntity.setCallbackUrl("http://example.com");
+        webhookEntity.setSigningKey("some-signing-key");
+        webhookDao.create(webhookEntity);
+        webhookMessageEntity.setWebhookEntity(webhookEntity);
+        webhookMessageEntity.setCreatedDate(Date.from(instantSource.instant()));
+    }
+    
+    @Test
+    void sendAttempterSetsDeliveryStatusBasedOnStatusCode() throws IOException, InterruptedException, InvalidKeyException {
+        given(mockWebhookMessageSender.sendWebhookMessage(any(WebhookMessageEntity.class))).willReturn(mockHttpResponse);
+        
+        var webhookMessage = webhookMessageDao.create(webhookMessageEntity);
+        var sendAttempter = new SendAttempter(webhookDeliveryQueueDao, instantSource, mockWebhookMessageSender);
+        var enqueuedItem = webhookDeliveryQueueDao.enqueueFrom(webhookMessage, WebhookDeliveryQueueEntity.DeliveryStatus.PENDING, Date.from(instantSource.instant()));
+        given(mockHttpResponse.statusCode()).willReturn(404, 200);
+        
+        sendAttempter.attemptSend(enqueuedItem);
+        assertThat(enqueuedItem.getDeliveryStatus(), is(WebhookDeliveryQueueEntity.DeliveryStatus.FAILED));
+        assertThat(enqueuedItem.getDeliveryResult(), is("404 Not Found"));
+        sendAttempter.attemptSend(enqueuedItem);
+        assertThat(enqueuedItem.getDeliveryStatus(), is(WebhookDeliveryQueueEntity.DeliveryStatus.SUCCESSFUL));
+        assertThat(enqueuedItem.getDeliveryResult(), is("200 OK"));
+    }
+
+    @Test
+    void sendAttempterCatchesExceptions() throws IOException, InterruptedException, InvalidKeyException {
+
+        var webhookMessage = webhookMessageDao.create(webhookMessageEntity);
+        var sendAttempter = new SendAttempter(webhookDeliveryQueueDao, instantSource, mockWebhookMessageSender);
+        var enqueuedItem = webhookDeliveryQueueDao.enqueueFrom(webhookMessage, WebhookDeliveryQueueEntity.DeliveryStatus.PENDING, Date.from(instantSource.instant()));
+        given(mockWebhookMessageSender.sendWebhookMessage(any(WebhookMessageEntity.class))).willThrow(IOException.class, HttpTimeoutException.class);
+
+        assertDoesNotThrow(() -> sendAttempter.attemptSend(enqueuedItem));
+        assertThat(enqueuedItem.getDeliveryStatus(), is(WebhookDeliveryQueueEntity.DeliveryStatus.FAILED));
+
+        assertDoesNotThrow(() -> sendAttempter.attemptSend(enqueuedItem));
+        assertThat(enqueuedItem.getDeliveryStatus(), is(WebhookDeliveryQueueEntity.DeliveryStatus.FAILED));
+    }
+    
+    @Test
+    void sendAttempterEnqueuesRetriesIfFailure() throws IOException, InvalidKeyException, InterruptedException {
+        given(mockWebhookMessageSender.sendWebhookMessage(any(WebhookMessageEntity.class))).willReturn(mockHttpResponse);
+        var webhookMessage = webhookMessageDao.create(webhookMessageEntity);
+        var sendAttempter = new SendAttempter(webhookDeliveryQueueDao, instantSource, mockWebhookMessageSender);
+        var enqueuedItem = webhookDeliveryQueueDao.enqueueFrom(webhookMessage, WebhookDeliveryQueueEntity.DeliveryStatus.PENDING, Date.from(instantSource.instant()));
+        given(mockHttpResponse.statusCode()).willReturn(404);
+        sendAttempter.attemptSend(enqueuedItem);
+        assertThat(enqueuedItem.getDeliveryStatus(), is(WebhookDeliveryQueueEntity.DeliveryStatus.FAILED));
+
+        database.inTransaction(() -> {
+            assertThat(webhookDeliveryQueueDao.nextToSend(Date.from((Instant.parse("2007-12-03T10:15:30.00Z")))), is(notNullValue()));
+            assertThat(webhookDeliveryQueueDao.countFailed(webhookMessageEntity), is(1L));
+        });
+        
+    }
+}


### PR DESCRIPTION
Extracts the sending & retry logic from the scheduled task execution to make it more test-able.

* Extract attempt sending logic in separate SendAttempter class
* Prettify delivery result message with HTTP reason
* Inject WebhookMessageSender into SendAttempter to allow for mocking in tests
* Add tests for SendAttempter