### PR TITLE
PP-9202 Improve how we model timestamps

### DIFF
--- a/src/main/java/uk/gov/pay/webhooks/deliveryqueue/dao/WebhookDeliveryQueueDao.java
+++ b/src/main/java/uk/gov/pay/webhooks/deliveryqueue/dao/WebhookDeliveryQueueDao.java
@@ -7,8 +7,10 @@ import uk.gov.pay.webhooks.message.dao.entity.WebhookMessageEntity;
 
 import javax.inject.Inject;
 import javax.persistence.LockModeType;
+import java.time.Instant;
 import java.time.InstantSource;
-import java.util.Date;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 import java.util.List;
 import java.util.Optional;
 
@@ -21,9 +23,9 @@ public class WebhookDeliveryQueueDao extends AbstractDAO<WebhookDeliveryQueueEnt
         this.instantSource = instantSource;
     }
 
-    public Optional<WebhookDeliveryQueueEntity> nextToSend(Date sendAt) {
+    public Optional<WebhookDeliveryQueueEntity> nextToSend(Instant sendAt) {
         return namedTypedQuery(WebhookDeliveryQueueEntity.NEXT_TO_SEND)
-                .setParameter("send_at", sendAt)
+                .setParameter("send_at", OffsetDateTime.ofInstant(sendAt, ZoneOffset.UTC))
                 .setMaxResults(1)
                 .setLockMode(LockModeType.PESSIMISTIC_WRITE)
                 .setHint(
@@ -35,7 +37,7 @@ public class WebhookDeliveryQueueDao extends AbstractDAO<WebhookDeliveryQueueEnt
                 .findAny();
     }
 
-    public WebhookDeliveryQueueEntity enqueueFrom(WebhookMessageEntity webhookMessageEntity, WebhookDeliveryQueueEntity.DeliveryStatus deliveryStatus, Date sendAt) {
+    public WebhookDeliveryQueueEntity enqueueFrom(WebhookMessageEntity webhookMessageEntity, WebhookDeliveryQueueEntity.DeliveryStatus deliveryStatus, Instant sendAt) {
        return persist(WebhookDeliveryQueueEntity.enqueueFrom(
                 webhookMessageEntity,
                 instantSource.instant(),

--- a/src/main/java/uk/gov/pay/webhooks/deliveryqueue/dao/WebhookDeliveryQueueEntity.java
+++ b/src/main/java/uk/gov/pay/webhooks/deliveryqueue/dao/WebhookDeliveryQueueEntity.java
@@ -5,17 +5,18 @@ import uk.gov.pay.webhooks.message.dao.entity.WebhookMessageEntity;
 
 import javax.persistence.Column;
 import javax.persistence.Entity;
+import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
-import javax.persistence.OneToOne;
 import javax.persistence.NamedQuery;
+import javax.persistence.OneToOne;
 import javax.persistence.SequenceGenerator;
 import javax.persistence.Table;
-import javax.persistence.FetchType;
 import java.time.Instant;
-import java.util.Date;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 import java.util.Optional;
 
 @NamedQuery(
@@ -50,24 +51,24 @@ public class WebhookDeliveryQueueEntity {
     private Long id;
 
     @Column(name = "created_date")
-    private Date createdDate;
+    private OffsetDateTime createdDate;
 
     public WebhookDeliveryQueueEntity() {
     }
 
-    public Date getSendAt() {
-        return sendAt;
+    public Instant getSendAt() {
+        return sendAt.toInstant();
     }
 
-    public void setSendAt(Date sendAt) {
-        this.sendAt = sendAt;
+    public void setSendAt(Instant sendAt) {
+        this.sendAt = OffsetDateTime.ofInstant(sendAt, ZoneOffset.UTC);
     }
 
     @Column(name = "send_at")
-    private Date sendAt;
+    private OffsetDateTime sendAt;
 
-    public Date getCreatedDate() {
-        return createdDate;
+    public Instant getCreatedDate() {
+        return createdDate.toInstant();
     }
 
     public enum DeliveryStatus {
@@ -122,13 +123,13 @@ public class WebhookDeliveryQueueEntity {
 
 
 
-    public void setCreatedDate(Date createdDate) {
-        this.createdDate = createdDate;
+    public void setCreatedDate(Instant createdDate) {
+        this.createdDate = OffsetDateTime.ofInstant(createdDate, ZoneOffset.UTC);
     }
 
-    public static WebhookDeliveryQueueEntity enqueueFrom(WebhookMessageEntity webhookMessageEntity, Instant createdInstant, DeliveryStatus deliveryStatus, Date sendAt) {
+    public static WebhookDeliveryQueueEntity enqueueFrom(WebhookMessageEntity webhookMessageEntity, Instant createdInstant, DeliveryStatus deliveryStatus, Instant sendAt) {
         var entity = new WebhookDeliveryQueueEntity();
-        entity.setCreatedDate(Date.from(createdInstant));
+        entity.setCreatedDate(createdInstant);
         entity.setWebhookMessageEntity(webhookMessageEntity);
         entity.setDeliveryStatus(deliveryStatus);
         entity.setSendAt(sendAt);

--- a/src/main/java/uk/gov/pay/webhooks/deliveryqueue/managed/SendAttempter.java
+++ b/src/main/java/uk/gov/pay/webhooks/deliveryqueue/managed/SendAttempter.java
@@ -1,6 +1,5 @@
 package uk.gov.pay.webhooks.deliveryqueue.managed;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.pay.webhooks.deliveryqueue.dao.WebhookDeliveryQueueDao;
@@ -15,7 +14,6 @@ import java.security.InvalidKeyException;
 import java.time.Duration;
 import java.time.InstantSource;
 import java.time.temporal.ChronoUnit;
-import java.util.Date;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -69,7 +67,7 @@ public class SendAttempter {
 
     private void enqueueRetry(WebhookDeliveryQueueEntity queueItem, Duration nextRetryIn) {
         Optional.ofNullable(nextRetryIn).ifPresent(
-                retryDelay -> webhookDeliveryQueueDao.enqueueFrom(queueItem.getWebhookMessageEntity(), WebhookDeliveryQueueEntity.DeliveryStatus.PENDING, Date.from(instantSource.instant().plus(retryDelay)))
+                retryDelay -> webhookDeliveryQueueDao.enqueueFrom(queueItem.getWebhookMessageEntity(), WebhookDeliveryQueueEntity.DeliveryStatus.PENDING, instantSource.instant().plus(retryDelay))
         );
     }
 

--- a/src/main/java/uk/gov/pay/webhooks/deliveryqueue/managed/WebhookMessageSendingQueueProcessor.java
+++ b/src/main/java/uk/gov/pay/webhooks/deliveryqueue/managed/WebhookMessageSendingQueueProcessor.java
@@ -14,7 +14,6 @@ import uk.gov.pay.webhooks.message.WebhookMessageSender;
 
 import javax.inject.Inject;
 import java.time.InstantSource;
-import java.util.Date;
 import java.util.Optional;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -73,7 +72,7 @@ public class WebhookMessageSendingQueueProcessor implements Managed {
         ManagedSessionContext.bind(session);
         Transaction transaction = session.beginTransaction();
         try {
-            Optional<WebhookDeliveryQueueEntity> maybeQueueItem = webhookDeliveryQueueDao.nextToSend(Date.from(instantSource.instant()));
+            Optional<WebhookDeliveryQueueEntity> maybeQueueItem = webhookDeliveryQueueDao.nextToSend(instantSource.instant());
             maybeQueueItem.ifPresent(sendAttempter::attemptSend);
             transaction.commit();
         } catch (Exception e) {

--- a/src/main/java/uk/gov/pay/webhooks/ledger/model/SettlementSummary.java
+++ b/src/main/java/uk/gov/pay/webhooks/ledger/model/SettlementSummary.java
@@ -5,9 +5,9 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import uk.gov.service.payments.commons.api.json.ApiResponseDateTimeDeserializer;
+import uk.gov.pay.webhooks.util.InstantDeserializer;
 
-import java.time.ZonedDateTime;
+import java.time.Instant;
 
 import static uk.gov.service.payments.commons.model.ApiResponseDateTimeFormatter.ISO_INSTANT_MILLISECOND_PRECISION;
 
@@ -16,9 +16,9 @@ import static uk.gov.service.payments.commons.model.ApiResponseDateTimeFormatter
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class SettlementSummary {
 
-    @JsonDeserialize(using = ApiResponseDateTimeDeserializer.class)
+    @JsonDeserialize(using = InstantDeserializer.class)
     @JsonProperty("capture_submit_time")
-    private ZonedDateTime captureSubmitTime;
+    private Instant captureSubmitTime;
     @JsonProperty("captured_date")
     private String capturedDate;
 
@@ -26,7 +26,7 @@ public class SettlementSummary {
         return (captureSubmitTime != null) ? ISO_INSTANT_MILLISECOND_PRECISION.format(captureSubmitTime) : null;
     }
 
-    public void setCaptureSubmitTime(ZonedDateTime captureSubmitTime) {
+    public void setCaptureSubmitTime(Instant captureSubmitTime) {
         this.captureSubmitTime = captureSubmitTime;
     }
 

--- a/src/main/java/uk/gov/pay/webhooks/message/WebhookMessageBody.java
+++ b/src/main/java/uk/gov/pay/webhooks/message/WebhookMessageBody.java
@@ -24,7 +24,7 @@ public record WebhookMessageBody(String id,
 
     public static WebhookMessageBody from(WebhookMessageEntity webhookMessage) {
         return new WebhookMessageBody(webhookMessage.getExternalId(),
-                webhookMessage.getEventDate().toInstant(),
+                webhookMessage.getEventDate(),
                 webhookMessage.getResourceExternalId(),
                 API_VERSION,
                 webhookMessage.getResourceType(),

--- a/src/main/java/uk/gov/pay/webhooks/message/WebhookMessageService.java
+++ b/src/main/java/uk/gov/pay/webhooks/message/WebhookMessageService.java
@@ -21,7 +21,6 @@ import uk.gov.pay.webhooks.webhook.dao.entity.WebhookEntity;
 import javax.inject.Inject;
 import java.io.IOException;
 import java.time.InstantSource;
-import java.util.Date;
 import java.util.Optional;
 
 public class WebhookMessageService {
@@ -67,7 +66,7 @@ public class WebhookMessageService {
                     .map(webhook -> buildWebhookMessage(webhook, event, ledgerTransaction))
                     .flatMap(Optional::stream)
                     .map(webhookMessageDao::create)
-                    .forEach(webhookMessageEntity -> webhookDeliveryQueueDao.enqueueFrom(webhookMessageEntity, WebhookDeliveryQueueEntity.DeliveryStatus.PENDING, Date.from(instantSource.instant())));
+                    .forEach(webhookMessageEntity -> webhookDeliveryQueueDao.enqueueFrom(webhookMessageEntity, WebhookDeliveryQueueEntity.DeliveryStatus.PENDING, instantSource.instant()));
         }
     }
 
@@ -91,9 +90,9 @@ public class WebhookMessageService {
     private WebhookMessageEntity buildWebhookMessageEntity(WebhookEntity webhook, InternalEvent event, JsonNode resource) {
         var webhookMessageEntity = new WebhookMessageEntity();
         webhookMessageEntity.setExternalId(idGenerator.newExternalId());
-        webhookMessageEntity.setCreatedDate(Date.from(instantSource.instant()));
+        webhookMessageEntity.setCreatedDate(instantSource.instant());
         webhookMessageEntity.setWebhookEntity(webhook);
-        webhookMessageEntity.setEventDate(Date.from(event.eventDate()));
+        webhookMessageEntity.setEventDate(event.eventDate());
         webhookMessageEntity.setEventType(eventTypeDao.findByName(EventMapper.getWebhookEventNameFor(event.eventType())).orElseThrow(IllegalArgumentException::new));
         webhookMessageEntity.setResource(resource);
         webhookMessageEntity.setResourceExternalId(event.resourceExternalId());

--- a/src/main/java/uk/gov/pay/webhooks/message/dao/entity/WebhookMessageEntity.java
+++ b/src/main/java/uk/gov/pay/webhooks/message/dao/entity/WebhookMessageEntity.java
@@ -12,16 +12,18 @@ import uk.gov.pay.webhooks.webhook.dao.entity.WebhookEntity;
 
 import javax.persistence.Column;
 import javax.persistence.Entity;
+import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
+import javax.persistence.NamedQuery;
 import javax.persistence.SequenceGenerator;
 import javax.persistence.Table;
-import javax.persistence.NamedQuery;
-import javax.persistence.FetchType;
-import java.util.Date;
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 
 @NamedQuery(
         name = WebhookMessageEntity.MESSAGE_BY_WEBHOOK_ID_AND_MESSAGE_ID,
@@ -94,14 +96,14 @@ public class WebhookMessageEntity {
     private String resourceType;
 
     @Column(name = "created_date")
-    private Date createdDate;
+    private OffsetDateTime createdDate;
 
     @ManyToOne
     @JoinColumn(name = "webhook_id", updatable = false)
     private WebhookEntity webhookEntity;
 
     @Column(name = "event_date")
-    private Date eventDate;
+    private OffsetDateTime eventDate;
 
     @ManyToOne
     @JoinColumn(name = "event_type", updatable = false)
@@ -132,12 +134,12 @@ public class WebhookMessageEntity {
         this.externalId = externalId;
     }
 
-    public Date getCreatedDate() {
-        return createdDate;
+    public Instant getCreatedDate() {
+        return createdDate.toInstant();
     }
 
-    public void setCreatedDate(Date createdDate) {
-        this.createdDate = createdDate;
+    public void setCreatedDate(Instant createdDate) {
+        this.createdDate = OffsetDateTime.ofInstant(createdDate, ZoneOffset.UTC);
     }
 
     public WebhookEntity getWebhookEntity() {
@@ -148,12 +150,12 @@ public class WebhookMessageEntity {
         this.webhookEntity = webhookEntity;
     }
 
-    public Date getEventDate() {
-        return eventDate;
+    public Instant getEventDate() {
+        return eventDate.toInstant();
     }
 
-    public void setEventDate(Date eventDate) {
-        this.eventDate = eventDate;
+    public void setEventDate(Instant eventDate) {
+        this.eventDate = OffsetDateTime.ofInstant(eventDate, ZoneOffset.UTC);
     }
 
     public EventTypeEntity getEventType() {

--- a/src/main/java/uk/gov/pay/webhooks/message/resource/WebhookDeliveryQueueResponse.java
+++ b/src/main/java/uk/gov/pay/webhooks/message/resource/WebhookDeliveryQueueResponse.java
@@ -7,14 +7,13 @@ import uk.gov.pay.webhooks.deliveryqueue.dao.WebhookDeliveryQueueEntity;
 import uk.gov.service.payments.commons.api.json.ApiResponseInstantSerializer;
 
 import java.time.Instant;
-import java.util.Date;
 
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public record WebhookDeliveryQueueResponse(@JsonSerialize(using = ApiResponseInstantSerializer.class) Instant createdDate, @JsonSerialize(using = ApiResponseInstantSerializer.class) Instant sendAt, WebhookDeliveryQueueEntity.DeliveryStatus status, Integer statusCode, String result) {
     public static WebhookDeliveryQueueResponse from(WebhookDeliveryQueueEntity webhookDeliveryQueueEntity) {
         return new WebhookDeliveryQueueResponse(
-                webhookDeliveryQueueEntity.getCreatedDate().toInstant(),
-                webhookDeliveryQueueEntity.getSendAt().toInstant(),
+                webhookDeliveryQueueEntity.getCreatedDate(),
+                webhookDeliveryQueueEntity.getSendAt(),
                 webhookDeliveryQueueEntity.getDeliveryStatus(),
                 webhookDeliveryQueueEntity.getStatusCode(),
                 webhookDeliveryQueueEntity.getDeliveryResult()

--- a/src/main/java/uk/gov/pay/webhooks/message/resource/WebhookMessageResponse.java
+++ b/src/main/java/uk/gov/pay/webhooks/message/resource/WebhookMessageResponse.java
@@ -3,13 +3,11 @@ package uk.gov.pay.webhooks.message.resource;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import uk.gov.pay.webhooks.deliveryqueue.dao.WebhookDeliveryQueueEntity;
 import uk.gov.pay.webhooks.eventtype.EventTypeName;
 import uk.gov.pay.webhooks.message.dao.entity.WebhookMessageEntity;
 import uk.gov.service.payments.commons.api.json.ApiResponseInstantSerializer;
 
 import java.time.Instant;
-import java.util.List;
 
 public record WebhookMessageResponse(
         @JsonProperty("external_id") String externalId,
@@ -23,8 +21,8 @@ public record WebhookMessageResponse(
         var latestAttempt = (webhookMessageEntity.getWebhookDeliveryQueueEntity() != null) ? WebhookDeliveryQueueResponse.from(webhookMessageEntity.getWebhookDeliveryQueueEntity()) : null;
         return new WebhookMessageResponse(
                 webhookMessageEntity.getExternalId(),
-                webhookMessageEntity.getCreatedDate().toInstant(),
-                webhookMessageEntity.getEventDate().toInstant(),
+                webhookMessageEntity.getCreatedDate(),
+                webhookMessageEntity.getEventDate(),
                 webhookMessageEntity.getEventType().getName(),
                 webhookMessageEntity.getResource(),
                 latestAttempt

--- a/src/main/java/uk/gov/pay/webhooks/webhook/dao/entity/WebhookEntity.java
+++ b/src/main/java/uk/gov/pay/webhooks/webhook/dao/entity/WebhookEntity.java
@@ -18,7 +18,8 @@ import javax.persistence.OneToMany;
 import javax.persistence.SequenceGenerator;
 import javax.persistence.Table;
 import java.time.Instant;
-import java.util.Date;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -51,7 +52,7 @@ public class WebhookEntity {
     private Long id;
     
     @Column(name = "created_date")
-    private Date createdDate;
+    private OffsetDateTime createdDate;
     
     @Column(name = "external_id")
     private String externalId;
@@ -85,18 +86,17 @@ public class WebhookEntity {
         entity.setCallbackUrl(createWebhookRequest.callbackUrl());
         entity.setServiceId(createWebhookRequest.serviceId());
         entity.setLive(createWebhookRequest.live());
-        entity.setCreatedDate(Date.from(createdDate));
+        entity.setCreatedDate(createdDate);
         entity.setStatus(WebhookStatus.ACTIVE);
         entity.setExternalId(externalId);
         entity.setSigningKey(webhookSigningKey);
         return entity;
     }
 
-    public Date getCreatedDate() {
-        return createdDate;
+    public Instant getCreatedDate() {
+        return createdDate.toInstant();
     }
 
-    
     public String getExternalId() {
         return externalId;
     }
@@ -153,8 +153,8 @@ public class WebhookEntity {
         this.description = description;
     }
 
-    public void setCreatedDate(Date instant) {
-        this.createdDate = instant;
+    public void setCreatedDate(Instant instant) {
+        this.createdDate = OffsetDateTime.ofInstant(instant, ZoneOffset.UTC);
     }
     
     public void setSigningKey(String signingKey) {

--- a/src/main/java/uk/gov/pay/webhooks/webhook/resource/WebhookResponse.java
+++ b/src/main/java/uk/gov/pay/webhooks/webhook/resource/WebhookResponse.java
@@ -35,7 +35,7 @@ public record WebhookResponse(
                 webhookEntity.getDescription(),
                 webhookEntity.getExternalId(),
                 webhookEntity.getStatus(),
-                webhookEntity.getCreatedDate().toInstant(),
+                webhookEntity.getCreatedDate(),
                 webhookEntity.getSubscriptions().stream()
                         .map(EventTypeEntity::getName)
                         .toList()

--- a/src/main/resources/migrations/0006_alter_table_webhooks_alter_column_created_date_type_timestamp_with_time_zone.sql
+++ b/src/main/resources/migrations/0006_alter_table_webhooks_alter_column_created_date_type_timestamp_with_time_zone.sql
@@ -1,0 +1,6 @@
+--liquibase formatted sql
+
+--changeset uk.gov.pay:alter-table-webhooks-alter-column-created_date-type-timestamp-with-time-zone.sql
+ALTER TABLE webhooks ALTER COLUMN created_date TYPE TIMESTAMP WITH TIME ZONE
+
+--rollback ALTER TABLE webhooks ALTER COLUMN created_date TYPE TIMESTAMP WITHOUT TIME ZONE

--- a/src/test/java/uk/gov/pay/webhooks/deliveryqueue/dao/WebhookDeliveryQueueDaoTest.java
+++ b/src/test/java/uk/gov/pay/webhooks/deliveryqueue/dao/WebhookDeliveryQueueDaoTest.java
@@ -12,7 +12,6 @@ import uk.gov.pay.webhooks.webhook.dao.entity.WebhookEntity;
 
 import java.time.Instant;
 import java.time.InstantSource;
-import java.util.Date;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
@@ -43,12 +42,12 @@ class WebhookDeliveryQueueDaoTest {
     void nextToSendReturnsEnqueuedMessage() {
         WebhookMessageEntity persisted = database.inTransaction(() -> {
             WebhookMessageEntity webhookMessageEntity = new WebhookMessageEntity();
-            webhookMessageEntity.setCreatedDate(Date.from(instantSource.instant()));
+            webhookMessageEntity.setCreatedDate(instantSource.instant());
             return webhookMessageDao.create(webhookMessageEntity);
         });
         database.inTransaction(() -> {
-            webhookDeliveryQueueDao.enqueueFrom(persisted, WebhookDeliveryQueueEntity.DeliveryStatus.PENDING, Date.from(instantSource.instant().minusMillis(1)));
-            assertThat(webhookDeliveryQueueDao.nextToSend(Date.from(instantSource.instant())).get().getWebhookMessageEntity(), is(persisted));
+            webhookDeliveryQueueDao.enqueueFrom(persisted, WebhookDeliveryQueueEntity.DeliveryStatus.PENDING, instantSource.instant().minusMillis(1));
+            assertThat(webhookDeliveryQueueDao.nextToSend(instantSource.instant()).get().getWebhookMessageEntity(), is(persisted));
         });
     }
 
@@ -56,11 +55,11 @@ class WebhookDeliveryQueueDaoTest {
     void recordResultUpdatesAttempt() {
         WebhookMessageEntity persisted = database.inTransaction(() -> {
             WebhookMessageEntity webhookMessageEntity = new WebhookMessageEntity();
-            webhookMessageEntity.setCreatedDate(Date.from(instantSource.instant()));
+            webhookMessageEntity.setCreatedDate(instantSource.instant());
             return webhookMessageDao.create(webhookMessageEntity);
         });
         database.inTransaction(() -> {
-            var enqueued = webhookDeliveryQueueDao.enqueueFrom(persisted, WebhookDeliveryQueueEntity.DeliveryStatus.PENDING, Date.from(instantSource.instant().minusMillis(1)));
+            var enqueued = webhookDeliveryQueueDao.enqueueFrom(persisted, WebhookDeliveryQueueEntity.DeliveryStatus.PENDING, instantSource.instant().minusMillis(1));
             var updated = webhookDeliveryQueueDao.recordResult(enqueued, "200 OK", 200, WebhookDeliveryQueueEntity.DeliveryStatus.SUCCESSFUL);
             assertThat(updated.getDeliveryStatus(), is(WebhookDeliveryQueueEntity.DeliveryStatus.SUCCESSFUL));
             assertThat(updated.getDeliveryResult(), is("200 OK"));
@@ -72,12 +71,12 @@ class WebhookDeliveryQueueDaoTest {
     void countFailed() {
         WebhookMessageEntity persisted = database.inTransaction(() -> {
             WebhookMessageEntity webhookMessageEntity = new WebhookMessageEntity();
-            webhookMessageEntity.setCreatedDate(Date.from(instantSource.instant()));
+            webhookMessageEntity.setCreatedDate(instantSource.instant());
             return webhookMessageDao.create(webhookMessageEntity);
         });
         database.inTransaction(() -> {
-            webhookDeliveryQueueDao.enqueueFrom(persisted, WebhookDeliveryQueueEntity.DeliveryStatus.FAILED, Date.from(instantSource.instant()));
-            webhookDeliveryQueueDao.enqueueFrom(persisted, WebhookDeliveryQueueEntity.DeliveryStatus.FAILED, Date.from(instantSource.instant()));
+            webhookDeliveryQueueDao.enqueueFrom(persisted, WebhookDeliveryQueueEntity.DeliveryStatus.FAILED, instantSource.instant());
+            webhookDeliveryQueueDao.enqueueFrom(persisted, WebhookDeliveryQueueEntity.DeliveryStatus.FAILED, instantSource.instant());
             assertThat(webhookDeliveryQueueDao.countFailed(persisted), is(2L));
         });
     }

--- a/src/test/java/uk/gov/pay/webhooks/deliveryqueue/managed/SendAttempterTest.java
+++ b/src/test/java/uk/gov/pay/webhooks/deliveryqueue/managed/SendAttempterTest.java
@@ -22,14 +22,13 @@ import java.net.http.HttpTimeoutException;
 import java.security.InvalidKeyException;
 import java.time.Instant;
 import java.time.InstantSource;
-import java.util.Date;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
-import static org.hamcrest.Matchers.is;
 
 @ExtendWith(MockitoExtension.class)
 @ExtendWith(DropwizardExtensionsSupport.class)
@@ -64,12 +63,12 @@ class SendAttempterTest {
         WebhookEntity webhookEntity = new WebhookEntity();
         webhookEntity.setLive(true);
         webhookEntity.setServiceId("service-id-1");
-        webhookEntity.setCreatedDate(Date.from(Instant.parse("2007-12-03T10:15:30.00Z")));
+        webhookEntity.setCreatedDate(Instant.parse("2007-12-03T10:15:30.00Z"));
         webhookEntity.setCallbackUrl("http://example.com");
         webhookEntity.setSigningKey("some-signing-key");
         webhookDao.create(webhookEntity);
         webhookMessageEntity.setWebhookEntity(webhookEntity);
-        webhookMessageEntity.setCreatedDate(Date.from(instantSource.instant()));
+        webhookMessageEntity.setCreatedDate(instantSource.instant());
     }
     
     @Test
@@ -78,7 +77,7 @@ class SendAttempterTest {
         
         var webhookMessage = webhookMessageDao.create(webhookMessageEntity);
         var sendAttempter = new SendAttempter(webhookDeliveryQueueDao, instantSource, mockWebhookMessageSender);
-        var enqueuedItem = webhookDeliveryQueueDao.enqueueFrom(webhookMessage, WebhookDeliveryQueueEntity.DeliveryStatus.PENDING, Date.from(instantSource.instant()));
+        var enqueuedItem = webhookDeliveryQueueDao.enqueueFrom(webhookMessage, WebhookDeliveryQueueEntity.DeliveryStatus.PENDING, instantSource.instant());
         given(mockHttpResponse.statusCode()).willReturn(404, 200);
         
         sendAttempter.attemptSend(enqueuedItem);
@@ -94,7 +93,7 @@ class SendAttempterTest {
 
         var webhookMessage = webhookMessageDao.create(webhookMessageEntity);
         var sendAttempter = new SendAttempter(webhookDeliveryQueueDao, instantSource, mockWebhookMessageSender);
-        var enqueuedItem = webhookDeliveryQueueDao.enqueueFrom(webhookMessage, WebhookDeliveryQueueEntity.DeliveryStatus.PENDING, Date.from(instantSource.instant()));
+        var enqueuedItem = webhookDeliveryQueueDao.enqueueFrom(webhookMessage, WebhookDeliveryQueueEntity.DeliveryStatus.PENDING, instantSource.instant());
         given(mockWebhookMessageSender.sendWebhookMessage(any(WebhookMessageEntity.class))).willThrow(IOException.class, HttpTimeoutException.class);
 
         assertDoesNotThrow(() -> sendAttempter.attemptSend(enqueuedItem));
@@ -109,13 +108,13 @@ class SendAttempterTest {
         given(mockWebhookMessageSender.sendWebhookMessage(any(WebhookMessageEntity.class))).willReturn(mockHttpResponse);
         var webhookMessage = webhookMessageDao.create(webhookMessageEntity);
         var sendAttempter = new SendAttempter(webhookDeliveryQueueDao, instantSource, mockWebhookMessageSender);
-        var enqueuedItem = webhookDeliveryQueueDao.enqueueFrom(webhookMessage, WebhookDeliveryQueueEntity.DeliveryStatus.PENDING, Date.from(instantSource.instant()));
+        var enqueuedItem = webhookDeliveryQueueDao.enqueueFrom(webhookMessage, WebhookDeliveryQueueEntity.DeliveryStatus.PENDING, instantSource.instant());
         given(mockHttpResponse.statusCode()).willReturn(404);
         sendAttempter.attemptSend(enqueuedItem);
         assertThat(enqueuedItem.getDeliveryStatus(), is(WebhookDeliveryQueueEntity.DeliveryStatus.FAILED));
 
         database.inTransaction(() -> {
-            assertThat(webhookDeliveryQueueDao.nextToSend(Date.from((Instant.parse("2007-12-03T10:15:30.00Z")))), is(notNullValue()));
+            assertThat(webhookDeliveryQueueDao.nextToSend((Instant.parse("2007-12-03T10:15:30.00Z"))), is(notNullValue()));
             assertThat(webhookDeliveryQueueDao.countFailed(webhookMessageEntity), is(1L));
         });
         

--- a/src/test/java/uk/gov/pay/webhooks/message/WebhookMessageBodyTest.java
+++ b/src/test/java/uk/gov/pay/webhooks/message/WebhookMessageBodyTest.java
@@ -12,7 +12,6 @@ import uk.gov.pay.webhooks.message.dao.entity.WebhookMessageEntity;
 
 import java.time.Instant;
 import java.time.InstantSource;
-import java.util.Date;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
@@ -39,7 +38,7 @@ class WebhookMessageBodyTest {
             """;
         var webhookMessageEntity = new WebhookMessageEntity();
         webhookMessageEntity.setExternalId("externalId");
-        webhookMessageEntity.setEventDate(Date.from(instantSource.instant()));
+        webhookMessageEntity.setEventDate(instantSource.instant());
         EventTypeEntity eventTypeEntity = new EventTypeEntity(EventTypeName.CARD_PAYMENT_CAPTURED);
         webhookMessageEntity.setEventType(eventTypeEntity);
         webhookMessageEntity.setResourceType("payment");

--- a/src/test/java/uk/gov/pay/webhooks/message/WebhookMessageSenderTest.java
+++ b/src/test/java/uk/gov/pay/webhooks/message/WebhookMessageSenderTest.java
@@ -20,7 +20,6 @@ import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.security.InvalidKeyException;
-import java.sql.Date;
 import java.time.Instant;
 import java.util.Optional;
 
@@ -81,7 +80,7 @@ class WebhookMessageSenderTest {
         webhookMessageEntity = new WebhookMessageEntity();
         webhookMessageEntity.setWebhookEntity(webhookEntity);
         webhookMessageEntity.setResource(jsonPayload);
-        webhookMessageEntity.setEventDate(Date.from(Instant.parse("2019-10-01T08:25:24.00Z")));
+        webhookMessageEntity.setEventDate(Instant.parse("2019-10-01T08:25:24.00Z"));
         EventTypeEntity eventTypeEntity = new EventTypeEntity(EventTypeName.CARD_PAYMENT_CAPTURED);
         webhookMessageEntity.setEventType(eventTypeEntity);
         webhookMessageEntity.setResourceExternalId("foo");

--- a/src/test/java/uk/gov/pay/webhooks/message/dao/WebhookMessageDaoTest.java
+++ b/src/test/java/uk/gov/pay/webhooks/message/dao/WebhookMessageDaoTest.java
@@ -14,7 +14,6 @@ import uk.gov.pay.webhooks.webhook.dao.entity.WebhookEntity;
 
 import java.time.Instant;
 import java.time.InstantSource;
-import java.util.Date;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
@@ -83,14 +82,14 @@ class WebhookMessageDaoTest {
        database.inTransaction(() -> {
            webhookDao.create(webhook);
            webhookMessageDao.create(message);
-           webhookDeliveryQueueDao.enqueueFrom(message, WebhookDeliveryQueueEntity.DeliveryStatus.SUCCESSFUL, new Date());
+           webhookDeliveryQueueDao.enqueueFrom(message, WebhookDeliveryQueueEntity.DeliveryStatus.SUCCESSFUL, Instant.now());
 
            for (var i = 0; i < numberOfPendingMessagesToPad; i++) {
                var padMessage = new WebhookMessageEntity();
                padMessage.setWebhookEntity(webhook);
                padMessage.setExternalId("padded-message-%s".formatted(i));
                webhookMessageDao.create(padMessage);
-               webhookDeliveryQueueDao.enqueueFrom(padMessage, WebhookDeliveryQueueEntity.DeliveryStatus.PENDING, new Date());
+               webhookDeliveryQueueDao.enqueueFrom(padMessage, WebhookDeliveryQueueEntity.DeliveryStatus.PENDING, Instant.now());
            }
        });
    }

--- a/src/test/java/uk/gov/pay/webhooks/util/InstantDeserializerTest.java
+++ b/src/test/java/uk/gov/pay/webhooks/util/InstantDeserializerTest.java
@@ -1,0 +1,66 @@
+package uk.gov.pay.webhooks.util;
+
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.time.Instant;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class InstantDeserializerTest {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    private record Entity(@JsonDeserialize(using = InstantDeserializer.class) Instant instant) { }
+
+    @BeforeEach
+    public void setUp() {
+        SimpleModule simpleModule = new SimpleModule();
+        simpleModule.addDeserializer(Instant.class, new InstantDeserializer());
+        objectMapper.registerModule(simpleModule);
+    }
+
+    @Test
+    void shouldDeserializeValidInstantString() throws IOException {
+        var timestamp = "2022-01-02T17:21:12.123456789Z";
+
+        var json = """
+                {
+                    "instant": "%s"
+                }
+                """.formatted(timestamp);
+
+        assertThat(objectMapper.readValue(json, Entity.class).instant(), is(Instant.parse(timestamp)));
+    }
+
+    @Test
+    void shouldDeserializeNullToNull() throws IOException {
+        var json = """
+                {
+                    "instant": null
+                }
+                """;
+
+        assertThat(objectMapper.readValue(json, Entity.class).instant(), is(nullValue()));
+    }
+
+    @Test
+    void shouldThrowExceptionWhenValueInvalid() {
+        var json = """
+                {
+                    "instant": "invalid"
+                }
+                """;
+
+        assertThrows(JsonMappingException.class, () -> objectMapper.readValue(json, Entity.class));
+    }
+
+}

--- a/src/test/java/uk/gov/pay/webhooks/webhook/WebhookServiceTest.java
+++ b/src/test/java/uk/gov/pay/webhooks/webhook/WebhookServiceTest.java
@@ -16,7 +16,6 @@ import uk.gov.pay.webhooks.webhook.resource.CreateWebhookRequest;
 
 import java.time.Instant;
 import java.time.InstantSource;
-import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Optional;
 

--- a/src/test/java/uk/gov/pay/webhooks/webhook/dao/WebhookDaoTest.java
+++ b/src/test/java/uk/gov/pay/webhooks/webhook/dao/WebhookDaoTest.java
@@ -10,7 +10,6 @@ import uk.gov.pay.webhooks.eventtype.dao.EventTypeEntity;
 import uk.gov.pay.webhooks.webhook.dao.entity.WebhookEntity;
 
 import java.time.Instant;
-import java.util.Date;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.any;
@@ -151,18 +150,18 @@ public class WebhookDaoTest {
             WebhookEntity webhookEntityServiceOne = new WebhookEntity();
             webhookEntityServiceOne.setLive(true);
             webhookEntityServiceOne.setServiceId("service-id-1");
-            webhookEntityServiceOne.setCreatedDate(Date.from(Instant.parse("2007-12-03T10:15:30.00Z")));
+            webhookEntityServiceOne.setCreatedDate(Instant.parse("2007-12-03T10:15:30.00Z"));
             webhookDao.create(webhookEntityServiceOne);
 
             WebhookEntity webhookEntityServiceTwo = new WebhookEntity();
             webhookEntityServiceTwo.setLive(true);
             webhookEntityServiceTwo.setServiceId("service-id-newer-created-date");
-            webhookEntityServiceTwo.setCreatedDate(Date.from(Instant.parse("2020-12-03T10:15:30.00Z")));
+            webhookEntityServiceTwo.setCreatedDate(Instant.parse("2020-12-03T10:15:30.00Z"));
             webhookDao.create(webhookEntityServiceTwo);
         });
 
         assertThat(webhookDao.list(true).stream().map(WebhookEntity::getCreatedDate).toList(),
-                contains((Date.from(Instant.parse("2020-12-03T10:15:30.00Z"))),(Date.from(Instant.parse("2007-12-03T10:15:30.00Z")))));
+                contains((Instant.parse("2020-12-03T10:15:30.00Z")),(Instant.parse("2007-12-03T10:15:30.00Z"))));
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/webhooks/webhook/resource/WebhookResourceTest.java
+++ b/src/test/java/uk/gov/pay/webhooks/webhook/resource/WebhookResourceTest.java
@@ -16,7 +16,6 @@ import uk.gov.pay.webhooks.webhook.dao.entity.WebhookEntity;
 
 import javax.ws.rs.client.Entity;
 import java.time.Instant;
-import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -44,7 +43,7 @@ public class WebhookResourceTest {
     @BeforeEach
     void setup() {
         webhook = new WebhookEntity();
-        webhook.setCreatedDate(Date.from(Instant.now()));
+        webhook.setCreatedDate(Instant.now());
     }
 
     @Test
@@ -171,7 +170,7 @@ public class WebhookResourceTest {
         webhook.setLive(true);
         webhook.setDescription("fooBar");
         webhook.addSubscription(new EventTypeEntity(EventTypeName.CARD_PAYMENT_CAPTURED));
-        webhook.setCreatedDate(Date.from(Instant.parse("2007-12-03T10:15:30.00Z")));
+        webhook.setCreatedDate(Instant.parse("2007-12-03T10:15:30.00Z"));
 
         when(webhookService.list(true, existingServiceId)).thenReturn((List.of(webhook, webhook)));
 


### PR DESCRIPTION
In short, make the following so:

- Except in entity classes, all timestamps in the application are `Instant`s
- In entity classes (that is, classes that represent something in the database), all timestamps are `OffsetDateTime`s
- In the database, all columns holding timestamps are of the type `TIMESTAMP WITH TIME ZONE`

Longer explanation:

Up until now, the webhooks application used a mixture of `Instant`s, `Date`s and `ZonedDateTime`s to represent timestamps. In the database, timestamps were a mixture of `TIMESTAMP WITH TIME ZONE` and `TIMESTAMP WITHOUT TIME ZONE`.

`Instant` is clearly the best class to model timestamps in the application. While we used Instants in most places, in entity objects we used `Dat`e because Hibernate can natively persist this to the database. `Date` is essentially deprecated and only supports millisecond precision (as opposed to Instant, which supports nanosecond precision, though in practice the system clocks on most Linux systems will only proffer microsecond-precision timestamps). `ZonedDateTime` has historically been used in the Pay platform but almost always with a time zone of UTC (or the default time zone with the expectation it will be UTC), so `Instant` is a simpler alternative in almost all cases.

Ideally, we’d simply use `Instant` everywhere. However, JPA 2.2+ does not natively support mapping an Instant in entity classes to an appropriate database column type. Unlike EclipseLink, Hibernate does not seem to support using JPA attribute converters to transform to an appropriate type on the fly (or if it does, we cannot get it working). Therefore, we have to use a natively supported type in each entity class. There are two such types defined in JPA 2.2+ that make sense:

- `OffsetDateTime`, which maps to `TIMESTAMP WITH TIME ZONE`
- `LocalDateTime`, which maps to `TIMESTAMP WITHOUT TIME ZONE`

Looking from the database side, there is not really much difference between `TIMESTAMP WITH TIME ZONE` and `TIMESTAMP WITHOUT TIME ZONE`. Indeed, PostgreSQL stores them in the same way (a count of nanoseconds since the epoch) and the time zone for `TIMESTAMP WITH TIME ZONE` is always UTC (PostgreSQL does conversion from other time zones when reading and writing). The webhooks application and the Pay platform in general use a mixture of both: either `TIMESTAMP WITH TIME ZONE` (which is UTC) or `TIMESTAMP WITHOUT TIME ZONE` (which the application code assumes is UTC).

`LocalDateTime` has no time zone, which makes it less than ideal for storing timestamps. `OffsetDateTime` is more appropriate.

Therefore, in entity classes, we now use `OffsetDateTime` to store timestamps. In the matching database columns, we use `TIMESTAMP WITH TIME ZONE`.

Note that only the type of the field itself is `OffsetDateTime`. We do not allow this type to ‘escape’ the entity class. We eagerly convert to and from Instant when necessary (conversion between `Instant`s and UTC `OffsetDateTime`s is infallible and lossless).

As such, setters in entities take an `Instant` and covert to a UTC `OffsetDateTime`:

```java
public void setCreatedDate(Instant createdDate) {
    this.createdDate = OffsetDateTime.ofInstant(createdDate,
                                                ZoneOffset.UTC);
}
```

Getters always return an `Instant`:

```java
public Instant getCreatedDate() {
    return createdDate.toInstant();
}
```

There should be no observable behavioural changes as a result of this change, with one exception: when JSON from ledger is converted to a `SettlementSummary` object, the `capture_submit_time` property is now parsed as an `ISO_INSTANT` rather than an `ISO_ZONED_DATE_TIME`. Every `ISO_INSTANT` can be parsed as an `ISO_ZONED_DATE_TIME` but the reverse is not true. Previously, parsing a string like this would have been supported:

```
2021-04-01T13:00:00.000+01:00[Europe/London]
```

Now, only strings like this are supported:

```
2021-04-01T12:00:00.000Z
```

Ledger only produces strings like that the latter, so this change should have no effect.