### PR TITLE
BAU Filter out events that don't contain service id or live properties

### DIFF
--- a/src/main/java/uk/gov/pay/webhooks/app/WebhooksKeys.java
+++ b/src/main/java/uk/gov/pay/webhooks/app/WebhooksKeys.java
@@ -10,6 +10,7 @@ public final class WebhooksKeys {
     public static final String WEBHOOK_MESSAGE_RESOURCE_EXTERNAL_ID = "resource_external_id";
     public static final String RESOURCE_IS_LIVE = "is_live";
     public static final String JOB_BATCH_ID = "job_id";
+    public static final String ERROR = "error";
     public static final String ERROR_MESSAGE = "error_message";
     public static final String WEBHOOK_MESSAGE_RETRY_COUNT = "retry_count";
     public static final String STATE_TRANSITION_TO_STATE = "to_state";

--- a/src/main/java/uk/gov/pay/webhooks/queue/EventMessageDto.java
+++ b/src/main/java/uk/gov/pay/webhooks/queue/EventMessageDto.java
@@ -13,7 +13,7 @@ import java.time.Instant;
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public record EventMessageDto(@JsonProperty("service_id") String serviceId,
-                              Boolean live,
+                              @JsonProperty("live") Boolean live,
                               @JsonProperty("timestamp") @JsonDeserialize(using = InstantDeserializer.class) Instant timestamp,
                               @JsonProperty("resource_external_id") String resourceExternalId,
                               @JsonProperty("parent_resource_external_id") String parentResourceExternalId,

--- a/src/main/java/uk/gov/pay/webhooks/queue/EventMessageHandler.java
+++ b/src/main/java/uk/gov/pay/webhooks/queue/EventMessageHandler.java
@@ -15,6 +15,7 @@ import java.util.Optional;
 import java.util.UUID;
 
 import static net.logstash.logback.argument.StructuredArguments.kv;
+import static uk.gov.pay.webhooks.app.WebhooksKeys.ERROR;
 import static uk.gov.pay.webhooks.app.WebhooksKeys.ERROR_MESSAGE;
 import static uk.gov.pay.webhooks.app.WebhooksKeys.JOB_BATCH_ID;
 import static uk.gov.pay.webhooks.app.WebhooksKeys.RESOURCE_IS_LIVE;
@@ -64,8 +65,9 @@ public class EventMessageHandler {
             webhookMessageService.handleInternalEvent(event);
             eventQueue.markMessageAsProcessed(message);
         } catch (Exception e) {
-            LOGGER.error(
-                    Markers.append(ERROR_MESSAGE, e.getMessage()),
+            LOGGER.warn(
+                    Markers.append(ERROR_MESSAGE, e.getMessage())
+                            .and(Markers.append(ERROR, e)),
                     "Event message scheduled for retry"
             );
             eventQueue.scheduleMessageForRetry(message);

--- a/src/main/java/uk/gov/pay/webhooks/queue/EventQueue.java
+++ b/src/main/java/uk/gov/pay/webhooks/queue/EventQueue.java
@@ -57,6 +57,10 @@ public class EventQueue {
             //               to see if this should be unpacked here or if something can be optimised with the publish
             SNSMessageDto snsMessageDto = objectMapper.readValue(queueMessage.messageBody(), SNSMessageDto.class);
             EventMessageDto eventMessageDto = objectMapper.readValue(snsMessageDto.Message(), EventMessageDto.class);
+            if (eventMessageDto.live() == null || eventMessageDto.serviceId() == null) {
+                LOGGER.warn("Unable to process events without `service_id` or `live` properties");
+                return null;
+            }
             return EventMessage.of(eventMessageDto, queueMessage);
         } catch (IOException e) {
             LOGGER.warn(

--- a/src/main/java/uk/gov/pay/webhooks/queue/InternalEvent.java
+++ b/src/main/java/uk/gov/pay/webhooks/queue/InternalEvent.java
@@ -1,6 +1,5 @@
 package uk.gov.pay.webhooks.queue;
 
-import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import uk.gov.pay.webhooks.util.MicrosecondPrecisionInstantSerializer;
 

--- a/src/test/java/uk/gov/pay/webhooks/queue/EventQueueTest.java
+++ b/src/test/java/uk/gov/pay/webhooks/queue/EventQueueTest.java
@@ -1,0 +1,89 @@
+package uk.gov.pay.webhooks.queue;
+
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.classic.spi.LoggingEvent;
+import ch.qos.logback.core.Appender;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.slf4j.LoggerFactory;
+import uk.gov.pay.webhooks.app.SqsConfig;
+import uk.gov.pay.webhooks.app.WebhooksConfig;
+import uk.gov.pay.webhooks.queue.sqs.QueueException;
+import uk.gov.pay.webhooks.queue.sqs.QueueMessage;
+import uk.gov.pay.webhooks.queue.sqs.SqsQueueService;
+
+import java.util.List;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+
+@ExtendWith(MockitoExtension.class)
+class EventQueueTest {
+    @Mock
+    private Appender<ILoggingEvent> mockAppender;
+    @Captor
+    private ArgumentCaptor<LoggingEvent> loggingEventArgumentCaptor;
+    @Mock
+    private SqsQueueService sqsQueueService;
+    @Mock
+    private SqsConfig sqsConfig;
+    @Mock
+    private WebhooksConfig webhooksConfig;
+    private EventQueue eventQueue;
+
+    @BeforeEach
+    public void setUp() {
+        when(sqsConfig.getEventQueueUrl()).thenReturn("sqs://queue-url.test");
+        when(webhooksConfig.getSqsConfig()).thenReturn(sqsConfig);
+        eventQueue = new EventQueue(sqsQueueService, webhooksConfig, new ObjectMapper());
+    }
+
+    @Test
+    public void shouldFilterEventsWithoutValidPropertiesAndLog() throws QueueException {
+        Logger root = (Logger) LoggerFactory.getLogger(EventQueue.class);
+        root.addAppender(mockAppender);
+
+        var sqsMessageWithMissingServiceId = """
+                {
+                  "Message" : "{\\"sqs_message_id\\":\\"dc142884-1e4b-4e57-be93-111b692a4868\\",\\"live\\":false,\\"resource_type\\":\\"payment\\",\\"resource_external_id\\":\\"t8cj9v1lci7da7pbp99qg9olv3\\",\\"parent_resource_external_id\\":null,\\"timestamp\\":\\"2019-08-31T14:18:46.446541Z\\",\\"event_type\\":\\"PAYMENT_DETAILS_ENTERED\\",\\"reproject_domain_object\\":false}"
+                }
+                """;
+        var sqsMessageWithMissingLiveProperty = """
+                {
+                  "Message" : "{\\"sqs_message_id\\":\\"dc142884-1e4b-4e57-be93-111b692a4868\\",\\"service_id\\":\\"some-service-id\\",\\"resource_type\\":\\"payment\\",\\"resource_external_id\\":\\"t8cj9v1lci7da7pbp99qg9olv3\\",\\"parent_resource_external_id\\":null,\\"timestamp\\":\\"2019-08-31T14:18:46.446541Z\\",\\"event_type\\":\\"PAYMENT_DETAILS_ENTERED\\",\\"reproject_domain_object\\":false}"
+                }
+                """;
+        var sqsMessageWithValidProperties = """
+                {
+                  "Message" : "{\\"sqs_message_id\\":\\"dc142884-1e4b-4e57-be93-111b692a4868\\",\\"service_id\\":\\"some-service-id\\",\\"live\\":false,\\"resource_type\\":\\"payment\\",\\"resource_external_id\\":\\"t8cj9v1lci7da7pbp99qg9olv3\\",\\"parent_resource_external_id\\":null,\\"timestamp\\":\\"2019-08-31T14:18:46.446541Z\\",\\"event_type\\":\\"PAYMENT_DETAILS_ENTERED\\",\\"reproject_domain_object\\":false}"
+                }
+                """;
+        var queueMessageWithMissingServiceId = new QueueMessage("message-id-missing-service-id", "some-receipt-handle", sqsMessageWithMissingServiceId);
+        var queueMessageWithMissingLiveProperty = new QueueMessage("message-id-missing-live-property", "some-receipt-handle", sqsMessageWithMissingLiveProperty);
+        var queueMessageWithValidProperties = new QueueMessage("message-id-valid-properties", "some-receipt-handle", sqsMessageWithValidProperties);
+        when(sqsQueueService.receiveMessages("sqs://queue-url.test", "All")).thenReturn(List.of(queueMessageWithMissingServiceId, queueMessageWithMissingLiveProperty, queueMessageWithValidProperties));
+
+        var results = eventQueue.retrieveEvents();
+
+        verify(mockAppender, times(2)).doAppend(loggingEventArgumentCaptor.capture());
+        var logs = loggingEventArgumentCaptor.getAllValues();
+        assertThat(logs.get(0).getMessage(), containsString("Unable to process events without `service_id` or `live` properties"));
+        assertThat(logs.get(1).getMessage(), containsString("Unable to process events without `service_id` or `live` properties"));
+        assertThat(results.size(), is(1));
+        assertThat(results.get(0).queueMessage().messageId(), is("message-id-valid-properties"));
+    }
+
+}


### PR DESCRIPTION
The deployed event message handler is failing to process some messages
emitted by connector that are missing service id and live properties.
This could eventually be a pact contract requirement for system events
however for now the process should be able to manage this case (in
favour of NPE).

Check for these properties before using them to check for webhook
subscriptions with the DAO.

Add coverage to check that events missing these properties are filtered
out before being handed to the webhook message processing code.

Change the event handling rescheduling log from an error to a warn, this
error should be on events eventually making their way to the dead letter
queue.