### PR TITLE
BAU Improve logging 

### DIFF
--- a/src/main/java/uk/gov/pay/webhooks/app/WebhooksKeys.java
+++ b/src/main/java/uk/gov/pay/webhooks/app/WebhooksKeys.java
@@ -1,0 +1,16 @@
+package uk.gov.pay.webhooks.app;
+
+// Non-app specific keys should move to java commons
+public final class WebhooksKeys {
+    private WebhooksKeys() { }
+
+    public static final String WEBHOOK_EXTERNAL_ID = "webhook_external_id";
+    public static final String WEBHOOK_CALLBACK_URL = "webhook_callback_url";
+    public static final String WEBHOOK_MESSAGE_EXTERNAL_ID = "webhook_message_external_id";
+    public static final String WEBHOOK_MESSAGE_RESOURCE_EXTERNAL_ID = "resource_external_id";
+    public static final String RESOURCE_IS_LIVE = "is_live";
+    public static final String JOB_BATCH_ID = "job_id";
+    public static final String ERROR_MESSAGE = "error_message";
+    public static final String WEBHOOK_MESSAGE_RETRY_COUNT = "retry_count";
+    public static final String STATE_TRANSITION_TO_STATE = "to_state";
+}

--- a/src/main/java/uk/gov/pay/webhooks/app/WebhooksKeys.java
+++ b/src/main/java/uk/gov/pay/webhooks/app/WebhooksKeys.java
@@ -13,4 +13,5 @@ public final class WebhooksKeys {
     public static final String ERROR_MESSAGE = "error_message";
     public static final String WEBHOOK_MESSAGE_RETRY_COUNT = "retry_count";
     public static final String STATE_TRANSITION_TO_STATE = "to_state";
+    public static final String WEBHOOK_CALLBACK_URL_DOMAIN = "domain";
 }

--- a/src/main/java/uk/gov/pay/webhooks/app/WebhooksKeys.java
+++ b/src/main/java/uk/gov/pay/webhooks/app/WebhooksKeys.java
@@ -14,4 +14,7 @@ public final class WebhooksKeys {
     public static final String WEBHOOK_MESSAGE_RETRY_COUNT = "retry_count";
     public static final String STATE_TRANSITION_TO_STATE = "to_state";
     public static final String WEBHOOK_CALLBACK_URL_DOMAIN = "domain";
+    public static final String SQS_MESSAGE_ID = "sqs_message_id";
+    public static final String WEBHOOK_MESSAGE_EVENT_INTERNAL_TYPE = "internal_event_type";
+    public static final String WEBHOOK_MESSAGE_TIME_TO_EMIT = "time_to_send";
 }

--- a/src/main/java/uk/gov/pay/webhooks/app/filters/LoggingMDCRequestFilter.java
+++ b/src/main/java/uk/gov/pay/webhooks/app/filters/LoggingMDCRequestFilter.java
@@ -1,0 +1,37 @@
+package uk.gov.pay.webhooks.app.filters;
+
+import org.slf4j.MDC;
+
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerRequestFilter;
+import java.util.Optional;
+
+import static uk.gov.pay.webhooks.app.WebhooksKeys.RESOURCE_IS_LIVE;
+import static uk.gov.pay.webhooks.app.WebhooksKeys.WEBHOOK_EXTERNAL_ID;
+import static uk.gov.pay.webhooks.app.WebhooksKeys.WEBHOOK_MESSAGE_EXTERNAL_ID;
+import static uk.gov.service.payments.logging.LoggingKeys.SERVICE_EXTERNAL_ID;
+
+public class LoggingMDCRequestFilter implements ContainerRequestFilter {
+    @Override
+    public void filter(ContainerRequestContext containerRequestContext) {
+        getPathParameterFromRequest("webhookExternalId", containerRequestContext)
+                .ifPresent(webhookExternalId -> MDC.put(WEBHOOK_EXTERNAL_ID, webhookExternalId));
+
+        getPathParameterFromRequest("webhookMessageExternalId", containerRequestContext)
+                .ifPresent(webhookMessageExternalId -> MDC.put(WEBHOOK_MESSAGE_EXTERNAL_ID, webhookMessageExternalId));
+
+        getQueryParameterFromRequest("service_id", containerRequestContext)
+                .ifPresent(serviceExternalId -> MDC.put(SERVICE_EXTERNAL_ID, serviceExternalId));
+
+        getQueryParameterFromRequest("live", containerRequestContext)
+                .ifPresent(isLive -> MDC.put(RESOURCE_IS_LIVE, isLive));
+    }
+
+    private Optional<String> getPathParameterFromRequest(String parameterName, ContainerRequestContext requestContext) {
+        return Optional.ofNullable(requestContext.getUriInfo().getPathParameters().getFirst(parameterName));
+    }
+
+    private Optional<String> getQueryParameterFromRequest(String queryParameterName, ContainerRequestContext requestContext) {
+        return Optional.ofNullable(requestContext.getUriInfo().getQueryParameters().getFirst(queryParameterName));
+    }
+}

--- a/src/main/java/uk/gov/pay/webhooks/app/filters/LoggingMDCResponseFilter.java
+++ b/src/main/java/uk/gov/pay/webhooks/app/filters/LoggingMDCResponseFilter.java
@@ -1,0 +1,21 @@
+package uk.gov.pay.webhooks.app.filters;
+
+import org.slf4j.MDC;
+
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerResponseContext;
+import javax.ws.rs.container.ContainerResponseFilter;
+
+import java.util.List;
+
+import static uk.gov.pay.webhooks.app.WebhooksKeys.RESOURCE_IS_LIVE;
+import static uk.gov.pay.webhooks.app.WebhooksKeys.WEBHOOK_EXTERNAL_ID;
+import static uk.gov.pay.webhooks.app.WebhooksKeys.WEBHOOK_MESSAGE_EXTERNAL_ID;
+import static uk.gov.service.payments.logging.LoggingKeys.SERVICE_EXTERNAL_ID;
+
+public class LoggingMDCResponseFilter implements ContainerResponseFilter {
+    @Override
+    public void filter(ContainerRequestContext containerRequestContext, ContainerResponseContext containerResponseContext) {
+        List.of(WEBHOOK_EXTERNAL_ID, WEBHOOK_MESSAGE_EXTERNAL_ID, SERVICE_EXTERNAL_ID, RESOURCE_IS_LIVE).forEach(MDC::remove);
+    }
+}

--- a/src/main/java/uk/gov/pay/webhooks/deliveryqueue/managed/SendAttempter.java
+++ b/src/main/java/uk/gov/pay/webhooks/deliveryqueue/managed/SendAttempter.java
@@ -29,6 +29,7 @@ import static uk.gov.pay.webhooks.app.WebhooksKeys.STATE_TRANSITION_TO_STATE;
 import static uk.gov.pay.webhooks.app.WebhooksKeys.WEBHOOK_CALLBACK_URL;
 import static uk.gov.pay.webhooks.app.WebhooksKeys.WEBHOOK_CALLBACK_URL_DOMAIN;
 import static uk.gov.pay.webhooks.app.WebhooksKeys.WEBHOOK_MESSAGE_RETRY_COUNT;
+import static uk.gov.pay.webhooks.app.WebhooksKeys.WEBHOOK_MESSAGE_TIME_TO_EMIT;
 import static uk.gov.service.payments.logging.LoggingKeys.HTTP_STATUS;
 import static uk.gov.service.payments.logging.LoggingKeys.RESPONSE_TIME;
 
@@ -61,11 +62,11 @@ public class SendAttempter {
             LOGGER.info(
                     Markers.append(WEBHOOK_CALLBACK_URL, queueItem.getWebhookMessageEntity().getWebhookEntity().getCallbackUrl())
                             .and(Markers.append(WEBHOOK_MESSAGE_RETRY_COUNT, retryCount))
-                            .and(Markers.append(WEBHOOK_CALLBACK_URL_DOMAIN, uri.getHost())),
+                            .and(Markers.append(WEBHOOK_CALLBACK_URL_DOMAIN, uri.getHost()))
+                            .and(Markers.append(WEBHOOK_MESSAGE_TIME_TO_EMIT, Duration.between(queueItem.getCreatedDate(), instantSource.instant()).toMillis())),
                     "Sending webhook message"
             ); 
             var response = webhookMessageSender.sendWebhookMessage(queueItem.getWebhookMessageEntity());
-            var responseTime = Duration.between(start, instantSource.instant());
 
             var statusCode = response.statusCode();
             if (statusCode >= 200 && statusCode <= 299) {

--- a/src/main/java/uk/gov/pay/webhooks/deliveryqueue/managed/SendAttempter.java
+++ b/src/main/java/uk/gov/pay/webhooks/deliveryqueue/managed/SendAttempter.java
@@ -2,6 +2,7 @@ package uk.gov.pay.webhooks.deliveryqueue.managed;
 
 import com.codahale.metrics.MetricRegistry;
 import io.dropwizard.setup.Environment;
+import net.logstash.logback.marker.Markers;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.pay.webhooks.deliveryqueue.dao.WebhookDeliveryQueueDao;
@@ -11,6 +12,7 @@ import uk.gov.pay.webhooks.message.WebhookMessageSender;
 import javax.inject.Inject;
 import javax.ws.rs.core.Response;
 import java.io.IOException;
+import java.net.URI;
 import java.net.http.HttpTimeoutException;
 import java.security.InvalidKeyException;
 import java.time.Duration;
@@ -22,12 +24,20 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static uk.gov.pay.webhooks.app.WebhooksKeys.ERROR_MESSAGE;
+import static uk.gov.pay.webhooks.app.WebhooksKeys.STATE_TRANSITION_TO_STATE;
+import static uk.gov.pay.webhooks.app.WebhooksKeys.WEBHOOK_CALLBACK_URL;
+import static uk.gov.pay.webhooks.app.WebhooksKeys.WEBHOOK_CALLBACK_URL_DOMAIN;
+import static uk.gov.pay.webhooks.app.WebhooksKeys.WEBHOOK_MESSAGE_RETRY_COUNT;
+import static uk.gov.service.payments.logging.LoggingKeys.HTTP_STATUS;
+import static uk.gov.service.payments.logging.LoggingKeys.RESPONSE_TIME;
+
 public class SendAttempter {
     private static final Logger LOGGER = LoggerFactory.getLogger(SendAttempter.class);
     private final MetricRegistry metricRegistry;
-    private WebhookDeliveryQueueDao webhookDeliveryQueueDao;
-    private InstantSource instantSource;
-    private WebhookMessageSender webhookMessageSender;
+    private final WebhookDeliveryQueueDao webhookDeliveryQueueDao;
+    private final InstantSource instantSource;
+    private final WebhookMessageSender webhookMessageSender;
 
     @Inject
     public SendAttempter(WebhookDeliveryQueueDao webhookDeliveryQueueDao,
@@ -45,43 +55,66 @@ public class SendAttempter {
         Instant start = instantSource.instant();
 
         try {
-            LOGGER.info("Attempting to send Webhook ID %s to %s".formatted(queueItem.getWebhookMessageEntity().getExternalId(), queueItem.getWebhookMessageEntity().getWebhookEntity().getCallbackUrl()));
+            var url = queueItem.getWebhookMessageEntity().getWebhookEntity().getCallbackUrl();
+            var uri = new URI(url);
+            
+            LOGGER.info(
+                    Markers.append(WEBHOOK_CALLBACK_URL, queueItem.getWebhookMessageEntity().getWebhookEntity().getCallbackUrl())
+                            .and(Markers.append(WEBHOOK_MESSAGE_RETRY_COUNT, retryCount))
+                            .and(Markers.append(WEBHOOK_CALLBACK_URL_DOMAIN, uri.getHost())),
+                    "Sending webhook message"
+            ); 
             var response = webhookMessageSender.sendWebhookMessage(queueItem.getWebhookMessageEntity());
             var responseTime = Duration.between(start, instantSource.instant());
 
             var statusCode = response.statusCode();
             if (statusCode >= 200 && statusCode <= 299) {
-                LOGGER.info("Message attempt succeeded with %s".formatted(statusCode));
-                webhookDeliveryQueueDao.recordResult(queueItem, getReasonFromStatusCode(statusCode), responseTime, statusCode, WebhookDeliveryQueueEntity.DeliveryStatus.SUCCESSFUL, metricRegistry);
+                handleResponse(queueItem, WebhookDeliveryQueueEntity.DeliveryStatus.SUCCESSFUL, statusCode, getReasonFromStatusCode(statusCode), retryCount, start);
             } else {
-                LOGGER.info("Message attempt failed with %s".formatted(statusCode));
-                webhookDeliveryQueueDao.recordResult(queueItem, getReasonFromStatusCode(statusCode), responseTime, statusCode, WebhookDeliveryQueueEntity.DeliveryStatus.FAILED, metricRegistry);
-                enqueueRetry(queueItem, nextRetryIn(retryCount));
+                handleResponse(queueItem, WebhookDeliveryQueueEntity.DeliveryStatus.FAILED, statusCode, getReasonFromStatusCode(statusCode), retryCount, start);
             }
         } catch (HttpTimeoutException e) {
-            var responseTime = Duration.between(start, instantSource.instant());
-            LOGGER.info("HTTP timeout exception %s".formatted(e.toString()));
-            webhookDeliveryQueueDao.recordResult(queueItem, "HTTP Timeout", responseTime, null, WebhookDeliveryQueueEntity.DeliveryStatus.FAILED, metricRegistry);
-            enqueueRetry(queueItem, nextRetryIn(retryCount));
+            LOGGER.info("Request timed out");
+            handleResponse(queueItem, WebhookDeliveryQueueEntity.DeliveryStatus.FAILED, null, "HTTP Timeout", retryCount, start);
         } catch (IOException | InterruptedException | InvalidKeyException e) {
-            var responseTime = Duration.between(start, instantSource.instant());
-            LOGGER.warn("Exception %s attempting to send webhook message ID: %s".formatted(e.getMessage(), queueItem.getWebhookMessageEntity().getExternalId()));
-            webhookDeliveryQueueDao.recordResult(queueItem, e.getMessage(), responseTime, null, WebhookDeliveryQueueEntity.DeliveryStatus.FAILED, metricRegistry);
-            enqueueRetry(queueItem, nextRetryIn(retryCount));
+            LOGGER.info(
+                    Markers.append(ERROR_MESSAGE, e.getMessage()),
+                    "Exception caught by request"
+            );
+            handleResponse(queueItem, WebhookDeliveryQueueEntity.DeliveryStatus.FAILED, null, e.getMessage(), retryCount, start);
         } catch (Exception e) {
             var responseTime = Duration.between(start, instantSource.instant());
             // handle all exceptions at this level to make sure that the retry mechanism is allowed to work as designed
             // allowing errors passed this point (not guaranteeing an update) would allow perpetual failures 
-            LOGGER.warn("Unexpected exception %s attempting to send webhook message ID: %s".formatted(e.getMessage(), queueItem.getWebhookMessageEntity().getExternalId()));
-            webhookDeliveryQueueDao.recordResult(queueItem, "Unknown error", responseTime, null, WebhookDeliveryQueueEntity.DeliveryStatus.FAILED, metricRegistry);
-            enqueueRetry(queueItem, nextRetryIn(retryCount));
+            LOGGER.warn(
+                    Markers.append(ERROR_MESSAGE, e.getMessage()),
+                    "Unexpected exception thrown by request"
+            );
+            handleResponse(queueItem, WebhookDeliveryQueueEntity.DeliveryStatus.FAILED, null, "Unknown error", retryCount, start);
+        }
+    }
+    
+    private void handleResponse(WebhookDeliveryQueueEntity webhookDeliveryQueueEntity, WebhookDeliveryQueueEntity.DeliveryStatus status, Integer statusCode, String reason, Long retryCount, Instant startTime) {
+        var responseTime = Duration.between(startTime, instantSource.instant());
+        LOGGER.info(
+                Markers.append(HTTP_STATUS, statusCode)
+                        .and(Markers.append(WEBHOOK_MESSAGE_RETRY_COUNT, retryCount))
+                        .and(Markers.append(STATE_TRANSITION_TO_STATE, status))
+                        .and(Markers.append(RESPONSE_TIME, responseTime)),
+                "Sending webhook message finished"
+        ); 
+        webhookDeliveryQueueDao.recordResult(webhookDeliveryQueueEntity, reason, responseTime, statusCode, status, metricRegistry);
+        
+        if (!status.equals(WebhookDeliveryQueueEntity.DeliveryStatus.SUCCESSFUL)) {
+            enqueueRetry(webhookDeliveryQueueEntity, nextRetryIn(retryCount));
         }
     }
 
     private void enqueueRetry(WebhookDeliveryQueueEntity queueItem, Duration nextRetryIn) {
-        Optional.ofNullable(nextRetryIn).ifPresent(
-                retryDelay -> webhookDeliveryQueueDao.enqueueFrom(queueItem.getWebhookMessageEntity(), WebhookDeliveryQueueEntity.DeliveryStatus.PENDING, instantSource.instant().plus(retryDelay))
-        );
+        Optional.ofNullable(nextRetryIn).ifPresent(retryDelay -> {
+            LOGGER.info("Scheduling webhook message for retry");
+            webhookDeliveryQueueDao.enqueueFrom(queueItem.getWebhookMessageEntity(), WebhookDeliveryQueueEntity.DeliveryStatus.PENDING, instantSource.instant().plus(retryDelay));
+        });
     }
 
     private Duration nextRetryIn(Long retryCount) {

--- a/src/main/java/uk/gov/pay/webhooks/deliveryqueue/managed/WebhookMessagePollingService.java
+++ b/src/main/java/uk/gov/pay/webhooks/deliveryqueue/managed/WebhookMessagePollingService.java
@@ -1,11 +1,20 @@
 package uk.gov.pay.webhooks.deliveryqueue.managed;
 
 import io.dropwizard.hibernate.UnitOfWork;
+import org.slf4j.MDC;
 import uk.gov.pay.webhooks.deliveryqueue.dao.WebhookDeliveryQueueDao;
 import uk.gov.pay.webhooks.deliveryqueue.dao.WebhookDeliveryQueueEntity;
 
 import javax.inject.Inject;
+import java.util.List;
 import java.util.Optional;
+import java.util.UUID;
+
+import static uk.gov.pay.webhooks.app.WebhooksKeys.JOB_BATCH_ID;
+import static uk.gov.pay.webhooks.app.WebhooksKeys.WEBHOOK_EXTERNAL_ID;
+import static uk.gov.pay.webhooks.app.WebhooksKeys.WEBHOOK_MESSAGE_EXTERNAL_ID;
+import static uk.gov.pay.webhooks.app.WebhooksKeys.WEBHOOK_MESSAGE_RESOURCE_EXTERNAL_ID;
+import static uk.gov.service.payments.logging.LoggingKeys.MDC_REQUEST_ID_KEY;
 
 public class WebhookMessagePollingService {
     private final WebhookDeliveryQueueDao webhookDeliveryQueueDao;
@@ -19,18 +28,29 @@ public class WebhookMessagePollingService {
 
     public void pollWebhookMessageQueue() {
         Optional<WebhookDeliveryQueueEntity> attemptCursor;
+        MDC.put(JOB_BATCH_ID, UUID.randomUUID().toString());
 
         do {
             attemptCursor = sendIfAvailable();
         } while(attemptCursor.isPresent());
+        MDC.remove(JOB_BATCH_ID);
     }
 
     @UnitOfWork
     protected Optional<WebhookDeliveryQueueEntity> sendIfAvailable() {
-        return webhookDeliveryQueueDao.nextToSend()
+        MDC.put(MDC_REQUEST_ID_KEY, UUID.randomUUID().toString());
+
+        var sendAttempt = webhookDeliveryQueueDao.nextToSend()
                 .map(webhookDeliveryQueueEntity -> {
+                    MDC.put(WEBHOOK_EXTERNAL_ID, webhookDeliveryQueueEntity.getWebhookMessageEntity().getWebhookEntity().getExternalId());
+                    MDC.put(WEBHOOK_MESSAGE_RESOURCE_EXTERNAL_ID, webhookDeliveryQueueEntity.getWebhookMessageEntity().getResourceExternalId());
+                    MDC.put(WEBHOOK_MESSAGE_EXTERNAL_ID, webhookDeliveryQueueEntity.getWebhookMessageEntity().getExternalId());
+
                     sendAttempter.attemptSend(webhookDeliveryQueueEntity);
                     return webhookDeliveryQueueEntity;
                 });
+
+        List.of(MDC_REQUEST_ID_KEY, WEBHOOK_EXTERNAL_ID, WEBHOOK_MESSAGE_RESOURCE_EXTERNAL_ID).forEach(MDC::remove);
+        return sendAttempt;
     }
 }

--- a/src/main/java/uk/gov/pay/webhooks/queue/QueueMessageReceiver.java
+++ b/src/main/java/uk/gov/pay/webhooks/queue/QueueMessageReceiver.java
@@ -6,12 +6,16 @@ import io.dropwizard.lifecycle.Managed;
 import io.dropwizard.setup.Environment;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
 import uk.gov.pay.webhooks.app.QueueMessageReceiverConfig;
 import uk.gov.pay.webhooks.app.WebhooksConfig;
 import uk.gov.pay.webhooks.message.WebhookMessageService;
 
+import java.util.UUID;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
+
+import static uk.gov.pay.webhooks.app.WebhooksKeys.JOB_BATCH_ID;
 
 public class QueueMessageReceiver implements Managed {
 
@@ -62,11 +66,13 @@ public class QueueMessageReceiver implements Managed {
     }
 
     private void receive() {
-        LOGGER.info("Queue message receiver thread polling queue");
         try {
+            MDC.put(JOB_BATCH_ID, UUID.randomUUID().toString());
             eventMessageHandler.handle();
         } catch (Exception e) {
             LOGGER.error("Queue message receiver thread exception", e);
+        } finally {
+            MDC.remove(JOB_BATCH_ID);
         }
     }
 

--- a/src/main/java/uk/gov/pay/webhooks/webhook/resource/WebhookResource.java
+++ b/src/main/java/uk/gov/pay/webhooks/webhook/resource/WebhookResource.java
@@ -71,7 +71,7 @@ public class WebhookResource {
 
     @UnitOfWork
     @GET
-    @Path("/{externalId}")
+    @Path("/{webhookExternalId}")
     @Operation(
             summary = "Get webhook by external ID and service ID (query param)",
             responses = {
@@ -80,7 +80,7 @@ public class WebhookResource {
             }
     )
     public WebhookResponse getWebhookByExternalId(@Parameter(example = "gh0d0923jpsjdf0923jojlsfgkw3seg")
-                                                  @PathParam("externalId") @NotNull String externalId,
+                                                  @PathParam("webhookExternalId") @NotNull String externalId,
                                                   @Parameter(example = "eo29upsdkjlk3jpwjj2dfn12")
                                                   @QueryParam("service_id") @NotNull String serviceId) {
         return webhookService
@@ -92,7 +92,7 @@ public class WebhookResource {
 
     @UnitOfWork
     @GET
-    @Path("/{externalId}/signing-key")
+    @Path("/{webhookExternalId}/signing-key")
     @Operation(
             summary = "Get webhook signing key by external ID",
             responses = {
@@ -101,7 +101,7 @@ public class WebhookResource {
             }
     )
     public SigningKeyResponse getSigningKeyByExternalId(@Parameter(example = "gh0d0923jpsjdf0923jojlsfgkw3seg")
-                                                        @PathParam("externalId") @NotNull String externalId,
+                                                        @PathParam("webhookExternalId") @NotNull String externalId,
                                                         @Parameter(example = "eo29upsdkjlk3jpwjj2dfn12")
                                                         @QueryParam("service_id") @NotNull String serviceId) {
         return webhookService
@@ -113,7 +113,7 @@ public class WebhookResource {
 
     @UnitOfWork
     @POST
-    @Path("/{externalId}/signing-key")
+    @Path("/{webhookExternalId}/signing-key")
     @Operation(
             summary = "Regenerate webhook signing key",
             responses = {
@@ -122,7 +122,7 @@ public class WebhookResource {
             }
     )
     public SigningKeyResponse regenerateSigningKey(@Parameter(example = "gh0d0923jpsjdf0923jojlsfgkw3seg")
-                                                   @PathParam("externalId") @NotNull String externalId,
+                                                   @PathParam("webhookExternalId") @NotNull String externalId,
                                                    @Parameter(example = "eo29upsdkjlk3jpwjj2dfn12")
                                                    @QueryParam("service_id") @NotNull String serviceId) {
         return webhookService.regenerateSigningKey(externalId, serviceId)
@@ -163,7 +163,7 @@ public class WebhookResource {
     }
 
     @UnitOfWork
-    @Path("/{externalId}/message")
+    @Path("/{webhookExternalId}/message")
     @GET
     @Operation(
             summary = "Get webhook messages by webhook external ID",
@@ -172,7 +172,7 @@ public class WebhookResource {
             }
     )
     public WebhookMessageSearchResponse getWebhookMessages(
-            @Parameter(example = "gh0d0923jpsjdf0923jojlsfgkw3seg") @PathParam("externalId") String externalId,
+            @Parameter(example = "gh0d0923jpsjdf0923jojlsfgkw3seg") @PathParam("webhookExternalId") String externalId,
             @Parameter(example = "1") @QueryParam("page") Integer page,
             @Parameter(example = "SUCCESSFUL") @Valid @QueryParam("status") WebhookDeliveryQueueEntity.DeliveryStatus status
     ) {
@@ -185,7 +185,7 @@ public class WebhookResource {
     }
 
     @UnitOfWork
-    @Path("/{externalId}/message/{messageId}")
+    @Path("/{webhookExternalId}/message/{webhookMessageExternalId}")
     @GET
     @Operation(
             summary = "Get messages by webhook external ID and message ID",
@@ -194,14 +194,14 @@ public class WebhookResource {
             }
     )
     public WebhookMessageResponse getWebhookMessage(
-            @Schema(example = "gh0d0923jpsjdf0923jojlsfgkw3seg") @PathParam("externalId") String externalId,
-            @Schema(example = "s0wjen129ejalk21nfjkdknf1jejklh") @PathParam("messageId") String messageId
+            @Schema(example = "gh0d0923jpsjdf0923jojlsfgkw3seg") @PathParam("webhookExternalId") String externalId,
+            @Schema(example = "s0wjen129ejalk21nfjkdknf1jejklh") @PathParam("webhookMessageExternalId") String messageId
     ) {
         return webhookService.getMessage(externalId, messageId);
     }
 
     @UnitOfWork
-    @Path("/{externalId}/message/{messageId}/attempt")
+    @Path("/{webhookExternalId}/message/{webhookMessageExternalId}/attempt")
     @GET
     @Operation(
             summary = "Get message attempts for webhook external ID and message ID",
@@ -210,15 +210,15 @@ public class WebhookResource {
             }
     )
     public List<WebhookDeliveryQueueResponse> getWebhookMessageAttemps(
-            @Schema(example = "gh0d0923jpsjdf0923jojlsfgkw3seg") @PathParam("externalId") String externalId,
-            @Schema(example = "s0wjen129ejalk21nfjkdknf1jejklh") @PathParam("messageId") String messageId
+            @Schema(example = "gh0d0923jpsjdf0923jojlsfgkw3seg") @PathParam("webhookExternalId") String externalId,
+            @Schema(example = "s0wjen129ejalk21nfjkdknf1jejklh") @PathParam("webhookMessageExternalId") String messageId
     ) {
         return webhookService.listMessageAttempts(externalId, messageId);
     }
 
     @UnitOfWork
     @PATCH
-    @Path("/{externalId}")
+    @Path("/{webhookExternalId}")
     @Operation(
             summary = "Update webhook",
             description = "Allows patching `description, callback_url, status, subscriptions`",
@@ -227,7 +227,7 @@ public class WebhookResource {
                     @ApiResponse(responseCode = "400", description = "Invalid payload")
             }
     )
-    public WebhookResponse updateWebhook(@Parameter(example = "gh0d0923jpsjdf0923jojlsfgkw3seg") @PathParam("externalId") @NotNull String externalId,
+    public WebhookResponse updateWebhook(@Parameter(example = "gh0d0923jpsjdf0923jojlsfgkw3seg") @PathParam("webhookExternalId") @NotNull String externalId,
                                          @Parameter(example = "eo29upsdkjlk3jpwjj2dfn12") @QueryParam("service_id") @NotNull String serviceId,
                                          @ArraySchema(schema = @Schema(example = "{" +
                                                  "                            \"path\": \"description\"," +
@@ -245,6 +245,4 @@ public class WebhookResource {
                 .toList();
         return WebhookResponse.from(webhookService.update(externalId, serviceId, patchRequests));
     }
-
-
 }


### PR DESCRIPTION
For consistency with other apps, add the commons `LoggingFilter` for
structured request logs.

Add a custom request filter to take webhook context specific vars from
the path and query params and provide them to all subsequent logs.

Add structured logs to the two main webhook processes 
* recording messages to be sent by consuming the event stream
* sending webhook messages

----

Refactor code for sending messages to have a single method to handle
responses. This allows us to uniformly add a structured log that will be
easy to grep/ process in Splunk.

---

Tests should still pass.