### PR TITLE
PP-9113: serialise Public API representation of payment

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -107,6 +107,10 @@
             <artifactId>jackson-databind</artifactId>
         </dependency>
         <dependency>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-jdk8</artifactId>
+        </dependency>
+        <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-java-sdk-sqs</artifactId>
         </dependency>

--- a/src/main/java/uk/gov/pay/webhooks/app/WebhooksModule.java
+++ b/src/main/java/uk/gov/pay/webhooks/app/WebhooksModule.java
@@ -6,6 +6,7 @@ import com.amazonaws.client.builder.AwsClientBuilder;
 import com.amazonaws.services.sqs.AmazonSQS;
 import com.amazonaws.services.sqs.AmazonSQSClientBuilder;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.google.inject.AbstractModule;
 import com.google.inject.Provides;
 import io.dropwizard.hibernate.HibernateBundle;
@@ -59,7 +60,7 @@ public class WebhooksModule extends AbstractModule {
     @Provides
     @Singleton
     public WebhookMessageSender webhookMessageSender() {
-        return new WebhookMessageSender(httpClient(), new ObjectMapper(),
+        return new WebhookMessageSender(httpClient(), new ObjectMapper().registerModule(new Jdk8Module()),
                 new WebhookMessageSignatureGenerator());
     }
 

--- a/src/main/java/uk/gov/pay/webhooks/message/WebhookMessageService.java
+++ b/src/main/java/uk/gov/pay/webhooks/message/WebhookMessageService.java
@@ -6,21 +6,30 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.pay.webhooks.deliveryqueue.dao.WebhookDeliveryQueueDao;
 import uk.gov.pay.webhooks.deliveryqueue.dao.WebhookDeliveryQueueEntity;
-import uk.gov.pay.webhooks.eventtype.EventTypeName;
 import uk.gov.pay.webhooks.eventtype.dao.EventTypeDao;
 import uk.gov.pay.webhooks.ledger.LedgerService;
 import uk.gov.pay.webhooks.ledger.model.LedgerTransaction;
 import uk.gov.pay.webhooks.message.dao.WebhookMessageDao;
 import uk.gov.pay.webhooks.message.dao.entity.WebhookMessageEntity;
+import uk.gov.pay.webhooks.publicapi.model.Address;
+import uk.gov.pay.webhooks.publicapi.model.AuthorisationSummary;
+import uk.gov.pay.webhooks.publicapi.model.CardDetails;
+import uk.gov.pay.webhooks.publicapi.model.PaymentForSearchResult;
+import uk.gov.pay.webhooks.publicapi.model.PaymentSettlementSummary;
+import uk.gov.pay.webhooks.publicapi.model.PaymentState;
+import uk.gov.pay.webhooks.publicapi.model.RefundSummary;
+import uk.gov.pay.webhooks.publicapi.model.ThreeDSecure;
 import uk.gov.pay.webhooks.queue.InternalEvent;
 import uk.gov.pay.webhooks.util.IdGenerator;
 import uk.gov.pay.webhooks.webhook.WebhookService;
 import uk.gov.pay.webhooks.webhook.dao.entity.WebhookEntity;
+import uk.gov.service.payments.commons.model.charge.ExternalMetadata;
 
 import javax.inject.Inject;
 import java.io.IOException;
 import java.time.InstantSource;
 import java.util.Date;
+import java.util.Optional;
 
 public class WebhookMessageService {
 
@@ -69,8 +78,8 @@ public class WebhookMessageService {
     }
 
     private WebhookMessageEntity buildWebhookMessage(WebhookEntity webhook, InternalEvent event, LedgerTransaction ledgerTransaction) {
-        JsonNode resource = objectMapper.valueToTree(ledgerTransaction); 
-
+        JsonNode resource = objectMapper.valueToTree(paymentForSearchResultFrom(ledgerTransaction));
+        
         var webhookMessageEntity = new WebhookMessageEntity();
         webhookMessageEntity.setExternalId(idGenerator.newExternalId());
         webhookMessageEntity.setCreatedDate(Date.from(instantSource.instant()));

--- a/src/main/java/uk/gov/pay/webhooks/message/WebhookMessageService.java
+++ b/src/main/java/uk/gov/pay/webhooks/message/WebhookMessageService.java
@@ -14,6 +14,7 @@ import uk.gov.pay.webhooks.message.dao.entity.WebhookMessageEntity;
 import uk.gov.pay.webhooks.publicapi.model.Address;
 import uk.gov.pay.webhooks.publicapi.model.AuthorisationSummary;
 import uk.gov.pay.webhooks.publicapi.model.CardDetails;
+import uk.gov.pay.webhooks.publicapi.model.ExternalChargeState;
 import uk.gov.pay.webhooks.publicapi.model.PaymentForSearchResult;
 import uk.gov.pay.webhooks.publicapi.model.PaymentSettlementSummary;
 import uk.gov.pay.webhooks.publicapi.model.PaymentState;

--- a/src/main/java/uk/gov/pay/webhooks/message/WebhookMessageService.java
+++ b/src/main/java/uk/gov/pay/webhooks/message/WebhookMessageService.java
@@ -11,26 +11,16 @@ import uk.gov.pay.webhooks.ledger.LedgerService;
 import uk.gov.pay.webhooks.ledger.model.LedgerTransaction;
 import uk.gov.pay.webhooks.message.dao.WebhookMessageDao;
 import uk.gov.pay.webhooks.message.dao.entity.WebhookMessageEntity;
-import uk.gov.pay.webhooks.publicapi.model.Address;
-import uk.gov.pay.webhooks.publicapi.model.AuthorisationSummary;
-import uk.gov.pay.webhooks.publicapi.model.CardDetails;
-import uk.gov.pay.webhooks.publicapi.model.ExternalChargeState;
-import uk.gov.pay.webhooks.publicapi.model.PaymentForSearchResult;
-import uk.gov.pay.webhooks.publicapi.model.PaymentSettlementSummary;
-import uk.gov.pay.webhooks.publicapi.model.PaymentState;
-import uk.gov.pay.webhooks.publicapi.model.RefundSummary;
-import uk.gov.pay.webhooks.publicapi.model.ThreeDSecure;
+import uk.gov.pay.webhooks.publicapi.model.APICardPaymentV1;
 import uk.gov.pay.webhooks.queue.InternalEvent;
 import uk.gov.pay.webhooks.util.IdGenerator;
 import uk.gov.pay.webhooks.webhook.WebhookService;
 import uk.gov.pay.webhooks.webhook.dao.entity.WebhookEntity;
-import uk.gov.service.payments.commons.model.charge.ExternalMetadata;
 
 import javax.inject.Inject;
 import java.io.IOException;
 import java.time.InstantSource;
 import java.util.Date;
-import java.util.Optional;
 
 public class WebhookMessageService {
 
@@ -79,7 +69,7 @@ public class WebhookMessageService {
     }
 
     private WebhookMessageEntity buildWebhookMessage(WebhookEntity webhook, InternalEvent event, LedgerTransaction ledgerTransaction) {
-        JsonNode resource = objectMapper.valueToTree(paymentForSearchResultFrom(ledgerTransaction));
+        JsonNode resource = objectMapper.valueToTree(APICardPaymentV1.paymentForSearchResultFrom(ledgerTransaction));
         
         var webhookMessageEntity = new WebhookMessageEntity();
         webhookMessageEntity.setExternalId(idGenerator.newExternalId());

--- a/src/main/java/uk/gov/pay/webhooks/publicapi/model/APICardPaymentV1.java
+++ b/src/main/java/uk/gov/pay/webhooks/publicapi/model/APICardPaymentV1.java
@@ -1,0 +1,45 @@
+package uk.gov.pay.webhooks.publicapi.model;
+
+import uk.gov.pay.webhooks.ledger.model.LedgerTransaction;
+import uk.gov.service.payments.commons.model.charge.ExternalMetadata;
+
+import java.util.Optional;
+
+public class APICardPaymentV1 {
+    public static PaymentForSearchResult paymentForSearchResultFrom(LedgerTransaction ledgerTransaction) {
+        var externalChargeState = ExternalChargeState.fromStatusString(ledgerTransaction.getState().getStatus());
+        return new PaymentForSearchResult(
+                ledgerTransaction.getTransactionId(),
+                ledgerTransaction.getAmount(),
+                new PaymentState(externalChargeState.getStatus(), externalChargeState.isFinished(), externalChargeState.getMessage(), externalChargeState.getCode()),
+                ledgerTransaction.getReturnUrl(),
+                ledgerTransaction.getDescription(),
+                ledgerTransaction.getReference(),
+                ledgerTransaction.getEmail(),
+                ledgerTransaction.getPaymentProvider(),
+                ledgerTransaction.getCreatedDate(),
+                ledgerTransaction.getLanguage(),
+                ledgerTransaction.getDelayedCapture(),
+                ledgerTransaction.isMoto(),
+                Optional.ofNullable(ledgerTransaction.getRefundSummary()).map(rs -> new RefundSummary(rs.getStatus(), rs.getAmountAvailable(), rs.getAmountSubmitted())).orElse(null),
+                Optional.ofNullable(ledgerTransaction.getSettlementSummary()).map(ss -> new PaymentSettlementSummary(ss.getCaptureSubmitTime(), ss.getCapturedDate(), null)).orElse(null),
+                new CardDetails(ledgerTransaction.getCardDetails().getLastDigitsCardNumber(),
+                        ledgerTransaction.getCardDetails().getFirstDigitsCardNumber(),
+                        ledgerTransaction.getCardDetails().getCardholderName(),
+                        ledgerTransaction.getCardDetails().getExpiryDate(),
+                        new Address(ledgerTransaction.getCardDetails().getBillingAddress().getLine1(),
+                                ledgerTransaction.getCardDetails().getBillingAddress().getLine2(),
+                                ledgerTransaction.getCardDetails().getBillingAddress().getPostcode(),
+                                ledgerTransaction.getCardDetails().getBillingAddress().getCity(),
+                                ledgerTransaction.getCardDetails().getBillingAddress().getCountry()),
+                        ledgerTransaction.getCardDetails().getCardBrand(),
+                        ledgerTransaction.getCardDetails().getCardType()),
+                ledgerTransaction.getCorporateCardSurcharge(),
+                ledgerTransaction.getTotalAmount(),
+                ledgerTransaction.getPaymentProvider(),
+                Optional.ofNullable(ledgerTransaction.getExternalMetaData()).map(ExternalMetadata::new).orElse(null),
+                ledgerTransaction.getFee(),
+                ledgerTransaction.getNetAmount(),
+                new AuthorisationSummary(new ThreeDSecure(ledgerTransaction.getAuthorisationSummary().getThreeDSecure().isRequired())));
+    }
+}

--- a/src/main/java/uk/gov/pay/webhooks/publicapi/model/Address.java
+++ b/src/main/java/uk/gov/pay/webhooks/publicapi/model/Address.java
@@ -1,0 +1,79 @@
+package uk.gov.pay.webhooks.publicapi.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import javax.validation.constraints.Size;
+
+import java.util.Objects;
+
+import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(NON_NULL)
+public class Address {
+
+    @Size(max = 255, message = "Must be less than or equal to {max} characters length")
+    private String line1;
+
+    @Size(max = 255, message = "Must be less than or equal to {max} characters length")
+    private String line2;
+
+    @Size(max = 25, message = "Must be less than or equal to {max} characters length")
+    private String postcode;
+
+    @Size(max = 255, message = "Must be less than or equal to {max} characters length")
+    private String city;
+
+    private String country;
+
+    public Address(@JsonProperty("line1") String line1,
+                   @JsonProperty("line2") String line2,
+                   @JsonProperty("postcode") String postcode,
+                   @JsonProperty("city") String city,
+                   @JsonProperty("country") String country) {
+        this.line1 = line1;
+        this.line2 = line2;
+        this.postcode = postcode;
+        this.city = city;
+        this.country = country;
+    }
+
+    public String getLine1() {
+        return line1;
+    }
+
+    public String getLine2() {
+        return line2;
+    }
+
+    public String getPostcode() {
+        return postcode;
+    }
+
+    public String getCity() {
+        return city;
+    }
+
+    public String getCountry() {
+        return country;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Address address = (Address) o;
+        return Objects.equals(line1, address.line1) &&
+                Objects.equals(line2, address.line2) &&
+                Objects.equals(postcode, address.postcode) &&
+                Objects.equals(city, address.city) &&
+                Objects.equals(country, address.country);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(line1, line2, postcode, city, country);
+    }
+}

--- a/src/main/java/uk/gov/pay/webhooks/publicapi/model/AuthorisationSummary.java
+++ b/src/main/java/uk/gov/pay/webhooks/publicapi/model/AuthorisationSummary.java
@@ -1,0 +1,24 @@
+package uk.gov.pay.webhooks.publicapi.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class AuthorisationSummary {
+
+    @JsonProperty("three_d_secure")
+    private ThreeDSecure threeDSecure;
+
+    public AuthorisationSummary() {
+    }
+
+    public AuthorisationSummary(ThreeDSecure threeDSecure) {
+        this.threeDSecure = threeDSecure;
+    }
+
+    public ThreeDSecure getThreeDSecure() {
+        return threeDSecure;
+    }
+}

--- a/src/main/java/uk/gov/pay/webhooks/publicapi/model/CardDetails.java
+++ b/src/main/java/uk/gov/pay/webhooks/publicapi/model/CardDetails.java
@@ -1,0 +1,79 @@
+package uk.gov.pay.webhooks.publicapi.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.Optional;
+
+import static com.fasterxml.jackson.annotation.JsonInclude.Include.ALWAYS;
+
+@JsonInclude(ALWAYS)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class CardDetails {
+
+    @JsonProperty("last_digits_card_number")
+    private final String lastDigitsCardNumber;
+
+    @JsonProperty("first_digits_card_number")
+    private final String firstDigitsCardNumber;
+
+    @JsonProperty("cardholder_name")
+    private final String cardHolderName;
+
+    @JsonProperty("expiry_date")
+    private final String expiryDate;
+
+    @JsonProperty("billing_address")
+    private final Address billingAddress;
+
+    @JsonProperty("card_brand")
+    private final String cardBrand;
+
+    @JsonProperty("card_type")
+    private final String cardType;
+
+    public CardDetails(@JsonProperty("last_digits_card_number") String lastDigitsCardNumber,
+                       @JsonProperty("first_digits_card_number") String firstDigitsCardNumber,
+                       @JsonProperty("cardholder_name") String cardHolderName,
+                       @JsonProperty("expiry_date") String expiryDate,
+                       @JsonProperty("billing_address") Address billingAddress,
+                       @JsonProperty("card_brand") String cardBrand,
+                       @JsonProperty("card_type") String cardType) {
+        this.lastDigitsCardNumber = lastDigitsCardNumber;
+        this.firstDigitsCardNumber = firstDigitsCardNumber;
+        this.cardHolderName = cardHolderName;
+        this.expiryDate = expiryDate;
+        this.billingAddress = billingAddress;
+        this.cardBrand = cardBrand;
+        this.cardType = cardType;
+    }
+
+    public String getLastDigitsCardNumber() {
+        return lastDigitsCardNumber;
+    }
+
+    public String getFirstDigitsCardNumber() {
+        return firstDigitsCardNumber;
+    }
+
+    public String getCardHolderName() {
+        return cardHolderName;
+    }
+
+    public String getExpiryDate() {
+        return expiryDate;
+    }
+
+    public Optional<Address> getBillingAddress() {
+        return Optional.ofNullable(billingAddress);
+    }
+
+    public String getCardBrand() {
+        return cardBrand;
+    }
+
+    public String getCardType() {
+        return cardType;
+    }
+}

--- a/src/main/java/uk/gov/pay/webhooks/publicapi/model/CardPayment.java
+++ b/src/main/java/uk/gov/pay/webhooks/publicapi/model/CardPayment.java
@@ -1,0 +1,191 @@
+package uk.gov.pay.webhooks.publicapi.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
+import uk.gov.service.payments.commons.api.json.ExternalMetadataSerialiser;
+import uk.gov.service.payments.commons.model.SupportedLanguage;
+import uk.gov.service.payments.commons.model.charge.ExternalMetadata;
+
+import java.util.Optional;
+
+import static uk.gov.service.payments.commons.model.TokenPaymentType.CARD;
+
+@JsonInclude(value = JsonInclude.Include.NON_EMPTY)
+public class CardPayment extends Payment {
+
+    @JsonProperty("refund_summary")
+    private final RefundSummary refundSummary;
+
+    @JsonProperty("settlement_summary")
+    private final PaymentSettlementSummary settlementSummary;
+
+    @JsonProperty("card_details")
+    private final CardDetails cardDetails;
+
+    @JsonSerialize(using = ToStringSerializer.class)
+    private final SupportedLanguage language;
+
+    @JsonProperty("delayed_capture")
+    private final boolean delayedCapture;
+
+    @JsonProperty("moto")
+    private final boolean moto;
+
+    @JsonProperty("corporate_card_surcharge")
+    private final Long corporateCardSurcharge;
+
+    @JsonProperty("total_amount")
+    private final Long totalAmount;
+
+    @JsonProperty("fee")
+    private final Long fee;
+
+    @JsonProperty("net_amount")
+    private final Long netAmount;
+
+    @JsonProperty("provider_id")
+    private final String providerId;
+
+    @JsonSerialize(using = ExternalMetadataSerialiser.class)
+    private final ExternalMetadata metadata;
+
+    @JsonProperty("return_url")
+    protected String returnUrl;
+
+    protected String email;
+
+    protected PaymentState state;
+
+    //Used by Swagger to document the right model in the PaymentsResource
+    @JsonIgnore
+    protected String paymentType;
+
+    @JsonProperty("authorisation_summary")
+    private AuthorisationSummary authorisationSummary;
+
+
+    public CardPayment(String chargeId, long amount, PaymentState state, String returnUrl, String description,
+                       String reference, String email, String paymentProvider, String createdDate,
+                       RefundSummary refundSummary, PaymentSettlementSummary settlementSummary, CardDetails cardDetails,
+                       SupportedLanguage language, boolean delayedCapture, boolean moto, Long corporateCardSurcharge, Long totalAmount,
+                       String providerId, ExternalMetadata metadata, Long fee, Long netAmount, AuthorisationSummary authorisationSummary) {
+        super(chargeId, amount, description, reference, paymentProvider, createdDate);
+        this.state = state;
+        this.refundSummary = refundSummary;
+        this.settlementSummary = settlementSummary;
+        this.cardDetails = cardDetails;
+        this.providerId = providerId;
+        this.metadata = metadata;
+        this.paymentType = CARD.getFriendlyName();
+        this.language = language;
+        this.delayedCapture = delayedCapture;
+        this.moto = moto;
+        this.corporateCardSurcharge = corporateCardSurcharge;
+        this.totalAmount = totalAmount;
+        this.fee = fee;
+        this.netAmount = netAmount;
+        this.email = email;
+        this.returnUrl = returnUrl;
+        this.authorisationSummary = authorisationSummary;
+    }
+
+    /**
+     * card brand is no longer a top level charge property. It is now at `card_details.card_brand` attribute
+     * We still need to support `v1` clients with a top level card brand attribute to keep support their integrations.
+     *
+     * @return
+     */
+
+    @JsonProperty("card_brand")
+    @Deprecated
+    public String getCardBrand() {
+        return cardDetails != null ? cardDetails.getCardBrand() : null;
+    }
+
+    public ExternalMetadata getMetadata() {
+        return metadata;
+    }
+
+    public Optional<RefundSummary> getRefundSummary() {
+        return Optional.ofNullable(refundSummary);
+    }
+
+    public Optional<PaymentSettlementSummary> getSettlementSummary() {
+        return Optional.ofNullable(settlementSummary);
+    }
+
+    public Optional<CardDetails> getCardDetails() {
+        return Optional.ofNullable(cardDetails);
+    }
+
+    public SupportedLanguage getLanguage() {
+        return language;
+    }
+
+    public boolean getDelayedCapture() {
+        return delayedCapture;
+    }
+
+    public boolean getMoto() { return moto; }
+
+    public Optional<Long> getCorporateCardSurcharge() {
+        return Optional.ofNullable(corporateCardSurcharge);
+    }
+
+    public Optional<Long> getFee() {
+        return Optional.ofNullable(fee);
+    }
+
+    public Optional<Long> getNetAmount() {
+        return Optional.ofNullable(netAmount);
+    }
+
+    public Optional<Long> getTotalAmount() {
+        return Optional.ofNullable(totalAmount);
+    }
+
+    public String getProviderId() {
+        return providerId;
+    }
+
+    public Optional<String> getReturnUrl() {
+        return Optional.ofNullable(returnUrl);
+    }
+
+    public Optional<String> getEmail() {
+        return Optional.ofNullable(email);
+    }
+
+    public PaymentState getState() {
+        return state;
+    }
+
+    public AuthorisationSummary getAuthorisationSummary() {
+        return authorisationSummary;
+    }
+
+    @Override
+    public String toString() {
+        // Don't include:
+        // description - some services include PII
+        // reference - can come from user input for payment links, in the past they have mistakenly entered card numbers
+        return "Card Payment{" +
+                "paymentId='" + super.paymentId + '\'' +
+                ", paymentProvider='" + paymentProvider + '\'' +
+                ", cardBrandLabel='" + getCardBrand() + '\'' +
+                ", amount=" + amount +
+                ", fee=" + fee +
+                ", netAmount=" + netAmount +
+                ", corporateCardSurcharge='" + corporateCardSurcharge + '\'' +
+                ", state='" + state + '\'' +
+                ", returnUrl='" + returnUrl + '\'' +
+                ", language='" + language.toString() + '\'' +
+                ", delayedCapture=" + delayedCapture +
+                ", moto=" + moto +
+                ", createdDate='" + createdDate + '\'' +
+                '}';
+    }
+}

--- a/src/main/java/uk/gov/pay/webhooks/publicapi/model/ExternalChargeState.java
+++ b/src/main/java/uk/gov/pay/webhooks/publicapi/model/ExternalChargeState.java
@@ -1,0 +1,57 @@
+package uk.gov.pay.webhooks.publicapi.model;
+
+import static java.util.Arrays.stream;
+
+// Based on Connector enum: https://github.com/alphagov/pay-connector/blob/master/src/main/java/uk/gov/pay/connector/common/model/api/ExternalChargeState.java 
+public enum ExternalChargeState {
+    EXTERNAL_CREATED("created", false),
+    EXTERNAL_STARTED("started", false),
+    EXTERNAL_SUBMITTED("submitted", false),
+    EXTERNAL_CAPTURABLE("capturable", false),
+    EXTERNAL_SUCCESS("success", true),
+    EXTERNAL_FAILED_REJECTED( "declined", true, "P0010", "Payment method rejected"),
+    EXTERNAL_FAILED_EXPIRED("timedout", true, "P0020", "Payment expired"),
+    EXTERNAL_FAILED_CANCELLED( "cancelled", true, "P0030", "Payment was cancelled by the user"),
+    EXTERNAL_CANCELLED("cancelled", true, "P0040", "Payment was cancelled by the service"),
+    EXTERNAL_ERROR_GATEWAY("error", true, "P0050", "Payment provider returned an error");
+
+    private final String status;
+    private final boolean finished;
+    private final String code;
+    private final String message;
+
+    ExternalChargeState(String status, boolean finished) {
+        this.status = status;
+        this.finished = finished;
+        this.code = null;
+        this.message = null;
+    }
+
+    ExternalChargeState(String status, boolean finished, String code, String message) {
+        this.status = status;
+        this.finished = finished;
+        this.code = code;
+        this.message = message;
+    }
+    
+
+    public String getStatus() {
+        return status;
+    }
+
+    public boolean isFinished() {
+        return finished;
+    }
+
+    public String getCode() {
+        return code;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public static ExternalChargeState fromStatusString(String status) {
+        return stream(values()).filter(v -> v.getStatus().equals(status)).findFirst().orElseThrow(() -> new IllegalArgumentException("External charge state not recognized: " + status));
+    }
+}

--- a/src/main/java/uk/gov/pay/webhooks/publicapi/model/Payment.java
+++ b/src/main/java/uk/gov/pay/webhooks/publicapi/model/Payment.java
@@ -1,0 +1,66 @@
+package uk.gov.pay.webhooks.publicapi.model;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@JsonInclude(value = JsonInclude.Include.NON_EMPTY)
+
+public abstract class Payment {
+    public static final String LINKS_JSON_ATTRIBUTE = "_links";
+
+    @JsonProperty("payment_id")
+    protected String paymentId;
+
+    @JsonProperty("payment_provider")
+    protected String paymentProvider;
+
+    protected long amount;
+    protected String description;
+    protected String reference;
+
+
+    @JsonProperty("created_date")
+    protected String createdDate;
+
+    protected Payment() {
+        //To enable Jackson serialisation we need a default constructor
+    }
+
+    public Payment(String chargeId,
+                   long amount,
+                   String description,
+                   String reference,
+                   String paymentProvider,
+                   String createdDate) {
+        this.paymentId = chargeId;
+        this.amount = amount;
+        this.description = description;
+        this.reference = reference;
+        this.paymentProvider = paymentProvider;
+        this.createdDate = createdDate;
+    }
+    
+    public String getCreatedDate() {
+        return createdDate;
+    }
+    
+    public String getPaymentId() {
+        return paymentId;
+    }
+    
+    public long getAmount() {
+        return amount;
+    }
+    
+    public String getDescription() {
+        return description;
+    }
+    
+    public String getReference() {
+        return reference;
+    }
+    
+    public String getPaymentProvider() {
+        return paymentProvider;
+    }
+}

--- a/src/main/java/uk/gov/pay/webhooks/publicapi/model/PaymentForSearchResult.java
+++ b/src/main/java/uk/gov/pay/webhooks/publicapi/model/PaymentForSearchResult.java
@@ -1,0 +1,53 @@
+package uk.gov.pay.webhooks.publicapi.model;
+
+import uk.gov.service.payments.commons.model.SupportedLanguage;
+import uk.gov.service.payments.commons.model.charge.ExternalMetadata;
+
+
+public class PaymentForSearchResult extends CardPayment {
+
+
+
+    public PaymentForSearchResult(String chargeId, long amount, PaymentState state, String returnUrl, String description,
+                                  String reference, String email, String paymentProvider, String createdDate, SupportedLanguage language,
+                                  boolean delayedCapture, boolean moto, RefundSummary refundSummary, PaymentSettlementSummary settlementSummary, CardDetails cardDetails,
+                                  Long corporateCardSurcharge, Long totalAmount, String providerId, ExternalMetadata externalMetadata,
+                                  Long fee, Long netAmount, AuthorisationSummary authorisationSummary) {
+
+        super(chargeId, amount, state, returnUrl, description, reference, email, paymentProvider,
+                createdDate, refundSummary, settlementSummary, cardDetails, language, delayedCapture, moto, corporateCardSurcharge, totalAmount, providerId, externalMetadata,
+                fee, netAmount, authorisationSummary);
+        
+    }
+
+    public static PaymentForSearchResult valueOf(
+            TransactionResponse paymentResult) {
+
+        return new PaymentForSearchResult(
+                paymentResult.getTransactionId(),
+                paymentResult.getAmount(),
+                paymentResult.getState(),
+                paymentResult.getReturnUrl(),
+                paymentResult.getDescription(),
+                paymentResult.getReference(),
+                paymentResult.getEmail(),
+                paymentResult.getPaymentProvider(),
+                paymentResult.getCreatedDate(),
+                paymentResult.getLanguage(),
+                paymentResult.getDelayedCapture(),
+                paymentResult.isMoto(),
+                paymentResult.getRefundSummary(),
+                paymentResult.getSettlementSummary(),
+                paymentResult.getCardDetails(),
+                paymentResult.getCorporateCardSurcharge(),
+                paymentResult.getTotalAmount(),
+                paymentResult.getGatewayTransactionId(),
+                paymentResult.getMetadata().orElse(null),
+                paymentResult.getFee(),
+                paymentResult.getNetAmount(),
+                paymentResult.getAuthorisationSummary());
+    }
+    
+}
+
+

--- a/src/main/java/uk/gov/pay/webhooks/publicapi/model/PaymentSettlementSummary.java
+++ b/src/main/java/uk/gov/pay/webhooks/publicapi/model/PaymentSettlementSummary.java
@@ -1,0 +1,39 @@
+package uk.gov.pay.webhooks.publicapi.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@JsonInclude(value = JsonInclude.Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class PaymentSettlementSummary {
+
+    @JsonProperty("capture_submit_time")
+    private String captureSubmitTime;
+
+    @JsonProperty("captured_date")
+    private String capturedDate;
+
+    @JsonProperty("settled_date")
+    private String settledDate;
+
+    public PaymentSettlementSummary() {}
+
+    public PaymentSettlementSummary(String captureSubmitTime, String capturedDate, String settledDate) {
+        this.captureSubmitTime = captureSubmitTime;
+        this.capturedDate = capturedDate;
+        this.settledDate = settledDate;
+    }
+    
+    public String getCaptureSubmitTime() {
+        return captureSubmitTime;
+    }
+
+    public String getCapturedDate() {
+        return capturedDate;
+    }
+
+    public String getSettledDate() {
+        return settledDate;
+    }
+}

--- a/src/main/java/uk/gov/pay/webhooks/publicapi/model/PaymentSettlementSummary.java
+++ b/src/main/java/uk/gov/pay/webhooks/publicapi/model/PaymentSettlementSummary.java
@@ -16,8 +16,7 @@ public class PaymentSettlementSummary {
 
     @JsonProperty("settled_date")
     private String settledDate;
-
-    public PaymentSettlementSummary() {}
+    
 
     public PaymentSettlementSummary(String captureSubmitTime, String capturedDate, String settledDate) {
         this.captureSubmitTime = captureSubmitTime;

--- a/src/main/java/uk/gov/pay/webhooks/publicapi/model/PaymentState.java
+++ b/src/main/java/uk/gov/pay/webhooks/publicapi/model/PaymentState.java
@@ -1,10 +1,12 @@
 package uk.gov.pay.webhooks.publicapi.model;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.JsonNode;
 
 import java.util.Objects;
 
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class PaymentState {
     @JsonProperty("status")
     private String status;

--- a/src/main/java/uk/gov/pay/webhooks/publicapi/model/PaymentState.java
+++ b/src/main/java/uk/gov/pay/webhooks/publicapi/model/PaymentState.java
@@ -1,0 +1,86 @@
+package uk.gov.pay.webhooks.publicapi.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.JsonNode;
+
+import java.util.Objects;
+
+public class PaymentState {
+    @JsonProperty("status")
+    private String status;
+
+    @JsonProperty("finished")
+    private boolean finished;
+
+    @JsonProperty("message")
+    private String message;
+
+    @JsonProperty("code")
+    private String code;
+
+
+    public static PaymentState createPaymentState(JsonNode node) {
+        return new PaymentState(
+                node.get("status").asText(),
+                node.get("finished").asBoolean(),
+                node.has("message") ? node.get("message").asText() : null,
+                node.has("code") ? node.get("code").asText() : null
+        );
+    }
+
+    public PaymentState() {
+    }
+
+    public PaymentState(String status, boolean finished) {
+        this(status, finished, null, null);
+    }
+
+    public PaymentState(String status, boolean finished, String message, String code) {
+        this.status = status;
+        this.finished = finished;
+        this.message = message;
+        this.code = code;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    public boolean isFinished() {
+        return finished;
+    }
+    
+    public String getMessage() {
+        return message;
+    }
+    
+    public String getCode() {
+        return code;
+    }
+
+    @Override
+    public String toString() {
+        return "PaymentState{" +
+                "status='" + status + '\'' +
+                ", finished='" + finished + '\'' +
+                ", message=" + message +
+                ", code=" + code +
+                '}';
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        PaymentState that = (PaymentState) o;
+        return finished == that.finished &&
+                Objects.equals(status, that.status) &&
+                Objects.equals(message, that.message) &&
+                Objects.equals(code, that.code);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(status, finished, message, code);
+    }
+}

--- a/src/main/java/uk/gov/pay/webhooks/publicapi/model/PaymentState.java
+++ b/src/main/java/uk/gov/pay/webhooks/publicapi/model/PaymentState.java
@@ -27,9 +27,7 @@ public class PaymentState {
                 node.has("code") ? node.get("code").asText() : null
         );
     }
-
-    public PaymentState() {
-    }
+    
 
     public PaymentState(String status, boolean finished) {
         this(status, finished, null, null);

--- a/src/main/java/uk/gov/pay/webhooks/publicapi/model/RefundSummary.java
+++ b/src/main/java/uk/gov/pay/webhooks/publicapi/model/RefundSummary.java
@@ -1,0 +1,36 @@
+package uk.gov.pay.webhooks.publicapi.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class RefundSummary {
+
+    private String status;
+
+    @JsonProperty("amount_available")
+    private long amountAvailable;
+
+    @JsonProperty("amount_submitted")
+    private long amountSubmitted;
+
+    public RefundSummary() {}
+
+    public RefundSummary(String status, long amountAvailable, long amountSubmitted) {
+        this.status = status;
+        this.amountAvailable = amountAvailable;
+        this.amountSubmitted = amountSubmitted;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    public long getAmountAvailable() {
+        return amountAvailable;
+    }
+
+    public long getAmountSubmitted() {
+        return amountSubmitted;
+    }
+}

--- a/src/main/java/uk/gov/pay/webhooks/publicapi/model/ThreeDSecure.java
+++ b/src/main/java/uk/gov/pay/webhooks/publicapi/model/ThreeDSecure.java
@@ -1,0 +1,23 @@
+package uk.gov.pay.webhooks.publicapi.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class ThreeDSecure {
+
+    @JsonProperty("required")
+    private boolean required;
+
+    public ThreeDSecure() {
+    }
+
+    public ThreeDSecure(boolean required) {
+        this.required = required;
+    }
+
+    public boolean isRequired() {
+        return required;
+    }
+
+}

--- a/src/main/java/uk/gov/pay/webhooks/publicapi/model/TransactionResponse.java
+++ b/src/main/java/uk/gov/pay/webhooks/publicapi/model/TransactionResponse.java
@@ -1,0 +1,178 @@
+package uk.gov.pay.webhooks.publicapi.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import uk.gov.pay.webhooks.util.CustomSupportedLanguageDeserializer;
+import uk.gov.service.payments.commons.api.json.ExternalMetadataDeserialiser;
+import uk.gov.service.payments.commons.model.SupportedLanguage;
+import uk.gov.service.payments.commons.model.charge.ExternalMetadata;
+
+import java.util.Optional;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class TransactionResponse {
+
+    @JsonProperty("transaction_id")
+    private String transactionId;
+
+    @JsonProperty("return_url")
+    private String returnUrl;
+
+    @JsonProperty("payment_provider")
+    private String paymentProvider;
+    
+
+    @JsonProperty(value = "refund_summary")
+    private RefundSummary refundSummary;
+
+    @JsonProperty(value = "settlement_summary")
+    private PaymentSettlementSummary settlementSummary;
+
+    @JsonProperty(value = "card_details")
+    private CardDetails cardDetails;
+
+    private Long amount;
+
+    private PaymentState state;
+
+    private String description;
+
+    private String reference;
+
+    private String email;
+
+    @JsonDeserialize(using = CustomSupportedLanguageDeserializer.class)
+    private SupportedLanguage language;
+
+    @JsonProperty(value = "delayed_capture")
+    private boolean delayedCapture;
+
+    private boolean moto;
+
+    @JsonProperty("corporate_card_surcharge")
+    private Long corporateCardSurcharge;
+
+    @JsonProperty("total_amount")
+    private Long totalAmount;
+
+    @JsonProperty("fee")
+    private Long fee;
+
+    @JsonProperty("net_amount")
+    private Long netAmount;
+
+    @JsonProperty(value = "created_date")
+    private String createdDate;
+
+    @JsonProperty(value = "gateway_transaction_id")
+    private String gatewayTransactionId;
+
+    @JsonDeserialize(using = ExternalMetadataDeserialiser.class)
+    private ExternalMetadata metadata;
+
+    @JsonProperty("authorisation_summary")
+    private AuthorisationSummary authorisationSummary;
+
+    public Optional<ExternalMetadata> getMetadata() {
+        return Optional.ofNullable(metadata);
+    }
+
+    public Long getAmount() {
+        return amount;
+    }
+
+    public PaymentState getState() {
+        return state;
+    }
+
+    public String getReturnUrl() {
+        return returnUrl;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public String getReference() {
+        return reference;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public SupportedLanguage getLanguage() {
+        return language;
+    }
+
+    public boolean getDelayedCapture() {
+        return delayedCapture;
+    }
+
+    public boolean isMoto() {
+        return moto;
+    }
+
+    public Long getCorporateCardSurcharge() {
+        return corporateCardSurcharge;
+    }
+
+    public Long getTotalAmount() {
+        return totalAmount;
+    }
+
+    public Long getFee() {
+        return fee;
+    }
+
+    public Long getNetAmount() {
+        return netAmount;
+    }
+
+    public String getPaymentProvider() {
+        return paymentProvider;
+    }
+
+    /**
+     * card brand is no longer a top level charge property. It is now at `card_details.card_brand` attribute
+     * We still need to support `v1` clients with a top level card brand attribute to keep support their integrations.
+     *
+     * @return
+     */
+    @JsonProperty("card_brand")
+    public String getCardBrand() {
+        return cardDetails != null ? cardDetails.getCardBrand() : "";
+    }
+
+    public String getCreatedDate() {
+        return createdDate;
+    }
+    
+
+    public RefundSummary getRefundSummary() {
+        return refundSummary;
+    }
+
+    public PaymentSettlementSummary getSettlementSummary() {
+        return settlementSummary;
+    }
+
+    public CardDetails getCardDetails() {
+        return cardDetails;
+    }
+
+    public String getGatewayTransactionId() {
+        return gatewayTransactionId;
+    }
+
+    public String getTransactionId() {
+        return transactionId;
+    }
+
+    public AuthorisationSummary getAuthorisationSummary() {
+        return authorisationSummary;
+    }
+}

--- a/src/main/java/uk/gov/pay/webhooks/util/CustomSupportedLanguageDeserializer.java
+++ b/src/main/java/uk/gov/pay/webhooks/util/CustomSupportedLanguageDeserializer.java
@@ -1,0 +1,24 @@
+package uk.gov.pay.webhooks.util;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+import uk.gov.service.payments.commons.model.SupportedLanguage;
+
+import java.io.IOException;
+
+public class CustomSupportedLanguageDeserializer extends StdDeserializer<SupportedLanguage> {
+
+    public CustomSupportedLanguageDeserializer() {
+        this(null);
+    }
+
+    public CustomSupportedLanguageDeserializer(Class<?> vc) {
+        super(vc);
+    }
+
+    @Override
+    public SupportedLanguage deserialize(JsonParser jsonparser, DeserializationContext context) throws IOException {
+        return SupportedLanguage.fromIso639AlphaTwoCode(jsonparser.getText());
+    }
+}

--- a/src/test/java/uk/gov/pay/webhooks/message/WebhookMessageServiceTest.java
+++ b/src/test/java/uk/gov/pay/webhooks/message/WebhookMessageServiceTest.java
@@ -1,0 +1,109 @@
+package uk.gov.pay.webhooks.message;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
+import org.junit.jupiter.api.Test;
+import uk.gov.pay.webhooks.ledger.model.LedgerTransaction;
+import uk.gov.pay.webhooks.publicapi.model.PaymentForSearchResult;
+
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class WebhookMessageServiceTest {
+
+    @Test
+    void paymentForSearchResultFromSerialisesWebhookMessage() throws JsonProcessingException {
+        
+        var ledgerTransactionJson = """
+                            {
+                                 	"amount": 1000,
+                                 	"state": {
+                                 		"finished": false,
+                                 		"status": "created"
+                                 	},
+                                 	"description": "Test description",
+                                 	"reference": "aReference",
+                                 	"language": "en",
+                                 	"transaction_id": "3rke415aam1pl1u3hvaljbcll3",
+                                 	"return_url": "https://example.org",
+                                 	"email": "someone@example.org",
+                                 	"payment_provider": "sandbox",
+                                 	"created_date": "2018-09-22T10:13:16.067Z",
+                                 	"card_details": {
+                                 		"card_type": "debit",
+                                 		"card_brand": "Visa",
+                                 		"expiry_date": "10/24",
+                                 		"cardholder_name": "j.doe@example.org",
+                                 		"last_digits_card_number": "1234",
+                                 		"first_digits_card_number": "123456",
+                                 		"billing_address": {
+                                 			"line1": "line1",
+                                 			"line2": "line2",
+                                 			"postcode": "AB1 2CD",
+                                 			"city": "London",
+                                 			"country": "GB"
+                                 		}
+                                 	},
+                                 	"delayed_capture": false,
+                                 	"moto": false,
+                                 	"authorisation_summary": {
+                                 		"three_d_secure": {
+                                 			"required": true,
+                                 			"version": "2.1.0"
+                                 		}
+                                 	}
+                                 }
+                """;
+        
+        var expectedJson = """
+                {
+                	"amount": 1000,
+                	"description": "Test description",
+                	"reference": "aReference",
+                	"language": "en",
+                	"email": "someone@example.org",
+                	"state": {
+                		"status": "created",
+                		"finished": true,
+                		"message": null,
+                		"code": null
+                	},
+                	"payment_id": "3rke415aam1pl1u3hvaljbcll3",
+                	"payment_provider": "sandbox",
+                	"created_date": "2018-09-22T10:13:16.067Z",
+                	"card_details": {
+                		"last_digits_card_number": "1234",
+                		"first_digits_card_number": "123456",
+                		"cardholder_name": "j.doe@example.org",
+                		"expiry_date": "10/24",
+                		"billing_address": {
+                			"line1": "line1",
+                			"line2": "line2",
+                			"postcode": "AB1 2CD",
+                			"city": "London",
+                			"country": "GB"
+                		},
+                		"card_brand": "Visa",
+                		"card_type": "debit"
+                	},
+                	"delayed_capture": false,
+                	"moto": false,
+                	"provider_id": "sandbox",
+                	"return_url": "https://example.org",
+                	"authorisation_summary": {
+                		"three_d_secure": {
+                			"required": true
+                		}
+                	},
+                	"card_brand": "Visa"
+                }
+                """;
+
+        var objectMapper = new ObjectMapper().registerModule(new Jdk8Module());
+        LedgerTransaction ledgerTransaction = objectMapper.readValue(ledgerTransactionJson, LedgerTransaction.class);
+        PaymentForSearchResult transformed = WebhookMessageService.paymentForSearchResultFrom(ledgerTransaction);
+        assertEquals(objectMapper.readTree(expectedJson).toString(), objectMapper.valueToTree(transformed).toString());
+    
+    }
+}

--- a/src/test/java/uk/gov/pay/webhooks/message/WebhookMessageServiceTest.java
+++ b/src/test/java/uk/gov/pay/webhooks/message/WebhookMessageServiceTest.java
@@ -65,9 +65,7 @@ class WebhookMessageServiceTest {
                 	"email": "someone@example.org",
                 	"state": {
                 		"status": "created",
-                		"finished": true,
-                		"message": null,
-                		"code": null
+                		"finished": false
                 	},
                 	"payment_id": "3rke415aam1pl1u3hvaljbcll3",
                 	"payment_provider": "sandbox",
@@ -106,4 +104,64 @@ class WebhookMessageServiceTest {
         assertEquals(objectMapper.readTree(expectedJson).toString(), objectMapper.valueToTree(transformed).toString());
     
     }
+    
+    @Test
+    void getsErrorCodeFromStatus() throws JsonProcessingException {
+        var ledgerTransactionJson = """
+                            {
+                                 	"amount": 1000,
+                                 	"state": {
+                                 		"finished": true,
+                                 		"status": "error"
+                                 	},
+                                 	"description": "Test description",
+                                 	"reference": "aReference",
+                                 	"language": "en",
+                                 	"transaction_id": "3rke415aam1pl1u3hvaljbcll3",
+                                 	"return_url": "https://example.org",
+                                 	"email": "someone@example.org",
+                                 	"payment_provider": "sandbox",
+                                 	"created_date": "2018-09-22T10:13:16.067Z",
+                                 	"card_details": {
+                                 		"card_type": "debit",
+                                 		"card_brand": "Visa",
+                                 		"expiry_date": "10/24",
+                                 		"cardholder_name": "j.doe@example.org",
+                                 		"last_digits_card_number": "1234",
+                                 		"first_digits_card_number": "123456",
+                                 		"billing_address": {
+                                 			"line1": "line1",
+                                 			"line2": "line2",
+                                 			"postcode": "AB1 2CD",
+                                 			"city": "London",
+                                 			"country": "GB"
+                                 		}
+                                 	},
+                                 	"delayed_capture": false,
+                                 	"moto": false,
+                                 	"authorisation_summary": {
+                                 		"three_d_secure": {
+                                 			"required": true,
+                                 			"version": "2.1.0"
+                                 		}
+                                 	}
+                                 }
+                """;
+
+        var expectedState = """ 
+                        {
+                        "status": "error",
+                        "finished": true,
+                        "message": "Payment provider returned an error",
+                        "code": "P0050"
+                         }
+                """;
+
+        var objectMapper = new ObjectMapper().registerModule(new Jdk8Module());
+        LedgerTransaction ledgerTransaction = objectMapper.readValue(ledgerTransactionJson, LedgerTransaction.class);
+        PaymentForSearchResult transformed = WebhookMessageService.paymentForSearchResultFrom(ledgerTransaction);
+        assertEquals(objectMapper.readTree(expectedState), objectMapper.valueToTree(transformed).get("state"));
+    }
+    
+    
 }

--- a/src/test/java/uk/gov/pay/webhooks/publicapi/model/APICardPaymentV1Test.java
+++ b/src/test/java/uk/gov/pay/webhooks/publicapi/model/APICardPaymentV1Test.java
@@ -1,20 +1,19 @@
-package uk.gov.pay.webhooks.message;
+package uk.gov.pay.webhooks.publicapi.model;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import org.junit.jupiter.api.Test;
 import uk.gov.pay.webhooks.ledger.model.LedgerTransaction;
-import uk.gov.pay.webhooks.publicapi.model.PaymentForSearchResult;
-
 
 import static org.junit.jupiter.api.Assertions.*;
 
-class WebhookMessageServiceTest {
+class APICardPaymentV1Test {
+    private final ObjectMapper objectMapper = new ObjectMapper().registerModule(new Jdk8Module());
 
     @Test
     void paymentForSearchResultFromSerialisesWebhookMessage() throws JsonProcessingException {
-        
+
         var ledgerTransactionJson = """
                             {
                                  	"amount": 1000,
@@ -55,7 +54,7 @@ class WebhookMessageServiceTest {
                                  	}
                                  }
                 """;
-        
+
         var expectedJson = """
                 {
                 	"amount": 1000,
@@ -98,13 +97,12 @@ class WebhookMessageServiceTest {
                 }
                 """;
 
-        var objectMapper = new ObjectMapper().registerModule(new Jdk8Module());
         LedgerTransaction ledgerTransaction = objectMapper.readValue(ledgerTransactionJson, LedgerTransaction.class);
-        PaymentForSearchResult transformed = WebhookMessageService.paymentForSearchResultFrom(ledgerTransaction);
+        PaymentForSearchResult transformed = APICardPaymentV1.paymentForSearchResultFrom(ledgerTransaction);
         assertEquals(objectMapper.readTree(expectedJson).toString(), objectMapper.valueToTree(transformed).toString());
-    
+
     }
-    
+
     @Test
     void getsErrorCodeFromStatus() throws JsonProcessingException {
         var ledgerTransactionJson = """
@@ -157,11 +155,8 @@ class WebhookMessageServiceTest {
                          }
                 """;
 
-        var objectMapper = new ObjectMapper().registerModule(new Jdk8Module());
         LedgerTransaction ledgerTransaction = objectMapper.readValue(ledgerTransactionJson, LedgerTransaction.class);
-        PaymentForSearchResult transformed = WebhookMessageService.paymentForSearchResultFrom(ledgerTransaction);
+        PaymentForSearchResult transformed = APICardPaymentV1.paymentForSearchResultFrom(ledgerTransaction);
         assertEquals(objectMapper.readTree(expectedState), objectMapper.valueToTree(transformed).get("state"));
     }
-    
-    
 }


### PR DESCRIPTION
Transforms ledger transaction to Public API representation of a payment (excluding the `_links` block)

Models are copy-pasted from Public API (and Connector for Payment State enum)

N.B. This leaves a TODO for Refunds which is assumed will require a separate transformation.