### PR TITLE
BAU — Dependency configuration: use Mockito bill of materials

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,6 +59,13 @@
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
+            <dependency>
+                <groupId>org.mockito</groupId>
+                <artifactId>mockito-bom</artifactId>
+                <version>4.3.1</version>
+                <scope>import</scope>
+                <type>pom</type>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 
@@ -174,14 +181,13 @@
             <artifactId>junit-jupiter-params</artifactId>
             <scope>test</scope>
         </dependency>
-
-        <!-- Test dependencies that need explicit versions -->
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-junit-jupiter</artifactId>
-            <version>4.3.1</version>
             <scope>test</scope>
         </dependency>
+
+        <!-- Test dependencies that need explicit versions -->
         <dependency>
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest-core</artifactId>


### PR DESCRIPTION
Mockito now publish a bill of materials so use that in our POM.

We currently only use one Mockito dependency so this does not make any real difference but it’s nice to have in case we add more in the future.