### PR TITLE
BAU Serialise resource id and type on webhook message

### DIFF
--- a/src/main/java/uk/gov/pay/webhooks/message/resource/WebhookMessageResponse.java
+++ b/src/main/java/uk/gov/pay/webhooks/message/resource/WebhookMessageResponse.java
@@ -14,6 +14,8 @@ public record WebhookMessageResponse(
         @JsonProperty("created_date") @JsonSerialize(using = ApiResponseInstantSerializer.class) Instant createdDate,
         @JsonProperty("event_date") @JsonSerialize(using = ApiResponseInstantSerializer.class) Instant eventDate,
         @JsonProperty("event_type") EventTypeName eventTypeName,
+        @JsonProperty("resource_id") String resourceId,
+        @JsonProperty("resource_type") String resourceType,
         @JsonProperty("resource") JsonNode resource,
         @JsonProperty("latest_attempt") WebhookDeliveryQueueResponse webhookDeliveryQueueEntity) {
 
@@ -24,6 +26,8 @@ public record WebhookMessageResponse(
                 webhookMessageEntity.getCreatedDate(),
                 webhookMessageEntity.getEventDate(),
                 webhookMessageEntity.getEventType().getName(),
+                webhookMessageEntity.getResourceExternalId(),
+                webhookMessageEntity.getResourceType(),
                 webhookMessageEntity.getResource(),
                 latestAttempt
         );

--- a/src/test/java/uk/gov/pay/webhooks/webhook/resource/WebhookResourceIT.java
+++ b/src/test/java/uk/gov/pay/webhooks/webhook/resource/WebhookResourceIT.java
@@ -134,6 +134,8 @@ public class WebhookResourceIT {
                 .then()
                 .statusCode(Response.Status.OK.getStatusCode())
                 .body("external_id", is(messageExternalId))
+                .body("resource_id", is("transaction-external-id"))
+                .body("resource_type", is("payment"))
                 .body("latest_attempt.status", is("FAILED"));
     }
 
@@ -152,18 +154,18 @@ public class WebhookResourceIT {
         ));
         app.getJdbi().withHandle(h -> h.execute("""
                             INSERT INTO webhook_messages VALUES
-                            (1, '%s', '2022-01-01', 1, '2022-01-01', 1, '{}'),
-                            (2, 'second-message-external-id', '2022-01-01', 1, '2022-01-01', 1, '{}'),
-                            (3, 'third-message-external-id', '2022-01-01', 1, '2022-01-01', 1, '{}'),
-                            (4, 'fourth-message-external-id', '2022-01-01', 1, '2022-01-01', 1, '{}'),
-                            (5, 'fifth-message-external-id', '2022-01-01', 1, '2022-01-01', 1, '{}'),
-                            (6, 'sixth-message-external-id', '2022-01-01', 1, '2022-01-01', 1, '{}'),
-                            (7, 'seventh-message-external-id', '2022-01-01', 1, '2022-01-01', 1, '{}'),
-                            (8, 'eighth-message-external-id', '2022-01-01', 1, '2022-01-01', 1, '{}'),
-                            (9, 'ninth-message-external-id', '2022-01-01', 1, '2022-01-01', 1, '{}'),
-                            (10, 'tenth-message-external-id', '2022-01-01', 1, '2022-01-01', 1, '{}'),
-                            (11, 'eleventh-message-external-id', '2022-01-01', 1, '2022-01-01', 1, '{}'),
-                            (12, 'twelfth-message-external-id', '2022-01-01', 1, '2022-01-01', 1, '{}')
+                            (1, '%s', '2022-01-01', 1, '2022-01-01', 1, '{}', 'transaction-external-id', 'payment'),
+                            (2, 'second-message-external-id', '2022-01-01', 1, '2022-01-01', 1, '{}', null, null),
+                            (3, 'third-message-external-id', '2022-01-01', 1, '2022-01-01', 1, '{}', null, null),
+                            (4, 'fourth-message-external-id', '2022-01-01', 1, '2022-01-01', 1, '{}', null, null),
+                            (5, 'fifth-message-external-id', '2022-01-01', 1, '2022-01-01', 1, '{}', null, null),
+                            (6, 'sixth-message-external-id', '2022-01-01', 1, '2022-01-01', 1, '{}', null, null),
+                            (7, 'seventh-message-external-id', '2022-01-01', 1, '2022-01-01', 1, '{}', null, null),
+                            (8, 'eighth-message-external-id', '2022-01-01', 1, '2022-01-01', 1, '{}', null, null),
+                            (9, 'ninth-message-external-id', '2022-01-01', 1, '2022-01-01', 1, '{}', null, null),
+                            (10, 'tenth-message-external-id', '2022-01-01', 1, '2022-01-01', 1, '{}', null, null),
+                            (11, 'eleventh-message-external-id', '2022-01-01', 1, '2022-01-01', 1, '{}', null, null),
+                            (12, 'twelfth-message-external-id', '2022-01-01', 1, '2022-01-01', 1, '{}', null, null)
                         """.formatted(messageExternalId)
         ));
         app.getJdbi().withHandle(h -> h.execute("""


### PR DESCRIPTION
The admin tool currently parses the `resource` attribute of the webhook
message to get the transaction id (to be linked to and referenced). This
shouldn't be relied on as the shape of the api may in the future be
configurable.

The WebhookMessageEntity already parses and stores the resource ID based
on internal pay messages. Expose this on the serialised record so that
it can be used by the admin tool consumer.