### PR TITLE
BAU: reflect that authorisation summary is optional in ledger payload

### DIFF
--- a/src/main/java/uk/gov/pay/webhooks/message/apirepresentation/PaymentApiRepresentation.java
+++ b/src/main/java/uk/gov/pay/webhooks/message/apirepresentation/PaymentApiRepresentation.java
@@ -80,7 +80,7 @@ public record PaymentApiRepresentation(
                 ledgerTransaction.getExternalMetaData(),
                 ledgerTransaction.getFee(),
                 ledgerTransaction.getNetAmount(),
-                new PaymentApiAuthorisationSummary(new PaymentApiThreeDSecure(ledgerTransaction.getAuthorisationSummary().getThreeDSecure().isRequired()))
+                Optional.ofNullable(ledgerTransaction.getAuthorisationSummary()).map(as -> new PaymentApiAuthorisationSummary(new PaymentApiThreeDSecure(as.getThreeDSecure().isRequired()))).orElse(null)
         );
     }
 }

--- a/src/test/java/uk/gov/pay/webhooks/message/apirepresentation/PaymentApiRepresentationTest.java
+++ b/src/test/java/uk/gov/pay/webhooks/message/apirepresentation/PaymentApiRepresentationTest.java
@@ -175,12 +175,7 @@ class PaymentApiRepresentationTest {
                                  	"payment_provider": "sandbox",
                                  	"created_date": "2018-09-22T10:13:16.067Z",
                                  	"delayed_capture": false,
-                                 	"moto": false,
-                                 	"authorisation_summary": {
-                                 		"three_d_secure": {
-                                 			"required": true,
-                                 			"version": "2.1.0"
-                                 		}
+                                 	"moto": false
                                  	}
                                  }
                 """;


### PR DESCRIPTION
We are seeing an exception on Webhooks in Test:
```
uk.gov.pay.webhooks.ledger.model.AuthorisationSummary.getThreeDSecure()" because the return value of "uk.gov.pay.webhooks.ledger.model.LedgerTransaction.getAuthorisationSummary() is null" 
```
which suggests this field is not always present in the ledger payload. This PR makes it optional, so no NPE will be thrown if it is not present. 