### PR TITLE
Revert "Bump dropwizard-sentry from 2.0.29 to 2.1.0"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -178,7 +178,7 @@
         <dependency>
             <groupId>org.dhatim</groupId>
             <artifactId>dropwizard-sentry</artifactId>
-            <version>2.1.0</version>
+            <version>2.0.29</version>
         </dependency>
 
         <!-- Test dependencies that use a BOM so no explicit versions needed -->


### PR DESCRIPTION
Reverts alphagov/pay-webhooks#218

This did not seem to work.