### PR TITLE
PP-9077 Support all initially proposed payment event types

### DIFF
--- a/src/main/java/uk/gov/pay/webhooks/eventtype/EventTypeName.java
+++ b/src/main/java/uk/gov/pay/webhooks/eventtype/EventTypeName.java
@@ -5,9 +5,15 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.stream.Stream;
 
 public enum EventTypeName {
+    @JsonProperty("card_payment_started")
+    CARD_PAYMENT_STARTED("card_payment_started"),
+    @JsonProperty("card_payment_succeeded")
+    CARD_PAYMENT_SUCCEEDED("card_payment_succeeded"),
     @JsonProperty("card_payment_captured")
-    CARD_PAYMENT_CAPTURED("card_payment_captured");
-    
+    CARD_PAYMENT_CAPTURED("card_payment_captured"),
+    @JsonProperty("card_payment_refunded")
+    CARD_PAYMENT_REFUNDED("card_payment_refunded");
+
     private final String name;
     
     EventTypeName(String name) {

--- a/src/main/java/uk/gov/pay/webhooks/message/EventMapper.java
+++ b/src/main/java/uk/gov/pay/webhooks/message/EventMapper.java
@@ -1,18 +1,28 @@
 package uk.gov.pay.webhooks.message;
 
+import jdk.jfr.Event;
+import jdk.jfr.EventType;
 import uk.gov.pay.webhooks.eventtype.EventTypeName;
 
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 public class EventMapper {
     private static final Map<String, EventTypeName> internalToWebhook = Map.of(
-            "CAPTURE_CONFIRMED", EventTypeName.CARD_PAYMENT_CAPTURED
+            "PAYMENT_STARTED", EventTypeName.CARD_PAYMENT_STARTED,
+            "AUTHORISATION_SUCCEEDED", EventTypeName.CARD_PAYMENT_SUCCEEDED,
+            "CAPTURE_CONFIRMED", EventTypeName.CARD_PAYMENT_CAPTURED,
+            "REFUND_SUCCEEDED", EventTypeName.CARD_PAYMENT_REFUNDED
     );
 
-    private static final Map<EventTypeName, String> webhookToInternal = Map.of(
-            EventTypeName.CARD_PAYMENT_CAPTURED, "CAPTURE_CONFIRMED"
-    );
+    private static final Map<EventTypeName, String> webhookToInternal = internalToWebhook
+            .entrySet()
+            .stream()
+            .collect(Collectors.toMap(Map.Entry::getValue, Map.Entry::getKey));
+
+    private static final List<EventTypeName> childEvents = List.of(EventTypeName.CARD_PAYMENT_REFUNDED);
 
     public static Optional<String> getInternalEventNameFor(EventTypeName webhookEventTypeName) {
         return Optional.ofNullable(webhookToInternal.get(webhookEventTypeName));
@@ -20,5 +30,9 @@ public class EventMapper {
 
     public static EventTypeName getWebhookEventNameFor(String webhookEventName) {
         return internalToWebhook.get(webhookEventName);
+    }
+
+    public static boolean isChildEvent(EventTypeName webhookEventTypeName) {
+        return childEvents.contains(webhookEventTypeName);
     }
 }

--- a/src/main/java/uk/gov/pay/webhooks/message/WebhookMessageService.java
+++ b/src/main/java/uk/gov/pay/webhooks/message/WebhookMessageService.java
@@ -58,7 +58,8 @@ public class WebhookMessageService {
         var subscribedWebhooks = webhookService.getWebhooksSubscribedToEvent(event);
 
         if (!subscribedWebhooks.isEmpty()) {
-            LedgerTransaction ledgerTransaction = ledgerService.getTransaction(event.resourceExternalId()).orElseThrow(IllegalArgumentException::new);
+            var resourceExternalId = getResourceIdForEvent(event); 
+            LedgerTransaction ledgerTransaction = ledgerService.getTransaction(resourceExternalId).orElseThrow(IllegalArgumentException::new);
             subscribedWebhooks
                     .stream()
                     .map(webhook -> buildWebhookMessage(webhook, event, ledgerTransaction))
@@ -78,5 +79,10 @@ public class WebhookMessageService {
         webhookMessageEntity.setEventType(eventTypeDao.findByName(EventMapper.getWebhookEventNameFor(event.eventType())).orElseThrow(IllegalArgumentException::new));
         webhookMessageEntity.setResource(resource);
         return webhookMessageEntity;
+    }
+
+    private String getResourceIdForEvent(InternalEvent event) {
+        var isChildEvent = EventMapper.isChildEvent(EventMapper.getWebhookEventNameFor(event.eventType()));
+        return isChildEvent ? event.parentResourceExternalId() : event.resourceExternalId();
     }
 }

--- a/src/main/java/uk/gov/pay/webhooks/queue/EventMessage.java
+++ b/src/main/java/uk/gov/pay/webhooks/queue/EventMessage.java
@@ -14,6 +14,7 @@ public record EventMessage(EventMessageDto eventMessageDto, QueueMessage queueMe
                 eventMessageDto.serviceId(),
                 eventMessageDto.live(),
                 eventMessageDto.resourceExternalId(),
+                eventMessageDto.parentResourceExternalId(),
                 eventMessageDto.eventData(),
                 eventMessageDto.eventDate()
                 );

--- a/src/main/java/uk/gov/pay/webhooks/queue/EventMessageDto.java
+++ b/src/main/java/uk/gov/pay/webhooks/queue/EventMessageDto.java
@@ -16,6 +16,7 @@ public record EventMessageDto(@JsonProperty("service_id") String serviceId,
                               Boolean live,
                               @JsonProperty("event_date") @JsonDeserialize(using = MicrosecondPrecisionDateTimeDeserializer.class) ZonedDateTime eventDate,
                               @JsonProperty("resource_external_id") String resourceExternalId,
+                              @JsonProperty("parent_resource_external_id") String parentResourceExternalId,
                               @JsonProperty("event_type") String eventType,
                               @JsonProperty("event_data") JsonNode eventData
 ) {}

--- a/src/main/java/uk/gov/pay/webhooks/queue/InternalEvent.java
+++ b/src/main/java/uk/gov/pay/webhooks/queue/InternalEvent.java
@@ -11,6 +11,7 @@ public record InternalEvent(
         String serviceId,
         Boolean live,
         String resourceExternalId,
+        String parentResourceExternalId,
         JsonNode eventData,
         @JsonSerialize(using = MicrosecondPrecisionDateTimeSerializer.class) ZonedDateTime eventDate
         ) {}

--- a/src/main/resources/migrations/0002_create_table_event_types.sql
+++ b/src/main/resources/migrations/0002_create_table_event_types.sql
@@ -7,6 +7,10 @@ CREATE table event_types (
     name VARCHAR(64) NOT NULL
 );
 
-INSERT INTO event_types(name) VALUES (('card_payment_captured'));
+INSERT INTO event_types(name) VALUES
+    ('card_payment_started'),
+    ('card_payment_succeeded'),
+    ('card_payment_captured'),
+    ('card_payment_refunded');
 
 --rollback DROP table event_types

--- a/src/test/java/uk/gov/pay/webhooks/validations/WebhookRequestValidatorTest.java
+++ b/src/test/java/uk/gov/pay/webhooks/validations/WebhookRequestValidatorTest.java
@@ -84,7 +84,7 @@ class WebhookRequestValidatorTest {
                         """
         );
         var thrown = assertThrows(ValidationException.class, () -> new WebhookRequestValidator().validateJsonPatch(request));
-        assertThat(thrown.getErrors().get(0), is("Value for path [subscriptions] must be array of [card_payment_captured]"));
+        assertThat(thrown.getErrors().get(0), is("Value for path [subscriptions] must be array of [card_payment_started, card_payment_succeeded, card_payment_captured, card_payment_refunded]"));
     }
 
     @Test
@@ -102,7 +102,7 @@ class WebhookRequestValidatorTest {
                         """
         );
         var thrown = assertThrows(ValidationException.class, () -> new WebhookRequestValidator().validateJsonPatch(request));
-        assertThat(thrown.getErrors().get(0), is("Value for path [subscriptions] must be array of [card_payment_captured]"));
+        assertThat(thrown.getErrors().get(0), is("Value for path [subscriptions] must be array of [card_payment_started, card_payment_succeeded, card_payment_captured, card_payment_refunded]"));
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/webhooks/webhook/WebhookServiceTest.java
+++ b/src/test/java/uk/gov/pay/webhooks/webhook/WebhookServiceTest.java
@@ -107,7 +107,7 @@ class WebhookServiceTest {
         var webhookNotSubscribedToAnyEvents = new WebhookEntity();
         when(webhookDao.list(live, serviceId))
                 .thenReturn(List.of(webhookSubscribedToCaptureEvent, webhookNotSubscribedToAnyEvents));
-        var event = new InternalEvent("CAPTURE_CONFIRMED", serviceId, live, "resource_id", null, ZonedDateTime.now());
+        var event = new InternalEvent("CAPTURE_CONFIRMED", serviceId, live, "resource_id", null, null, ZonedDateTime.now());
         
         var subscribedWebhooks = webhookService.getWebhooksSubscribedToEvent(event);
         


### PR DESCRIPTION
Add entries for
* Payment started
* Payment succeeded
* Payment refunded

Clean up duplication in K/V maps.

Add an additional case to fetch a parent resource if the event relates to a
dependant resource.