### PR TITLE
BAU Remove unused serialised event fields

### DIFF
--- a/src/main/java/uk/gov/pay/webhooks/queue/EventMessage.java
+++ b/src/main/java/uk/gov/pay/webhooks/queue/EventMessage.java
@@ -15,7 +15,6 @@ public record EventMessage(EventMessageDto eventMessageDto, QueueMessage queueMe
                 eventMessageDto.live(),
                 eventMessageDto.resourceExternalId(),
                 eventMessageDto.parentResourceExternalId(),
-                eventMessageDto.eventData(),
                 eventMessageDto.eventDate(),
                 eventMessageDto.resourceType()
                 );

--- a/src/main/java/uk/gov/pay/webhooks/queue/EventMessageDto.java
+++ b/src/main/java/uk/gov/pay/webhooks/queue/EventMessageDto.java
@@ -18,6 +18,5 @@ public record EventMessageDto(@JsonProperty("service_id") String serviceId,
                               @JsonProperty("resource_external_id") String resourceExternalId,
                               @JsonProperty("parent_resource_external_id") String parentResourceExternalId,
                               @JsonProperty("event_type") String eventType,
-                              @JsonProperty("resource_type") String resourceType,
-                              @JsonProperty("event_data") JsonNode eventData
+                              @JsonProperty("resource_type") String resourceType
 ) {}

--- a/src/main/java/uk/gov/pay/webhooks/queue/InternalEvent.java
+++ b/src/main/java/uk/gov/pay/webhooks/queue/InternalEvent.java
@@ -12,7 +12,6 @@ public record InternalEvent(
         Boolean live,
         String resourceExternalId,
         String parentResourceExternalId,
-        JsonNode eventData,
         @JsonSerialize(using = MicrosecondPrecisionInstantSerializer.class) Instant eventDate,
         String resourceType
         ) {}

--- a/src/test/java/uk/gov/pay/webhooks/queue/EventQueueIT.java
+++ b/src/test/java/uk/gov/pay/webhooks/queue/EventQueueIT.java
@@ -57,7 +57,7 @@ public class EventQueueIT {
                 {
                   "Type" : "Notification",
                   "MessageId" : "04424f78-d540-5eb7-87e1-154d586b6b02",
-                  "Message" : "{\\"sqs_message_id\\":\\"dc142884-1e4b-4e57-be93-111b692a4868\\",\\"service_id\\":\\"some-service-id\\",\\"live\\":false,\\"resource_type\\":\\"payment\\",\\"resource_external_id\\":\\"t8cj9v1lci7da7pbp99qg9olv3\\",\\"parent_resource_external_id\\":null,\\"event_date\\":\\"2019-08-31T14:18:46.446541Z\\",\\"event_type\\":\\"PAYMENT_DETAILS_ENTERED\\",\\"event_data\\":{},\\"reproject_domain_object\\":false}",
+                  "Message" : "{\\"sqs_message_id\\":\\"dc142884-1e4b-4e57-be93-111b692a4868\\",\\"service_id\\":\\"some-service-id\\",\\"live\\":false,\\"resource_type\\":\\"payment\\",\\"resource_external_id\\":\\"t8cj9v1lci7da7pbp99qg9olv3\\",\\"parent_resource_external_id\\":null,\\"event_date\\":\\"2019-08-31T14:18:46.446541Z\\",\\"event_type\\":\\"PAYMENT_DETAILS_ENTERED\\",\\"reproject_domain_object\\":false}",
                   "TopicArn" : "card-payment-events-topic",
                   "Timestamp" : "2021-12-16T18:52:27.068Z",
                   "SignatureVersion" : "1",

--- a/src/test/java/uk/gov/pay/webhooks/webhook/WebhookServiceTest.java
+++ b/src/test/java/uk/gov/pay/webhooks/webhook/WebhookServiceTest.java
@@ -106,7 +106,7 @@ class WebhookServiceTest {
         var webhookNotSubscribedToAnyEvents = new WebhookEntity();
         when(webhookDao.list(live, serviceId))
                 .thenReturn(List.of(webhookSubscribedToCaptureEvent, webhookNotSubscribedToAnyEvents));
-        var event = new InternalEvent("CAPTURE_CONFIRMED", serviceId, live, "resource_id", null, null, instantSource.instant(), "PAYMENT");
+        var event = new InternalEvent("CAPTURE_CONFIRMED", serviceId, live, "resource_id", null, instantSource.instant(), "PAYMENT");
         
         var subscribedWebhooks = webhookService.getWebhooksSubscribedToEvent(event);
         


### PR DESCRIPTION
Remove reference (pseudo contracts) to data we don't need on events.
Content of events isn't used when processing webhooks so reflect that
with models.