### PR TITLE
PP-9107 Fix workflow permissions

### DIFF
--- a/.github/workflows/push-to-main.yml
+++ b/.github/workflows/push-to-main.yml
@@ -36,8 +36,9 @@ jobs:
           retention-days: 5
   tag-release:
     needs: test
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
-    environment: test
     steps:
       - name: Git checkout
         uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f


### PR DESCRIPTION
Need `contents: write` to write the tag. Have restricted this to the one job that needs it, which is run after merge.