### PR TITLE
BAU — Upgrade GitHub-provided GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -8,14 +8,14 @@ jobs:
   test:
     runs-on: ubuntu-18.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
       - name: Set up JDK 17
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@4fe61d24fe5472910b93bdeffb8aad49f979d862
         with:
           java-version: '17'
           distribution: 'adopt'
       - name: Cache Maven packages
-        uses: actions/cache@v2
+        uses: actions/cache@48af2dc4a9e8278b89d7fa154b955c30c6aaab09
         with:
           path: ~/.m2
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
@@ -23,7 +23,7 @@ jobs:
       - name: Run tests
         run: mvn clean verify
       - name: Upload Artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@6673cd052c4cd6fcf4b4e6e60ea986c889389535
         with:
           name: target
           path: target

--- a/.github/workflows/push-to-main.yml
+++ b/.github/workflows/push-to-main.yml
@@ -12,16 +12,16 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
       - name: Git checkout
-        uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
+        uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
         with:
           fetch-depth: '0'
       - name: Set up JDK 17
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@4fe61d24fe5472910b93bdeffb8aad49f979d862
         with:
           java-version: '17'
           distribution: 'adopt'
       - name: Cache Maven packages
-        uses: actions/cache@v2
+        uses: actions/cache@48af2dc4a9e8278b89d7fa154b955c30c6aaab09
         with:
           path: ~/.m2
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
@@ -29,7 +29,7 @@ jobs:
       - name: Run tests
         run: mvn clean verify
       - name: Upload jar
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@6673cd052c4cd6fcf4b4e6e60ea986c889389535
         with:
           name: target
           path: target
@@ -41,7 +41,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Git checkout
-        uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
+        uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
         with:
           fetch-depth: '0'
       - name: Tag release


### PR DESCRIPTION
- checkout from v2 (`pr.yml`) and v2.3.4 (`push-to-main.yml`) to v3.0.2
- setup-java from v2 to v3.2.0
- cache from v2 to v3.0.2
- upload-artifact from v2 to v3.0.0

In all cases, the main change is that the Action now runs using Node.js 16 rather than Node.js 12.

In line with our policy on GitHub Actions, consistently pin each Action to its release commit SHA rather than a version number (previously, only checkout in `push-to-main.yml` did this, being pinned to `5a4ac90`, which is v2.3.4).