### PR TITLE
PP-8557 Webhook messages endpoint

### DIFF
--- a/src/main/java/uk/gov/pay/webhooks/deliveryqueue/dao/WebhookDeliveryQueueDao.java
+++ b/src/main/java/uk/gov/pay/webhooks/deliveryqueue/dao/WebhookDeliveryQueueDao.java
@@ -9,6 +9,7 @@ import javax.inject.Inject;
 import javax.persistence.LockModeType;
 import java.time.InstantSource;
 import java.util.Date;
+import java.util.List;
 import java.util.Optional;
 
 public class WebhookDeliveryQueueDao extends AbstractDAO<WebhookDeliveryQueueEntity> {
@@ -50,5 +51,12 @@ public class WebhookDeliveryQueueDao extends AbstractDAO<WebhookDeliveryQueueEnt
 
     public WebhookDeliveryQueueEntity recordResult(WebhookDeliveryQueueEntity webhookDeliveryQueueEntity, String deliveryResult, Integer statusCode, WebhookDeliveryQueueEntity.DeliveryStatus deliveryStatus) {
         return persist(WebhookDeliveryQueueEntity.recordResult(webhookDeliveryQueueEntity, deliveryResult, statusCode, deliveryStatus));
+    }
+
+    public List<WebhookDeliveryQueueEntity> list(String webhookId, String messageId) {
+        return namedTypedQuery(WebhookDeliveryQueueEntity.LIST_DELIVERY_ATTEMPTS)
+                .setParameter("webhookId", webhookId)
+                .setParameter("messageId", messageId)
+                .getResultList();
     }
 }

--- a/src/main/java/uk/gov/pay/webhooks/deliveryqueue/dao/WebhookDeliveryQueueEntity.java
+++ b/src/main/java/uk/gov/pay/webhooks/deliveryqueue/dao/WebhookDeliveryQueueEntity.java
@@ -1,5 +1,6 @@
 package uk.gov.pay.webhooks.deliveryqueue.dao;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import uk.gov.pay.webhooks.message.dao.entity.WebhookMessageEntity;
 
 import javax.persistence.Column;
@@ -8,10 +9,11 @@ import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
-import javax.persistence.ManyToOne;
+import javax.persistence.OneToOne;
 import javax.persistence.NamedQuery;
 import javax.persistence.SequenceGenerator;
 import javax.persistence.Table;
+import javax.persistence.FetchType;
 import java.time.Instant;
 import java.util.Date;
 import java.util.Optional;
@@ -38,7 +40,7 @@ public class WebhookDeliveryQueueEntity {
 
 
     @Id
-    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "event_types_id_seq")
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "webhook_delivery_queue_id_seq")
     private Long id;
 
     @Column(name = "created_date")
@@ -103,7 +105,8 @@ public class WebhookDeliveryQueueEntity {
         return webhookMessageEntity;
     }
 
-    @ManyToOne
+    @JsonIgnore
+    @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "webhook_message_id", updatable = false)
     private WebhookMessageEntity webhookMessageEntity;
 

--- a/src/main/java/uk/gov/pay/webhooks/deliveryqueue/dao/WebhookDeliveryQueueEntity.java
+++ b/src/main/java/uk/gov/pay/webhooks/deliveryqueue/dao/WebhookDeliveryQueueEntity.java
@@ -28,6 +28,11 @@ import java.util.Optional;
         query = "select count(m) from WebhookDeliveryQueueEntity m where webhook_message_id = :webhook_message_id and delivery_status = 'FAILED'"
 )
 
+@NamedQuery(
+        name = WebhookDeliveryQueueEntity.LIST_DELIVERY_ATTEMPTS,
+        query = "select wdq from WebhookDeliveryQueueEntity wdq where webhookMessageEntity.webhookEntity.externalId = :webhookId and webhookMessageEntity.externalId = :messageId order by createdDate desc"
+)
+
 @Entity
 @SequenceGenerator(name="webhook_delivery_queue_id_seq", sequenceName = "webhook_delivery_queue_id_seq", allocationSize = 1)
 @Table(name = "webhook_delivery_queue")
@@ -37,6 +42,7 @@ import java.util.Optional;
 public class WebhookDeliveryQueueEntity {
     public static final String NEXT_TO_SEND = "WebhookDeliveryQueue.next_to_send";
     public static final String COUNT_FAILED = "WebhookDeliveryQueue.count_failed";
+    public static final String LIST_DELIVERY_ATTEMPTS = "WebhookDeliveryQueue.list_delivery_attempts";
 
 
     @Id

--- a/src/main/java/uk/gov/pay/webhooks/deliveryqueue/dao/WebhookDeliveryQueueEntity.java
+++ b/src/main/java/uk/gov/pay/webhooks/deliveryqueue/dao/WebhookDeliveryQueueEntity.java
@@ -66,6 +66,10 @@ public class WebhookDeliveryQueueEntity {
     @Column(name = "send_at")
     private Date sendAt;
 
+    public Date getCreatedDate() {
+        return createdDate;
+    }
+
     public enum DeliveryStatus {
         PENDING,
         SUCCESSFUL,

--- a/src/main/java/uk/gov/pay/webhooks/message/dao/WebhookMessageDao.java
+++ b/src/main/java/uk/gov/pay/webhooks/message/dao/WebhookMessageDao.java
@@ -21,6 +21,13 @@ public class WebhookMessageDao extends AbstractDAO<WebhookMessageEntity> {
         return webhookMessage;
     }
 
+    public WebhookMessageEntity get(String webhookId, String messageId) {
+       return namedTypedQuery(WebhookMessageEntity.MESSAGE_BY_WEBHOOK_ID_AND_MESSAGE_ID)
+               .setParameter("webhookId", webhookId)
+               .setParameter("messageId", messageId)
+               .getSingleResult();
+    }
+
     public List<WebhookMessageEntity> list(String webhookId, String deliveryStatus, int page) {
         var query = (deliveryStatus != null) ?
                 namedTypedQuery(WebhookMessageEntity.MESSAGES_BY_WEBHOOK_ID_AND_STATUS).setParameter("webhookId", webhookId).setParameter("deliveryStatuses", List.of(deliveryStatus)) :

--- a/src/main/java/uk/gov/pay/webhooks/message/dao/WebhookMessageDao.java
+++ b/src/main/java/uk/gov/pay/webhooks/message/dao/WebhookMessageDao.java
@@ -3,33 +3,41 @@ package uk.gov.pay.webhooks.message.dao;
 import io.dropwizard.hibernate.AbstractDAO;
 import org.hibernate.SessionFactory;
 import uk.gov.pay.webhooks.message.dao.entity.WebhookMessageEntity;
-import uk.gov.pay.webhooks.webhook.dao.entity.WebhookEntity;
 
 import javax.inject.Inject;
 import java.util.List;
 
 public class WebhookMessageDao extends AbstractDAO<WebhookMessageEntity> {
 
+    public static final int WEBHOOK_MESSAGES_PAGE_SIZE = 10;
+
     @Inject
     public WebhookMessageDao(SessionFactory factory) {
         super(factory);
         }
-        
+
     public WebhookMessageEntity create(WebhookMessageEntity webhookMessage) {
         persist(webhookMessage);
         return webhookMessage;
     }
 
-    public List<WebhookMessageEntity> list(String webhookId) {
-        return namedTypedQuery(WebhookMessageEntity.MESSAGES_BY_WEBHOOK_ID)
-                .setParameter("webhookId", webhookId)
+    public List<WebhookMessageEntity> list(String webhookId, String deliveryStatus, int page) {
+        var query = (deliveryStatus != null) ?
+                namedTypedQuery(WebhookMessageEntity.MESSAGES_BY_WEBHOOK_ID_AND_STATUS).setParameter("webhookId", webhookId).setParameter("deliveryStatuses", List.of(deliveryStatus)) :
+                namedTypedQuery(WebhookMessageEntity.MESSAGES_BY_WEBHOOK_ID).setParameter("webhookId", webhookId);
+        return query.setFirstResult(calculateFirstResult(page))
+                .setMaxResults(WEBHOOK_MESSAGES_PAGE_SIZE)
                 .getResultList();
     }
 
-    public List<WebhookMessageEntity> list(String webhookId, String deliveryStatus) {
-        return namedTypedQuery(WebhookMessageEntity.MESSAGES_BY_WEBHOOK_ID_AND_STATUS)
-                .setParameter("webhookId", webhookId)
-                .setParameter("deliveryStatus", deliveryStatus)
-                .getResultList();
+    public Long count(String webhookId, String deliveryStatus) {
+        var query = (deliveryStatus != null) ?
+                namedQuery(WebhookMessageEntity.COUNT_MESSAGES_BY_WEBHOOK_ID_AND_STATUS).setParameter("webhookId", webhookId).setParameter("deliveryStatuses", List.of(deliveryStatus)) :
+                namedQuery(WebhookMessageEntity.COUNT_MESSAGES_BY_WEBHOOK_ID).setParameter("webhookId", webhookId);
+        return (Long) query.getSingleResult();
+    }
+
+    private int calculateFirstResult(int page) {
+        return (page - 1) * WEBHOOK_MESSAGES_PAGE_SIZE;
     }
 }

--- a/src/main/java/uk/gov/pay/webhooks/message/dao/WebhookMessageDao.java
+++ b/src/main/java/uk/gov/pay/webhooks/message/dao/WebhookMessageDao.java
@@ -29,8 +29,8 @@ public class WebhookMessageDao extends AbstractDAO<WebhookMessageEntity> {
     }
 
     public List<WebhookMessageEntity> list(String webhookId, String deliveryStatus, int page) {
-        var query = (deliveryStatus != null) ?
-                namedTypedQuery(WebhookMessageEntity.MESSAGES_BY_WEBHOOK_ID_AND_STATUS).setParameter("webhookId", webhookId).setParameter("deliveryStatuses", List.of(deliveryStatus)) :
+        var query = deliveryStatus != null ?
+                namedTypedQuery(WebhookMessageEntity.MESSAGES_BY_WEBHOOK_ID_AND_STATUS).setParameter("webhookId", webhookId).setParameter("deliveryStatus", deliveryStatus) :
                 namedTypedQuery(WebhookMessageEntity.MESSAGES_BY_WEBHOOK_ID).setParameter("webhookId", webhookId);
         return query.setFirstResult(calculateFirstResult(page))
                 .setMaxResults(WEBHOOK_MESSAGES_PAGE_SIZE)
@@ -38,8 +38,8 @@ public class WebhookMessageDao extends AbstractDAO<WebhookMessageEntity> {
     }
 
     public Long count(String webhookId, String deliveryStatus) {
-        var query = (deliveryStatus != null) ?
-                namedQuery(WebhookMessageEntity.COUNT_MESSAGES_BY_WEBHOOK_ID_AND_STATUS).setParameter("webhookId", webhookId).setParameter("deliveryStatuses", List.of(deliveryStatus)) :
+        var query = deliveryStatus != null ?
+                namedQuery(WebhookMessageEntity.COUNT_MESSAGES_BY_WEBHOOK_ID_AND_STATUS).setParameter("webhookId", webhookId).setParameter("deliveryStatus", deliveryStatus) :
                 namedQuery(WebhookMessageEntity.COUNT_MESSAGES_BY_WEBHOOK_ID).setParameter("webhookId", webhookId);
         return (Long) query.getSingleResult();
     }

--- a/src/main/java/uk/gov/pay/webhooks/message/dao/WebhookMessageDao.java
+++ b/src/main/java/uk/gov/pay/webhooks/message/dao/WebhookMessageDao.java
@@ -3,8 +3,10 @@ package uk.gov.pay.webhooks.message.dao;
 import io.dropwizard.hibernate.AbstractDAO;
 import org.hibernate.SessionFactory;
 import uk.gov.pay.webhooks.message.dao.entity.WebhookMessageEntity;
+import uk.gov.pay.webhooks.webhook.dao.entity.WebhookEntity;
 
 import javax.inject.Inject;
+import java.util.List;
 
 public class WebhookMessageDao extends AbstractDAO<WebhookMessageEntity> {
 
@@ -16,5 +18,18 @@ public class WebhookMessageDao extends AbstractDAO<WebhookMessageEntity> {
     public WebhookMessageEntity create(WebhookMessageEntity webhookMessage) {
         persist(webhookMessage);
         return webhookMessage;
+    }
+
+    public List<WebhookMessageEntity> list(String webhookId) {
+        return namedTypedQuery(WebhookMessageEntity.MESSAGES_BY_WEBHOOK_ID)
+                .setParameter("webhookId", webhookId)
+                .getResultList();
+    }
+
+    public List<WebhookMessageEntity> list(String webhookId, String deliveryStatus) {
+        return namedTypedQuery(WebhookMessageEntity.MESSAGES_BY_WEBHOOK_ID_AND_STATUS)
+                .setParameter("webhookId", webhookId)
+                .setParameter("deliveryStatus", deliveryStatus)
+                .getResultList();
     }
 }

--- a/src/main/java/uk/gov/pay/webhooks/message/dao/entity/WebhookMessageEntity.java
+++ b/src/main/java/uk/gov/pay/webhooks/message/dao/entity/WebhookMessageEntity.java
@@ -25,12 +25,22 @@ import java.util.Date;
 
 @NamedQuery(
         name = WebhookMessageEntity.MESSAGES_BY_WEBHOOK_ID,
-        query = "select m from WebhookMessageEntity m where webhookEntity.externalId = :webhookId order by createdDate DESC"
+        query = "select m from WebhookMessageEntity m where webhookEntity.externalId = :webhookId order by createdDate desc"
 )
 
 @NamedQuery(
         name = WebhookMessageEntity.MESSAGES_BY_WEBHOOK_ID_AND_STATUS,
-        query = "select m from WebhookMessageEntity m where webhookEntity.externalId = :webhookId and webhookDeliveryQueueEntity.deliveryStatus = :deliveryStatus order by createdDate DESC"
+        query = "select m from WebhookMessageEntity m where webhookEntity.externalId = :webhookId and webhookDeliveryQueueEntity.deliveryStatus in :deliveryStatuses order by createdDate desc"
+)
+
+@NamedQuery(
+        name = WebhookMessageEntity.COUNT_MESSAGES_BY_WEBHOOK_ID,
+        query = "select count(m) from WebhookMessageEntity m where webhookEntity.externalId = :webhookId"
+)
+
+@NamedQuery(
+        name = WebhookMessageEntity.COUNT_MESSAGES_BY_WEBHOOK_ID_AND_STATUS,
+        query = "select count(m) from WebhookMessageEntity m where webhookEntity.externalId = :webhookId and webhookDeliveryQueueEntity.deliveryStatus in :deliveryStatuses"
 )
 
 @Entity
@@ -43,6 +53,8 @@ public class WebhookMessageEntity {
 
     public static final String MESSAGES_BY_WEBHOOK_ID = "WebhookMessage.messages_by_webhook_id";
     public static final String MESSAGES_BY_WEBHOOK_ID_AND_STATUS = "WebhookMessage.messages_by_webhook_id_and_status";
+    public static final String COUNT_MESSAGES_BY_WEBHOOK_ID = "WebhookMessage.count_messages_by_webhook_id";
+    public static final String COUNT_MESSAGES_BY_WEBHOOK_ID_AND_STATUS = "WebhookMessage.count_messages_by_webhook_id_and_status";
 
     public WebhookMessageEntity() {}
 

--- a/src/main/java/uk/gov/pay/webhooks/message/dao/entity/WebhookMessageEntity.java
+++ b/src/main/java/uk/gov/pay/webhooks/message/dao/entity/WebhookMessageEntity.java
@@ -24,6 +24,11 @@ import javax.persistence.FetchType;
 import java.util.Date;
 
 @NamedQuery(
+        name = WebhookMessageEntity.MESSAGE_BY_WEBHOOK_ID_AND_MESSAGE_ID,
+        query = "select m from WebhookMessageEntity m where webhookEntity.externalId = :webhookId and externalId = :messageId"
+)
+
+@NamedQuery(
         name = WebhookMessageEntity.MESSAGES_BY_WEBHOOK_ID,
         query = "select m from WebhookMessageEntity m where webhookEntity.externalId = :webhookId order by createdDate desc"
 )
@@ -51,6 +56,7 @@ import java.util.Date;
 })
 public class WebhookMessageEntity {
 
+    public static final String MESSAGE_BY_WEBHOOK_ID_AND_MESSAGE_ID = "WebhookMessage.message_by_webhook_id_and_message_id";
     public static final String MESSAGES_BY_WEBHOOK_ID = "WebhookMessage.messages_by_webhook_id";
     public static final String MESSAGES_BY_WEBHOOK_ID_AND_STATUS = "WebhookMessage.messages_by_webhook_id_and_status";
     public static final String COUNT_MESSAGES_BY_WEBHOOK_ID = "WebhookMessage.count_messages_by_webhook_id";

--- a/src/main/java/uk/gov/pay/webhooks/message/dao/entity/WebhookMessageEntity.java
+++ b/src/main/java/uk/gov/pay/webhooks/message/dao/entity/WebhookMessageEntity.java
@@ -35,7 +35,7 @@ import java.util.Date;
 
 @NamedQuery(
         name = WebhookMessageEntity.MESSAGES_BY_WEBHOOK_ID_AND_STATUS,
-        query = "select m from WebhookMessageEntity m where webhookEntity.externalId = :webhookId and webhookDeliveryQueueEntity.deliveryStatus in :deliveryStatuses order by createdDate desc"
+        query = "select m from WebhookMessageEntity m where webhookEntity.externalId = :webhookId and webhookDeliveryQueueEntity.deliveryStatus = :deliveryStatus order by createdDate desc"
 )
 
 @NamedQuery(
@@ -45,7 +45,7 @@ import java.util.Date;
 
 @NamedQuery(
         name = WebhookMessageEntity.COUNT_MESSAGES_BY_WEBHOOK_ID_AND_STATUS,
-        query = "select count(m) from WebhookMessageEntity m where webhookEntity.externalId = :webhookId and webhookDeliveryQueueEntity.deliveryStatus in :deliveryStatuses"
+        query = "select count(m) from WebhookMessageEntity m where webhookEntity.externalId = :webhookId and webhookDeliveryQueueEntity.deliveryStatus = :deliveryStatus"
 )
 
 @Entity

--- a/src/main/java/uk/gov/pay/webhooks/message/dao/entity/WebhookMessageEntity.java
+++ b/src/main/java/uk/gov/pay/webhooks/message/dao/entity/WebhookMessageEntity.java
@@ -77,6 +77,7 @@ public class WebhookMessageEntity {
            SELECT wdq.id
            FROM webhook_delivery_queue wdq
            WHERE wdq.webhook_message_id = id
+           AND wdq.delivery_status != 'PENDING'
            ORDER BY wdq.send_at DESC
            LIMIT 1
            )

--- a/src/main/java/uk/gov/pay/webhooks/message/dao/entity/WebhookMessageEntity.java
+++ b/src/main/java/uk/gov/pay/webhooks/message/dao/entity/WebhookMessageEntity.java
@@ -2,9 +2,11 @@ package uk.gov.pay.webhooks.message.dao.entity;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.vladmihalcea.hibernate.type.json.JsonType;
+import org.hibernate.annotations.JoinFormula;
 import org.hibernate.annotations.Type;
 import org.hibernate.annotations.TypeDef;
 import org.hibernate.annotations.TypeDefs;
+import uk.gov.pay.webhooks.deliveryqueue.dao.WebhookDeliveryQueueEntity;
 import uk.gov.pay.webhooks.eventtype.dao.EventTypeEntity;
 import uk.gov.pay.webhooks.webhook.dao.entity.WebhookEntity;
 
@@ -17,7 +19,19 @@ import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import javax.persistence.SequenceGenerator;
 import javax.persistence.Table;
+import javax.persistence.NamedQuery;
+import javax.persistence.FetchType;
 import java.util.Date;
+
+@NamedQuery(
+        name = WebhookMessageEntity.MESSAGES_BY_WEBHOOK_ID,
+        query = "select m from WebhookMessageEntity m where webhookEntity.externalId = :webhookId order by createdDate DESC"
+)
+
+@NamedQuery(
+        name = WebhookMessageEntity.MESSAGES_BY_WEBHOOK_ID_AND_STATUS,
+        query = "select m from WebhookMessageEntity m where webhookEntity.externalId = :webhookId and webhookDeliveryQueueEntity.deliveryStatus = :deliveryStatus order by createdDate DESC"
+)
 
 @Entity
 @SequenceGenerator(name="webhook_messages_id_seq", sequenceName = "webhook_messages_id_seq", allocationSize = 1)
@@ -27,10 +41,13 @@ import java.util.Date;
 })
 public class WebhookMessageEntity {
 
+    public static final String MESSAGES_BY_WEBHOOK_ID = "WebhookMessage.messages_by_webhook_id";
+    public static final String MESSAGES_BY_WEBHOOK_ID_AND_STATUS = "WebhookMessage.messages_by_webhook_id_and_status";
+
     public WebhookMessageEntity() {}
 
     @Id
-    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "event_types_id_seq")
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "webhook_messages_id_seq")
     private Long id;
 
     @Column(name = "external_id")
@@ -53,6 +70,18 @@ public class WebhookMessageEntity {
     @Type(type = "json")
     @Column(name = "resource", columnDefinition = "json")
     private JsonNode resource;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinFormula("""
+           (
+           SELECT wdq.id
+           FROM webhook_delivery_queue wdq
+           WHERE wdq.webhook_message_id = id
+           ORDER BY wdq.send_at DESC
+           LIMIT 1
+           )
+            """)
+    private WebhookDeliveryQueueEntity webhookDeliveryQueueEntity;
 
     public String getExternalId() {
         return externalId;
@@ -100,5 +129,9 @@ public class WebhookMessageEntity {
 
     public void setResource(JsonNode resource) {
         this.resource = resource;
+    }
+
+    public WebhookDeliveryQueueEntity getWebhookDeliveryQueueEntity() {
+        return webhookDeliveryQueueEntity;
     }
 }

--- a/src/main/java/uk/gov/pay/webhooks/message/resource/WebhookDeliveryQueueResponse.java
+++ b/src/main/java/uk/gov/pay/webhooks/message/resource/WebhookDeliveryQueueResponse.java
@@ -1,0 +1,23 @@
+package uk.gov.pay.webhooks.message.resource;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import uk.gov.pay.webhooks.deliveryqueue.dao.WebhookDeliveryQueueEntity;
+import uk.gov.service.payments.commons.api.json.ApiResponseInstantSerializer;
+
+import java.time.Instant;
+import java.util.Date;
+
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public record WebhookDeliveryQueueResponse(@JsonSerialize(using = ApiResponseInstantSerializer.class) Instant createdDate, @JsonSerialize(using = ApiResponseInstantSerializer.class) Instant sendAt, WebhookDeliveryQueueEntity.DeliveryStatus status, Integer statusCode, String result) {
+    public static WebhookDeliveryQueueResponse from(WebhookDeliveryQueueEntity webhookDeliveryQueueEntity) {
+        return new WebhookDeliveryQueueResponse(
+                webhookDeliveryQueueEntity.getCreatedDate().toInstant(),
+                webhookDeliveryQueueEntity.getSendAt().toInstant(),
+                webhookDeliveryQueueEntity.getDeliveryStatus(),
+                webhookDeliveryQueueEntity.getStatusCode(),
+                webhookDeliveryQueueEntity.getDeliveryResult()
+        );
+    }
+}

--- a/src/main/java/uk/gov/pay/webhooks/message/resource/WebhookMessageResponse.java
+++ b/src/main/java/uk/gov/pay/webhooks/message/resource/WebhookMessageResponse.java
@@ -17,16 +17,17 @@ public record WebhookMessageResponse(
         @JsonProperty("event_date") @JsonSerialize(using = ApiResponseInstantSerializer.class) Instant eventDate,
         @JsonProperty("event_type") EventTypeName eventTypeName,
         @JsonProperty("resource") JsonNode resource,
-        @JsonProperty("webhook_delivery_queue_entity") WebhookDeliveryQueueEntity webhookDeliveryQueueEntity) {
+        @JsonProperty("latest_attempt") WebhookDeliveryQueueResponse webhookDeliveryQueueEntity) {
 
     public static WebhookMessageResponse from(WebhookMessageEntity webhookMessageEntity) {
+        var latestAttempt = (webhookMessageEntity.getWebhookDeliveryQueueEntity() != null) ? WebhookDeliveryQueueResponse.from(webhookMessageEntity.getWebhookDeliveryQueueEntity()) : null;
         return new WebhookMessageResponse(
                 webhookMessageEntity.getExternalId(),
                 webhookMessageEntity.getCreatedDate().toInstant(),
                 webhookMessageEntity.getEventDate().toInstant(),
                 webhookMessageEntity.getEventType().getName(),
                 webhookMessageEntity.getResource(),
-                webhookMessageEntity.getWebhookDeliveryQueueEntity()
+                latestAttempt
         );
     }
 }

--- a/src/main/java/uk/gov/pay/webhooks/message/resource/WebhookMessageResponse.java
+++ b/src/main/java/uk/gov/pay/webhooks/message/resource/WebhookMessageResponse.java
@@ -1,0 +1,30 @@
+package uk.gov.pay.webhooks.message.resource;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import uk.gov.pay.webhooks.deliveryqueue.dao.WebhookDeliveryQueueEntity;
+import uk.gov.pay.webhooks.eventtype.EventTypeName;
+import uk.gov.pay.webhooks.message.dao.entity.WebhookMessageEntity;
+import uk.gov.service.payments.commons.api.json.ApiResponseInstantSerializer;
+
+import java.time.Instant;
+import java.util.List;
+
+public record WebhookMessageResponse(
+        @JsonProperty("created_date") @JsonSerialize(using = ApiResponseInstantSerializer.class) Instant createdDate,
+        @JsonProperty("event_date") @JsonSerialize(using = ApiResponseInstantSerializer.class) Instant eventDate,
+        @JsonProperty("event_type") EventTypeName eventTypeName,
+        @JsonProperty("resource") JsonNode resource,
+        @JsonProperty("webhook_delivery_queue_entity") WebhookDeliveryQueueEntity webhookDeliveryQueueEntity) {
+
+    public static WebhookMessageResponse from(WebhookMessageEntity webhookMessageEntity) {
+        return new WebhookMessageResponse(
+                webhookMessageEntity.getCreatedDate().toInstant(),
+                webhookMessageEntity.getEventDate().toInstant(),
+                webhookMessageEntity.getEventType().getName(),
+                webhookMessageEntity.getResource(),
+                webhookMessageEntity.getWebhookDeliveryQueueEntity()
+        );
+    }
+}

--- a/src/main/java/uk/gov/pay/webhooks/message/resource/WebhookMessageResponse.java
+++ b/src/main/java/uk/gov/pay/webhooks/message/resource/WebhookMessageResponse.java
@@ -12,6 +12,7 @@ import java.time.Instant;
 import java.util.List;
 
 public record WebhookMessageResponse(
+        @JsonProperty("external_id") String externalId,
         @JsonProperty("created_date") @JsonSerialize(using = ApiResponseInstantSerializer.class) Instant createdDate,
         @JsonProperty("event_date") @JsonSerialize(using = ApiResponseInstantSerializer.class) Instant eventDate,
         @JsonProperty("event_type") EventTypeName eventTypeName,
@@ -20,6 +21,7 @@ public record WebhookMessageResponse(
 
     public static WebhookMessageResponse from(WebhookMessageEntity webhookMessageEntity) {
         return new WebhookMessageResponse(
+                webhookMessageEntity.getExternalId(),
                 webhookMessageEntity.getCreatedDate().toInstant(),
                 webhookMessageEntity.getEventDate().toInstant(),
                 webhookMessageEntity.getEventType().getName(),

--- a/src/main/java/uk/gov/pay/webhooks/message/resource/WebhookMessageSearchResponse.java
+++ b/src/main/java/uk/gov/pay/webhooks/message/resource/WebhookMessageSearchResponse.java
@@ -1,0 +1,5 @@
+package uk.gov.pay.webhooks.message.resource;
+
+import java.util.List;
+
+public record WebhookMessageSearchResponse(int total, int count, int page, List<WebhookMessageResponse> results) { }

--- a/src/main/java/uk/gov/pay/webhooks/webhook/WebhookService.java
+++ b/src/main/java/uk/gov/pay/webhooks/webhook/WebhookService.java
@@ -8,6 +8,7 @@ import uk.gov.pay.webhooks.eventtype.dao.EventTypeEntity;
 import uk.gov.pay.webhooks.message.EventMapper;
 import uk.gov.pay.webhooks.message.dao.WebhookMessageDao;
 import uk.gov.pay.webhooks.message.dao.entity.WebhookMessageEntity;
+import uk.gov.pay.webhooks.message.resource.WebhookDeliveryQueueResponse;
 import uk.gov.pay.webhooks.message.resource.WebhookMessageResponse;
 import uk.gov.pay.webhooks.message.resource.WebhookMessageSearchResponse;
 import uk.gov.pay.webhooks.queue.InternalEvent;
@@ -85,8 +86,11 @@ public class WebhookService {
         return new WebhookMessageSearchResponse(total.intValue(), messages.size(), page, messages);
     }
 
-    public List<WebhookDeliveryQueueEntity> listMessageAttempts(String webhookId, String messageId) {
-        return webhookDeliveryQueueDao.list(webhookId, messageId);
+    public List<WebhookDeliveryQueueResponse> listMessageAttempts(String webhookId, String messageId) {
+        return webhookDeliveryQueueDao.list(webhookId, messageId)
+                .stream()
+                .map(WebhookDeliveryQueueResponse::from)
+                .toList();
     }
 
     public Optional<WebhookEntity> regenerateSigningKey(String externalId, String serviceId) {

--- a/src/main/java/uk/gov/pay/webhooks/webhook/WebhookService.java
+++ b/src/main/java/uk/gov/pay/webhooks/webhook/WebhookService.java
@@ -1,5 +1,7 @@
 package uk.gov.pay.webhooks.webhook;
 
+import uk.gov.pay.webhooks.deliveryqueue.dao.WebhookDeliveryQueueDao;
+import uk.gov.pay.webhooks.deliveryqueue.dao.WebhookDeliveryQueueEntity;
 import uk.gov.pay.webhooks.eventtype.EventTypeName;
 import uk.gov.pay.webhooks.eventtype.dao.EventTypeDao;
 import uk.gov.pay.webhooks.eventtype.dao.EventTypeEntity;
@@ -31,17 +33,19 @@ public class WebhookService {
 
     private final WebhookDao webhookDao;
     private final WebhookMessageDao webhookMessageDao;
+    private final WebhookDeliveryQueueDao webhookDeliveryQueueDao;
     private final EventTypeDao eventTypeDao;
     private final InstantSource instantSource;
     private final IdGenerator idGenerator;
 
     @Inject
-    public WebhookService(WebhookDao webhookDao, EventTypeDao eventTypeDao, InstantSource instantSource, IdGenerator idGenerator, WebhookMessageDao webhookMessageDao) {
+    public WebhookService(WebhookDao webhookDao, EventTypeDao eventTypeDao, InstantSource instantSource, IdGenerator idGenerator, WebhookMessageDao webhookMessageDao, WebhookDeliveryQueueDao webhookDeliveryQueueDao) {
         this.webhookDao = webhookDao;
         this.eventTypeDao = eventTypeDao;
         this.instantSource = instantSource;
         this.idGenerator = idGenerator;
         this.webhookMessageDao = webhookMessageDao;
+        this.webhookDeliveryQueueDao = webhookDeliveryQueueDao;
     }
 
     public WebhookEntity createWebhook(CreateWebhookRequest createWebhookRequest) {
@@ -61,17 +65,21 @@ public class WebhookService {
     public Optional<WebhookEntity> findByExternalId(String externalId, String serviceId) {
         return webhookDao.findByExternalId(externalId, serviceId);
     }    
-    
+
     public List<WebhookEntity> list(boolean live, String serviceId) {
         return webhookDao.list(live, serviceId);
     }      
-    
+
     public List<WebhookEntity> list(boolean live) {
         return webhookDao.list(live);
     }
-    
+
     public List<WebhookMessageEntity> listMessages(String webhookId) {
         return webhookMessageDao.list(webhookId);
+    }
+
+    public List<WebhookDeliveryQueueEntity> listMessageAttempts(String webhookId, String messageId) {
+        return webhookDeliveryQueueDao.list(webhookId, messageId);
     }
 
     public Optional<WebhookEntity> regenerateSigningKey(String externalId, String serviceId) {

--- a/src/main/java/uk/gov/pay/webhooks/webhook/WebhookService.java
+++ b/src/main/java/uk/gov/pay/webhooks/webhook/WebhookService.java
@@ -8,6 +8,8 @@ import uk.gov.pay.webhooks.eventtype.dao.EventTypeEntity;
 import uk.gov.pay.webhooks.message.EventMapper;
 import uk.gov.pay.webhooks.message.dao.WebhookMessageDao;
 import uk.gov.pay.webhooks.message.dao.entity.WebhookMessageEntity;
+import uk.gov.pay.webhooks.message.resource.WebhookMessageResponse;
+import uk.gov.pay.webhooks.message.resource.WebhookMessageSearchResponse;
 import uk.gov.pay.webhooks.queue.InternalEvent;
 import uk.gov.pay.webhooks.util.IdGenerator;
 import uk.gov.pay.webhooks.webhook.dao.WebhookDao;
@@ -74,8 +76,13 @@ public class WebhookService {
         return webhookDao.list(live);
     }
 
-    public List<WebhookMessageEntity> listMessages(String webhookId) {
-        return webhookMessageDao.list(webhookId);
+    public WebhookMessageSearchResponse listMessages(String webhookId, String status, int page) {
+        var messages = webhookMessageDao.list(webhookId, status, page)
+                .stream()
+                .map(WebhookMessageResponse::from)
+                .toList();
+        var total = webhookMessageDao.count(webhookId, status);
+        return new WebhookMessageSearchResponse(total.intValue(), messages.size(), page, messages);
     }
 
     public List<WebhookDeliveryQueueEntity> listMessageAttempts(String webhookId, String messageId) {

--- a/src/main/java/uk/gov/pay/webhooks/webhook/WebhookService.java
+++ b/src/main/java/uk/gov/pay/webhooks/webhook/WebhookService.java
@@ -86,6 +86,11 @@ public class WebhookService {
         return new WebhookMessageSearchResponse(total.intValue(), messages.size(), page, messages);
     }
 
+    public WebhookMessageResponse getMessage(String webhookId, String messageId) {
+        var message = webhookMessageDao.get(webhookId, messageId);
+        return WebhookMessageResponse.from(message);
+    }
+
     public List<WebhookDeliveryQueueResponse> listMessageAttempts(String webhookId, String messageId) {
         return webhookDeliveryQueueDao.list(webhookId, messageId)
                 .stream()

--- a/src/main/java/uk/gov/pay/webhooks/webhook/WebhookService.java
+++ b/src/main/java/uk/gov/pay/webhooks/webhook/WebhookService.java
@@ -4,6 +4,8 @@ import uk.gov.pay.webhooks.eventtype.EventTypeName;
 import uk.gov.pay.webhooks.eventtype.dao.EventTypeDao;
 import uk.gov.pay.webhooks.eventtype.dao.EventTypeEntity;
 import uk.gov.pay.webhooks.message.EventMapper;
+import uk.gov.pay.webhooks.message.dao.WebhookMessageDao;
+import uk.gov.pay.webhooks.message.dao.entity.WebhookMessageEntity;
 import uk.gov.pay.webhooks.queue.InternalEvent;
 import uk.gov.pay.webhooks.util.IdGenerator;
 import uk.gov.pay.webhooks.webhook.dao.WebhookDao;
@@ -28,16 +30,18 @@ import static uk.gov.pay.webhooks.webhook.resource.WebhookResponse.FIELD_SUBSCRI
 public class WebhookService {
 
     private final WebhookDao webhookDao;
+    private final WebhookMessageDao webhookMessageDao;
     private final EventTypeDao eventTypeDao;
     private final InstantSource instantSource;
     private final IdGenerator idGenerator;
 
     @Inject
-    public WebhookService(WebhookDao webhookDao, EventTypeDao eventTypeDao, InstantSource instantSource, IdGenerator idGenerator) {
+    public WebhookService(WebhookDao webhookDao, EventTypeDao eventTypeDao, InstantSource instantSource, IdGenerator idGenerator, WebhookMessageDao webhookMessageDao) {
         this.webhookDao = webhookDao;
         this.eventTypeDao = eventTypeDao;
         this.instantSource = instantSource;
         this.idGenerator = idGenerator;
+        this.webhookMessageDao = webhookMessageDao;
     }
 
     public WebhookEntity createWebhook(CreateWebhookRequest createWebhookRequest) {
@@ -66,6 +70,10 @@ public class WebhookService {
         return webhookDao.list(live);
     }
     
+    public List<WebhookMessageEntity> listMessages(String webhookId) {
+        return webhookMessageDao.list(webhookId);
+    }
+
     public Optional<WebhookEntity> regenerateSigningKey(String externalId, String serviceId) {
          return webhookDao.findByExternalId(externalId, serviceId).map(webhookEntity -> { 
           webhookEntity.setSigningKey(idGenerator.newWebhookSigningKey(webhookEntity.isLive()));

--- a/src/main/java/uk/gov/pay/webhooks/webhook/dao/entity/WebhookEntity.java
+++ b/src/main/java/uk/gov/pay/webhooks/webhook/dao/entity/WebhookEntity.java
@@ -129,7 +129,7 @@ public class WebhookEntity {
         return subscriptions;
     }
 
-    private void setExternalId(String externalId) {
+    public void setExternalId(String externalId) {
         this.externalId = externalId;
     }
 

--- a/src/main/java/uk/gov/pay/webhooks/webhook/resource/WebhookResource.java
+++ b/src/main/java/uk/gov/pay/webhooks/webhook/resource/WebhookResource.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import io.dropwizard.hibernate.UnitOfWork;
 import uk.gov.pay.webhooks.deliveryqueue.dao.WebhookDeliveryQueueEntity;
 import uk.gov.pay.webhooks.message.resource.WebhookMessageResponse;
+import uk.gov.pay.webhooks.message.resource.WebhookMessageSearchResponse;
 import uk.gov.pay.webhooks.validations.WebhookRequestValidator;
 import uk.gov.pay.webhooks.webhook.WebhookService;
 import uk.gov.pay.webhooks.webhook.dao.entity.WebhookEntity;
@@ -109,11 +110,13 @@ public class WebhookResource {
     @UnitOfWork
     @Path("/{externalId}/messages")
     @GET
-    public List<WebhookMessageResponse> getWebhookMessages(@PathParam("externalId") String externalId) {
-        return  webhookService.listMessages(externalId)
-                .stream()
-                .map(WebhookMessageResponse::from)
-                .toList();
+    public WebhookMessageSearchResponse getWebhookMessages(
+            @PathParam("externalId") String externalId,
+            @QueryParam("page") Integer page,
+            @QueryParam("status") String status
+    ) {
+        var currentPage = (page != null) ? page : 1;
+        return  webhookService.listMessages(externalId, status, currentPage);
     }
 
     @UnitOfWork

--- a/src/main/java/uk/gov/pay/webhooks/webhook/resource/WebhookResource.java
+++ b/src/main/java/uk/gov/pay/webhooks/webhook/resource/WebhookResource.java
@@ -3,6 +3,7 @@ package uk.gov.pay.webhooks.webhook.resource;
 import com.fasterxml.jackson.databind.JsonNode;
 import io.dropwizard.hibernate.UnitOfWork;
 import uk.gov.pay.webhooks.deliveryqueue.dao.WebhookDeliveryQueueEntity;
+import uk.gov.pay.webhooks.message.resource.WebhookDeliveryQueueResponse;
 import uk.gov.pay.webhooks.message.resource.WebhookMessageResponse;
 import uk.gov.pay.webhooks.message.resource.WebhookMessageSearchResponse;
 import uk.gov.pay.webhooks.validations.WebhookRequestValidator;
@@ -122,7 +123,7 @@ public class WebhookResource {
     @UnitOfWork
     @Path("/{externalId}/messages/{messageId}/attempts")
     @GET
-    public List<WebhookDeliveryQueueEntity> getWebhookMessageAttemps(
+    public List<WebhookDeliveryQueueResponse> getWebhookMessageAttemps(
             @PathParam("externalId") String externalId,
             @PathParam("messageId") String messageId
     ) {

--- a/src/main/java/uk/gov/pay/webhooks/webhook/resource/WebhookResource.java
+++ b/src/main/java/uk/gov/pay/webhooks/webhook/resource/WebhookResource.java
@@ -109,7 +109,7 @@ public class WebhookResource {
     }
 
     @UnitOfWork
-    @Path("/{externalId}/messages")
+    @Path("/{externalId}/message")
     @GET
     public WebhookMessageSearchResponse getWebhookMessages(
             @PathParam("externalId") String externalId,
@@ -117,11 +117,21 @@ public class WebhookResource {
             @QueryParam("status") String status
     ) {
         var currentPage = (page != null) ? page : 1;
-        return  webhookService.listMessages(externalId, status, currentPage);
+        return webhookService.listMessages(externalId, status, currentPage);
     }
 
     @UnitOfWork
-    @Path("/{externalId}/messages/{messageId}/attempts")
+    @Path("/{externalId}/message/{messageId}")
+    @GET
+    public WebhookMessageResponse getWebhookMessage(
+            @PathParam("externalId") String externalId,
+            @PathParam("messageId") String messageId
+    ) {
+        return webhookService.getMessage(externalId, messageId);
+    }
+
+    @UnitOfWork
+    @Path("/{externalId}/message/{messageId}/attempt")
     @GET
     public List<WebhookDeliveryQueueResponse> getWebhookMessageAttemps(
             @PathParam("externalId") String externalId,

--- a/src/main/java/uk/gov/pay/webhooks/webhook/resource/WebhookResource.java
+++ b/src/main/java/uk/gov/pay/webhooks/webhook/resource/WebhookResource.java
@@ -2,6 +2,7 @@ package uk.gov.pay.webhooks.webhook.resource;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import io.dropwizard.hibernate.UnitOfWork;
+import uk.gov.pay.webhooks.deliveryqueue.dao.WebhookDeliveryQueueEntity;
 import uk.gov.pay.webhooks.message.resource.WebhookMessageResponse;
 import uk.gov.pay.webhooks.validations.WebhookRequestValidator;
 import uk.gov.pay.webhooks.webhook.WebhookService;
@@ -113,6 +114,16 @@ public class WebhookResource {
                 .stream()
                 .map(WebhookMessageResponse::from)
                 .toList();
+    }
+
+    @UnitOfWork
+    @Path("/{externalId}/messages/{messageId}/attempts")
+    @GET
+    public List<WebhookDeliveryQueueEntity> getWebhookMessageAttemps(
+            @PathParam("externalId") String externalId,
+            @PathParam("messageId") String messageId
+    ) {
+        return  webhookService.listMessageAttempts(externalId, messageId);
     }
 
     @UnitOfWork

--- a/src/main/java/uk/gov/pay/webhooks/webhook/resource/WebhookResource.java
+++ b/src/main/java/uk/gov/pay/webhooks/webhook/resource/WebhookResource.java
@@ -27,6 +27,7 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.StreamSupport;
 
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
@@ -114,10 +115,14 @@ public class WebhookResource {
     public WebhookMessageSearchResponse getWebhookMessages(
             @PathParam("externalId") String externalId,
             @QueryParam("page") Integer page,
-            @QueryParam("status") String status
+            @Valid @QueryParam("status") WebhookDeliveryQueueEntity.DeliveryStatus status
     ) {
-        var currentPage = (page != null) ? page : 1;
-        return webhookService.listMessages(externalId, status, currentPage);
+        var currentPage = Optional.ofNullable(page)
+                .orElse(1);
+        var deliveryStatus = Optional.ofNullable(status)
+                .map(String::valueOf)
+                .orElse(null);
+        return webhookService.listMessages(externalId, deliveryStatus, currentPage);
     }
 
     @UnitOfWork

--- a/src/main/java/uk/gov/pay/webhooks/webhook/resource/WebhookResource.java
+++ b/src/main/java/uk/gov/pay/webhooks/webhook/resource/WebhookResource.java
@@ -2,6 +2,7 @@ package uk.gov.pay.webhooks.webhook.resource;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import io.dropwizard.hibernate.UnitOfWork;
+import uk.gov.pay.webhooks.message.resource.WebhookMessageResponse;
 import uk.gov.pay.webhooks.validations.WebhookRequestValidator;
 import uk.gov.pay.webhooks.webhook.WebhookService;
 import uk.gov.pay.webhooks.webhook.dao.entity.WebhookEntity;
@@ -103,7 +104,17 @@ public class WebhookResource {
                     .map(WebhookResponse::from)
                     .toList();
     }
-    
+
+    @UnitOfWork
+    @Path("/{externalId}/messages")
+    @GET
+    public List<WebhookMessageResponse> getWebhookMessages(@PathParam("externalId") String externalId) {
+        return  webhookService.listMessages(externalId)
+                .stream()
+                .map(WebhookMessageResponse::from)
+                .toList();
+    }
+
     @UnitOfWork
     @PATCH
     @Path("/{externalId}")

--- a/src/test/java/uk/gov/pay/webhooks/message/dao/WebhookMessageDaoTest.java
+++ b/src/test/java/uk/gov/pay/webhooks/message/dao/WebhookMessageDaoTest.java
@@ -37,12 +37,7 @@ class WebhookMessageDaoTest {
     public void setUp() {
         webhookDao = new WebhookDao(database.getSessionFactory());
         webhookMessageDao = new WebhookMessageDao(database.getSessionFactory());
-        webhookDeliveryQueueDao = new WebhookDeliveryQueueDao(database.getSessionFactory(), new InstantSource() {
-            @Override
-            public Instant instant() {
-                return Instant.now();
-            }
-        });
+        webhookDeliveryQueueDao = new WebhookDeliveryQueueDao(database.getSessionFactory(), InstantSource.fixed(Instant.now()));
     }
 
    @Test

--- a/src/test/java/uk/gov/pay/webhooks/message/dao/WebhookMessageDaoTest.java
+++ b/src/test/java/uk/gov/pay/webhooks/message/dao/WebhookMessageDaoTest.java
@@ -1,0 +1,102 @@
+package uk.gov.pay.webhooks.message.dao;
+
+import io.dropwizard.testing.junit5.DAOTestExtension;
+import io.dropwizard.testing.junit5.DropwizardExtensionsSupport;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import uk.gov.pay.webhooks.deliveryqueue.dao.WebhookDeliveryQueueDao;
+import uk.gov.pay.webhooks.deliveryqueue.dao.WebhookDeliveryQueueEntity;
+import uk.gov.pay.webhooks.eventtype.dao.EventTypeEntity;
+import uk.gov.pay.webhooks.message.dao.entity.WebhookMessageEntity;
+import uk.gov.pay.webhooks.webhook.dao.WebhookDao;
+import uk.gov.pay.webhooks.webhook.dao.entity.WebhookEntity;
+
+import java.time.Instant;
+import java.time.InstantSource;
+import java.util.Date;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+@ExtendWith(DropwizardExtensionsSupport.class)
+class WebhookMessageDaoTest {
+    public DAOTestExtension database = DAOTestExtension.newBuilder()
+            .addEntityClass(WebhookEntity.class)
+            .addEntityClass(WebhookMessageEntity.class)
+            .addEntityClass(WebhookDeliveryQueueEntity.class)
+            .addEntityClass(EventTypeEntity.class)
+            .build();
+
+    private WebhookDao webhookDao;
+    private WebhookMessageDao webhookMessageDao;
+    private WebhookDeliveryQueueDao webhookDeliveryQueueDao;
+    String webhookExternalId = "webhook-external-id";
+
+    @BeforeEach
+    public void setUp() {
+        webhookDao = new WebhookDao(database.getSessionFactory());
+        webhookMessageDao = new WebhookMessageDao(database.getSessionFactory());
+        webhookDeliveryQueueDao = new WebhookDeliveryQueueDao(database.getSessionFactory(), new InstantSource() {
+            @Override
+            public Instant instant() {
+                return Instant.now();
+            }
+        });
+    }
+
+   @Test
+   public void shouldListAndCountAllWithNoStatus() {
+        setup(1);
+        var messages = webhookMessageDao.list(webhookExternalId, null, 1);
+        var total = webhookMessageDao.count(webhookExternalId, null);
+        assertThat(messages.size(), is(2));
+        assertThat(total, is(2L));
+   }
+
+    @Test
+    public void shouldListAndCountFilteredByStatus() {
+        setup(1);
+        var messages = webhookMessageDao.list(webhookExternalId, "SUCCESSFUL", 1);
+        var total = webhookMessageDao.count(webhookExternalId, "SUCCESSFUL");
+        assertThat(messages.size(), is(1));
+        assertThat(total, is(1L));
+        assertThat(messages.get(0).getExternalId(), is("successful-message-external-id"));
+    }
+
+    @Test
+    public void shouldCalculateCorrectPagePosition() {
+        setup(15);
+        var firstPage = webhookMessageDao.list(webhookExternalId, null, 1);
+        var secondPage = webhookMessageDao.list(webhookExternalId, null, 2);
+        var total = webhookMessageDao.count(webhookExternalId, null);
+        assertThat(firstPage.size(), is(10));
+        assertThat(secondPage.size(), is(6));
+        assertThat(total, is(16L));
+    }
+
+   private void setup(int numberOfPendingMessagesToPad) {
+       var webhook = new WebhookEntity();
+       webhook.setLive(true);
+       webhook.setServiceId("real-service-id");
+       webhook.setExternalId(webhookExternalId);
+
+       var message = new WebhookMessageEntity();
+       message.setWebhookEntity(webhook);
+       message.setExternalId("successful-message-external-id");
+
+       database.inTransaction(() -> {
+           webhookDao.create(webhook);
+           webhookMessageDao.create(message);
+           webhookDeliveryQueueDao.enqueueFrom(message, WebhookDeliveryQueueEntity.DeliveryStatus.SUCCESSFUL, new Date());
+
+           for (var i = 0; i < numberOfPendingMessagesToPad; i++) {
+               var padMessage = new WebhookMessageEntity();
+               padMessage.setWebhookEntity(webhook);
+               padMessage.setExternalId("padded-message-%s".formatted(i));
+               webhookMessageDao.create(padMessage);
+               webhookDeliveryQueueDao.enqueueFrom(padMessage, WebhookDeliveryQueueEntity.DeliveryStatus.PENDING, new Date());
+           }
+       });
+   }
+}

--- a/src/test/java/uk/gov/pay/webhooks/webhook/WebhookServiceTest.java
+++ b/src/test/java/uk/gov/pay/webhooks/webhook/WebhookServiceTest.java
@@ -3,6 +3,7 @@ package uk.gov.pay.webhooks.webhook;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
+import uk.gov.pay.webhooks.deliveryqueue.dao.WebhookDeliveryQueueDao;
 import uk.gov.pay.webhooks.eventtype.EventTypeName;
 import uk.gov.pay.webhooks.eventtype.dao.EventTypeDao;
 import uk.gov.pay.webhooks.eventtype.dao.EventTypeEntity;
@@ -31,6 +32,7 @@ import static org.mockito.Mockito.when;
 class WebhookServiceTest {
     private final WebhookDao webhookDao = mock(WebhookDao.class);
     private final WebhookMessageDao webhookMessageDao = mock(WebhookMessageDao.class);
+    private final WebhookDeliveryQueueDao webhookDeliveryQueueDao = mock (WebhookDeliveryQueueDao.class);
     private final EventTypeDao eventTypeDao = mock(EventTypeDao.class);
     private final InstantSource instantSource = InstantSource.fixed(Instant.now());
     private final IdGenerator idGenerator = mock(IdGenerator.class);
@@ -42,7 +44,7 @@ class WebhookServiceTest {
     
     @BeforeEach
     public void setUp() {
-        webhookService = new WebhookService(webhookDao, eventTypeDao, instantSource, idGenerator, webhookMessageDao);
+        webhookService = new WebhookService(webhookDao, eventTypeDao, instantSource, idGenerator, webhookMessageDao, webhookDeliveryQueueDao);
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/webhooks/webhook/WebhookServiceTest.java
+++ b/src/test/java/uk/gov/pay/webhooks/webhook/WebhookServiceTest.java
@@ -6,6 +6,7 @@ import org.mockito.ArgumentCaptor;
 import uk.gov.pay.webhooks.eventtype.EventTypeName;
 import uk.gov.pay.webhooks.eventtype.dao.EventTypeDao;
 import uk.gov.pay.webhooks.eventtype.dao.EventTypeEntity;
+import uk.gov.pay.webhooks.message.dao.WebhookMessageDao;
 import uk.gov.pay.webhooks.queue.InternalEvent;
 import uk.gov.pay.webhooks.util.IdGenerator;
 import uk.gov.pay.webhooks.webhook.dao.WebhookDao;
@@ -29,6 +30,7 @@ import static org.mockito.Mockito.when;
 
 class WebhookServiceTest {
     private final WebhookDao webhookDao = mock(WebhookDao.class);
+    private final WebhookMessageDao webhookMessageDao = mock(WebhookMessageDao.class);
     private final EventTypeDao eventTypeDao = mock(EventTypeDao.class);
     private final InstantSource instantSource = InstantSource.fixed(Instant.now());
     private final IdGenerator idGenerator = mock(IdGenerator.class);
@@ -40,7 +42,7 @@ class WebhookServiceTest {
     
     @BeforeEach
     public void setUp() {
-        webhookService = new WebhookService(webhookDao, eventTypeDao, instantSource, idGenerator);
+        webhookService = new WebhookService(webhookDao, eventTypeDao, instantSource, idGenerator, webhookMessageDao);
     }
 
     @Test
@@ -134,4 +136,3 @@ class WebhookServiceTest {
     }
     
 }
-

--- a/src/test/java/uk/gov/pay/webhooks/webhook/resource/WebhookResourceIT.java
+++ b/src/test/java/uk/gov/pay/webhooks/webhook/resource/WebhookResourceIT.java
@@ -81,14 +81,14 @@ public class WebhookResourceIT {
         given().port(port)
                 .contentType(JSON)
                 .queryParam("status", "FAILED")
-                .get("/v1/webhook/%s/messages".formatted(externalId))
+                .get("/v1/webhook/%s/message".formatted(externalId))
                 .then()
                 .statusCode(Response.Status.OK.getStatusCode())
                 .body("results.latest_attempt[0].status", is("FAILED"));
 
         given().port(port)
                 .contentType(JSON)
-                .get("/v1/webhook/%s/messages".formatted(externalId))
+                .get("/v1/webhook/%s/message".formatted(externalId))
                 .then()
                 .statusCode(Response.Status.OK.getStatusCode())
                 .body("count", is(10))
@@ -99,7 +99,7 @@ public class WebhookResourceIT {
         given().port(port)
                 .contentType(JSON)
                 .queryParam("page", 2)
-                .get("/v1/webhook/%s/messages".formatted(externalId))
+                .get("/v1/webhook/%s/message".formatted(externalId))
                 .then()
                 .statusCode(Response.Status.OK.getStatusCode())
                 .body("count", is(2))
@@ -116,10 +116,25 @@ public class WebhookResourceIT {
 
         given().port(port)
                 .contentType(JSON)
-                .get("/v1/webhook/%s/messages/%s/attempts".formatted(externalId, messageExternalId))
+                .get("/v1/webhook/%s/message/%s/attempt".formatted(externalId, messageExternalId))
                 .then()
                 .statusCode(Response.Status.OK.getStatusCode())
                 .body("size()", is(3));
+    }
+
+    @Test
+    public void shouldReturnMessageDetail() {
+        var externalId = "awebhookexternalid";
+        var messageExternalId = "message-external-id-1";
+        setupWebhookWithMessages(externalId, messageExternalId);
+
+        given().port(port)
+                .contentType(JSON)
+                .get("/v1/webhook/%s/message/%s".formatted(externalId, messageExternalId))
+                .then()
+                .statusCode(Response.Status.OK.getStatusCode())
+                .body("external_id", is(messageExternalId))
+                .body("latest_attempt.status", is("FAILED"));
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/webhooks/webhook/resource/WebhookResourceIT.java
+++ b/src/test/java/uk/gov/pay/webhooks/webhook/resource/WebhookResourceIT.java
@@ -84,8 +84,8 @@ public class WebhookResourceIT {
                 .get("/v1/webhook/%s/messages".formatted(externalId))
                 .then()
                 .statusCode(Response.Status.OK.getStatusCode())
-                .body("results.webhook_delivery_queue_entity[0].deliveryStatus", is("FAILED"));
-        
+                .body("results.latest_attempt[0].status", is("FAILED"));
+
         given().port(port)
                 .contentType(JSON)
                 .get("/v1/webhook/%s/messages".formatted(externalId))

--- a/src/test/java/uk/gov/pay/webhooks/webhook/resource/WebhookResourceIT.java
+++ b/src/test/java/uk/gov/pay/webhooks/webhook/resource/WebhookResourceIT.java
@@ -83,7 +83,8 @@ public class WebhookResourceIT {
                 .contentType(JSON)
                 .get("/v1/webhook/%s/messages".formatted(externalId))
                 .then()
-                .statusCode(Response.Status.OK.getStatusCode());
+                .statusCode(Response.Status.OK.getStatusCode())
+                .body("webhook_delivery_queue_entity[0].deliveryStatus", is("FAILED"));
     }
 
     @Test


### PR DESCRIPTION
Adds endpoints for interrogating webhook messages and their delivery attempts.

---

`/v1/webhook/{externalId}/message`
List the messages for a given webhook
- ordered by created date
- 10 per page

`?page` - optional, specify how far into the data to fetch messages
`?status` - optional, filter by a given status `"SUCCESSFUL"`, `"FAILED"`

---

`/v1/webhook/{externalId}/message/{messageId}`
Get details for a given webhook and message

---

`/v1/webhook/{externalId}/message/{messageId}/attempt`
List all delivery attempts for a given webhook and message
