### PR TITLE
BAU — Only specify Java 17 once in the Maven POM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,10 +17,8 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <mainClass>uk.gov.pay.webhooks.app.WebhooksApp</mainClass>
-        <maven.compiler.source>17</maven.compiler.source>
-        <maven.compiler.target>17</maven.compiler.target>
         <pay-java-commons.version>1.0.20220726103109</pay-java-commons.version>
-        <swaggger-version>2.2.2</swaggger-version>
+        <swagger-version>2.2.2</swagger-version>
     </properties>
 
     <dependencyManagement>
@@ -236,7 +234,7 @@
         <dependency>
             <groupId>io.swagger.core.v3</groupId>
             <artifactId>swagger-annotations</artifactId>
-            <version>${swaggger-version}</version>
+            <version>${swagger-version}</version>
         </dependency>
     </dependencies>
 
@@ -336,7 +334,7 @@
             <plugin>
                 <groupId>io.swagger.core.v3</groupId>
                 <artifactId>swagger-maven-plugin</artifactId>
-                <version>${swaggger-version}</version>
+                <version>${swagger-version}</version>
                 <configuration>
                     <outputPath>openapi</outputPath>
                     <outputFileName>webhooks_spec</outputFileName>


### PR DESCRIPTION
`<maven.compiler.source>17</maven.compiler.source>` and `<maven.compiler.target>17</maven.compiler.target>` have the effect of passing `-source 17` and `-target 17` to the Java compiler.

However, in the `maven-compiler-plugin` block, we already have `<configuration><release>17</release></configuration>`, which passes `-release 17` to the Java compiler. The `-release` option makes both `-source` and `-target` redundant.

Remove `<maven.compiler.source>17</maven.compiler.source>` and `<maven.compiler.target>17</maven.compiler.target>` so we only specify Java 17 once.

Also change `swaggger-version` to `swagger-version` — too many g’s!