### PR TITLE
BAU Fix invalid liquibase file

### DIFF
--- a/src/main/resources/migrations/0008_index_searched_columns.sql
+++ b/src/main/resources/migrations/0008_index_searched_columns.sql
@@ -1,5 +1,3 @@
---liquibase formatted sql
-
 CREATE INDEX IF NOT EXISTS webhook_delivery_queue_created_date_idx ON webhook_delivery_queue(created_date);
 CREATE INDEX IF NOT EXISTS webhook_delivery_queue_message_id_idx ON webhook_delivery_queue(webhook_message_id);
 CREATE INDEX IF NOT EXISTS webhook_delivery_queue_send_at_idx ON webhook_delivery_queue(send_at);


### PR DESCRIPTION
If liquibase picks up an sql file with no comments it will create a
default change set (in this example
`changeset:0008_index_searched_columns.sql`).

If there is a liquibase comment but no explicit `changeset` comment it
looks like the file is not run by liquibase as it doesn't apply the
default behaviour.

Remove comments to use the default liquibase changeset and rollback
behaviour for this change.