### PR TITLE
PP-9016 Hook callback URL validation into create and update

### DIFF
--- a/src/main/java/uk/gov/pay/webhooks/app/WebhooksApp.java
+++ b/src/main/java/uk/gov/pay/webhooks/app/WebhooksApp.java
@@ -23,6 +23,8 @@ import uk.gov.pay.webhooks.healthcheck.Ping;
 import uk.gov.pay.webhooks.message.dao.entity.WebhookMessageEntity;
 import uk.gov.pay.webhooks.queue.QueueMessageReceiver;
 import uk.gov.pay.webhooks.webhook.dao.entity.WebhookEntity;
+import uk.gov.pay.webhooks.webhook.exception.ValidationExceptionMapper;
+import uk.gov.pay.webhooks.webhook.exception.WebhookExceptionMapper;
 import uk.gov.pay.webhooks.webhook.resource.WebhookResource;
 import uk.gov.service.payments.commons.utils.healthchecks.DatabaseHealthCheck;
 import uk.gov.service.payments.commons.utils.metrics.DatabaseMetricsService;
@@ -69,6 +71,9 @@ public class WebhooksApp extends Application<WebhooksConfig> {
         environment.healthChecks().register("database", new DatabaseHealthCheck(configuration.getDataSourceFactory()));
         environment.jersey().register(injector.getInstance(HealthCheckResource.class));
         environment.jersey().register(injector.getInstance(WebhookResource.class));
+
+        environment.jersey().register(new ValidationExceptionMapper());
+        environment.jersey().register(new WebhookExceptionMapper());
 
         if (configuration.getQueueMessageReceiverConfig().isBackgroundProcessingEnabled()) {
             environment.lifecycle().manage(injector.getInstance(QueueMessageReceiver.class));

--- a/src/main/java/uk/gov/pay/webhooks/app/WebhooksConfig.java
+++ b/src/main/java/uk/gov/pay/webhooks/app/WebhooksConfig.java
@@ -6,7 +6,6 @@ import io.dropwizard.db.DataSourceFactory;
 
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
-import java.util.List;
 import java.util.Set;
 
 public class WebhooksConfig extends Configuration {
@@ -72,10 +71,12 @@ public class WebhooksConfig extends Configuration {
     public String getGraphitePort() {
         return graphitePort;
     }
-   
-    private Set<String> liveDataAllowHosts;
 
-    public Set<String> getLiveDataAllowHosts() {
-        return liveDataAllowHosts;
+    @NotNull
+    @JsonProperty("liveDataAllowDomains")
+    private Set<String> liveDataAllowDomains;
+
+    public Set<String> getLiveDataAllowDomains() {
+        return liveDataAllowDomains;
     }
 }

--- a/src/main/java/uk/gov/pay/webhooks/validations/CallbackUrlDomainNotOnAllowListException.java
+++ b/src/main/java/uk/gov/pay/webhooks/validations/CallbackUrlDomainNotOnAllowListException.java
@@ -1,9 +1,11 @@
 package uk.gov.pay.webhooks.validations;
 
-public class CallbackUrlDomainNotOnAllowListException extends RuntimeException {
+import uk.gov.pay.webhooks.webhook.exception.WebhooksException;
+
+public class CallbackUrlDomainNotOnAllowListException extends WebhooksException {
 
     public CallbackUrlDomainNotOnAllowListException(String message) {
-        super(message);
+        super(message, IDENTIFIER_CALLBACK_URL_NOT_ON_ALLOW_LIST);
     }
 
 }

--- a/src/main/java/uk/gov/pay/webhooks/validations/CallbackUrlDomainNotOnAllowListException.java
+++ b/src/main/java/uk/gov/pay/webhooks/validations/CallbackUrlDomainNotOnAllowListException.java
@@ -1,11 +1,12 @@
 package uk.gov.pay.webhooks.validations;
 
+import uk.gov.pay.webhooks.webhook.exception.WebhooksErrorIdentifier;
 import uk.gov.pay.webhooks.webhook.exception.WebhooksException;
 
 public class CallbackUrlDomainNotOnAllowListException extends WebhooksException {
 
     public CallbackUrlDomainNotOnAllowListException(String message) {
-        super(message, IDENTIFIER_CALLBACK_URL_NOT_ON_ALLOW_LIST);
+        super(message, WebhooksErrorIdentifier.CALLBACK_URL_NOT_ON_ALLOW_LIST);
     }
 
 }

--- a/src/main/java/uk/gov/pay/webhooks/validations/CallbackUrlMalformedException.java
+++ b/src/main/java/uk/gov/pay/webhooks/validations/CallbackUrlMalformedException.java
@@ -1,9 +1,11 @@
 package uk.gov.pay.webhooks.validations;
 
-public class CallbackUrlMalformedException extends RuntimeException {
+import uk.gov.pay.webhooks.webhook.exception.WebhooksException;
+
+public class CallbackUrlMalformedException extends WebhooksException {
 
     public CallbackUrlMalformedException(String message) {
-        super(message);
+        super(message, IDENTIFIER_CALLBACK_URL_MALFORMED);
     }
 
 }

--- a/src/main/java/uk/gov/pay/webhooks/validations/CallbackUrlMalformedException.java
+++ b/src/main/java/uk/gov/pay/webhooks/validations/CallbackUrlMalformedException.java
@@ -1,11 +1,12 @@
 package uk.gov.pay.webhooks.validations;
 
+import uk.gov.pay.webhooks.webhook.exception.WebhooksErrorIdentifier;
 import uk.gov.pay.webhooks.webhook.exception.WebhooksException;
 
 public class CallbackUrlMalformedException extends WebhooksException {
 
     public CallbackUrlMalformedException(String message) {
-        super(message, IDENTIFIER_CALLBACK_URL_MALFORMED);
+        super(message, WebhooksErrorIdentifier.CALLBACK_URL_MALFORMED);
     }
 
 }

--- a/src/main/java/uk/gov/pay/webhooks/validations/CallbackUrlProtocolNotSupported.java
+++ b/src/main/java/uk/gov/pay/webhooks/validations/CallbackUrlProtocolNotSupported.java
@@ -1,9 +1,11 @@
 package uk.gov.pay.webhooks.validations;
 
-public class CallbackUrlProtocolNotSupported extends RuntimeException {
+import uk.gov.pay.webhooks.webhook.exception.WebhooksException;
+
+public class CallbackUrlProtocolNotSupported extends WebhooksException {
 
     public CallbackUrlProtocolNotSupported(String message) {
-        super(message);
+        super(message, IDENTIFIER_CALLBACK_URL_PROTOCOL_NOT_SUPPORTED);
     }
 
 }

--- a/src/main/java/uk/gov/pay/webhooks/validations/CallbackUrlProtocolNotSupported.java
+++ b/src/main/java/uk/gov/pay/webhooks/validations/CallbackUrlProtocolNotSupported.java
@@ -1,11 +1,12 @@
 package uk.gov.pay.webhooks.validations;
 
+import uk.gov.pay.webhooks.webhook.exception.WebhooksErrorIdentifier;
 import uk.gov.pay.webhooks.webhook.exception.WebhooksException;
 
 public class CallbackUrlProtocolNotSupported extends WebhooksException {
 
     public CallbackUrlProtocolNotSupported(String message) {
-        super(message, IDENTIFIER_CALLBACK_URL_PROTOCOL_NOT_SUPPORTED);
+        super(message, WebhooksErrorIdentifier.CALLBACK_URL_PROTOCOL_NOT_SUPPORTED);
     }
 
 }

--- a/src/main/java/uk/gov/pay/webhooks/validations/CallbackUrlService.java
+++ b/src/main/java/uk/gov/pay/webhooks/validations/CallbackUrlService.java
@@ -1,6 +1,7 @@
 package uk.gov.pay.webhooks.validations;
 
 import com.google.common.net.InternetDomainName;
+import com.google.inject.Inject;
 import org.apache.commons.lang3.StringUtils;
 import uk.gov.pay.webhooks.app.WebhooksConfig;
 
@@ -13,18 +14,19 @@ import static java.util.stream.Collectors.toUnmodifiableSet;
 public class CallbackUrlService {
     private final Set<InternetDomainName> allowedDomains;
 
+    @Inject
     public CallbackUrlService(WebhooksConfig webhooksConfig) {
-        this.allowedDomains = webhooksConfig.getLiveDataAllowHosts().stream().map(InternetDomainName::from).collect(toUnmodifiableSet());
+        this.allowedDomains = webhooksConfig.getLiveDataAllowDomains().stream().map(InternetDomainName::from).collect(toUnmodifiableSet());
     }
 
-    public void validateCallbackUrl(String callbackUrl, Boolean contextIsLive) throws MalformedURLException {
+    public void validateCallbackUrl(String callbackUrl, Boolean contextIsLive) {
         var url = validateAndGetUrlIsWellFormed(callbackUrl);
         if (Boolean.TRUE.equals(contextIsLive)) {
             validateUrlIsInLiveDomains(url);
         }
     }
 
-    private URL validateAndGetUrlIsWellFormed(String callbackUrl) throws MalformedURLException {
+    private URL validateAndGetUrlIsWellFormed(String callbackUrl) {
         URL url;
         try {
             url = new URL(callbackUrl);

--- a/src/main/java/uk/gov/pay/webhooks/validations/WebhookRequestValidator.java
+++ b/src/main/java/uk/gov/pay/webhooks/validations/WebhookRequestValidator.java
@@ -1,13 +1,14 @@
 package uk.gov.pay.webhooks.validations;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.google.inject.Inject;
+import uk.gov.pay.webhooks.webhook.resource.CreateWebhookRequest;
 import uk.gov.service.payments.commons.api.validation.JsonPatchRequestValidator;
 import uk.gov.service.payments.commons.api.validation.PatchPathOperation;
 import uk.gov.service.payments.commons.model.jsonpatch.JsonPatchOp;
 import uk.gov.service.payments.commons.model.jsonpatch.JsonPatchRequest;
 
 import java.util.Map;
-import java.util.function.Consumer;
 
 import static uk.gov.pay.webhooks.webhook.resource.WebhookResponse.FIELD_CALLBACK_URL;
 import static uk.gov.pay.webhooks.webhook.resource.WebhookResponse.FIELD_DESCRIPTION;
@@ -16,16 +17,44 @@ import static uk.gov.pay.webhooks.webhook.resource.WebhookResponse.FIELD_SUBSCRI
 
 
 public class WebhookRequestValidator {
-    private static final Map<PatchPathOperation, Consumer<JsonPatchRequest>> patchOperationValidators = Map.of(
-            new PatchPathOperation(FIELD_DESCRIPTION, JsonPatchOp.REPLACE), JsonPatchRequestValidator::throwIfValueNotString,
-            new PatchPathOperation(FIELD_CALLBACK_URL, JsonPatchOp.REPLACE), RequestValidations::throwIfValueNotValidUrl,
-            new PatchPathOperation(FIELD_STATUS, JsonPatchOp.REPLACE), RequestValidations::throwIfValueNotValidStatusEnum,
-            new PatchPathOperation(FIELD_SUBSCRIPTIONS, JsonPatchOp.REPLACE), RequestValidations::throwIfValueNotValidSubscriptionsArray
-    );
-    private final JsonPatchRequestValidator patchRequestValidator = new JsonPatchRequestValidator(patchOperationValidators);
+    private final CallbackUrlService callbackUrlService;
 
-    public void validateJsonPatch(JsonNode payload)  {
-        patchRequestValidator.validate(payload);
+    private final JsonPatchRequestValidator liveContextValidator = validator(true);
+    private final JsonPatchRequestValidator testContextValidator = validator(false);
+
+    @Inject
+    public WebhookRequestValidator(CallbackUrlService callbackUrlService) {
+        this.callbackUrlService = callbackUrlService;
+    }
+
+    public void validate(JsonNode payload, Boolean isLiveContext)  {
+        if (isLiveContext) {
+            liveContextValidator.validate(payload);
+        } else {
+            testContextValidator.validate(payload);
+        }
+    }
+
+    // @TODO(sfount): create request can use a declarative Hibernate "Custom constraint validator" with annotation to validate the
+    //                callback url. This will require guice injection in the validator contexts and is out of scoped here
+    //                but would allow for all of the validation to be processed in one place
+    public void validate(CreateWebhookRequest createWebhookRequest) {
+        callbackUrlService.validateCallbackUrl(createWebhookRequest.callbackUrl(), createWebhookRequest.live());
+    }
+
+    private JsonPatchRequestValidator validator(Boolean isLiveContext) {
+        return new JsonPatchRequestValidator(
+                Map.of(
+                        new PatchPathOperation(FIELD_DESCRIPTION, JsonPatchOp.REPLACE), JsonPatchRequestValidator::throwIfValueNotString,
+                        new PatchPathOperation(FIELD_STATUS, JsonPatchOp.REPLACE), RequestValidations::throwIfValueNotValidStatusEnum,
+                        new PatchPathOperation(FIELD_SUBSCRIPTIONS, JsonPatchOp.REPLACE), RequestValidations::throwIfValueNotValidSubscriptionsArray,
+                        new PatchPathOperation(FIELD_CALLBACK_URL, JsonPatchOp.REPLACE), (jsonPatchRequest) -> { throwIfCallbackUrlNotValid(jsonPatchRequest, isLiveContext); }
+                )
+        );
+    }
+
+    private void throwIfCallbackUrlNotValid(JsonPatchRequest jsonPatchRequest, Boolean isLiveContext) {
+        callbackUrlService.validateCallbackUrl(jsonPatchRequest.valueAsString(), isLiveContext);
     }
 }
 

--- a/src/main/java/uk/gov/pay/webhooks/webhook/exception/ErrorResponse.java
+++ b/src/main/java/uk/gov/pay/webhooks/webhook/exception/ErrorResponse.java
@@ -1,0 +1,10 @@
+package uk.gov.pay.webhooks.webhook.exception;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public record ErrorResponse(
+    String errorIdentifier,
+    String message
+) {}

--- a/src/main/java/uk/gov/pay/webhooks/webhook/exception/ErrorResponse.java
+++ b/src/main/java/uk/gov/pay/webhooks/webhook/exception/ErrorResponse.java
@@ -5,6 +5,6 @@ import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public record ErrorResponse(
-    String errorIdentifier,
+    WebhooksErrorIdentifier errorIdentifier,
     String message
 ) {}

--- a/src/main/java/uk/gov/pay/webhooks/webhook/exception/ValidationExceptionMapper.java
+++ b/src/main/java/uk/gov/pay/webhooks/webhook/exception/ValidationExceptionMapper.java
@@ -1,0 +1,14 @@
+package uk.gov.pay.webhooks.webhook.exception;
+
+import uk.gov.service.payments.commons.api.exception.ValidationException;
+
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+
+public class ValidationExceptionMapper implements ExceptionMapper<ValidationException> {
+
+    @Override
+    public Response toResponse(ValidationException e) {
+        return Response.status(Response.Status.BAD_REQUEST.getStatusCode(), String.join(",", e.getErrors())).build();
+    }
+}

--- a/src/main/java/uk/gov/pay/webhooks/webhook/exception/WebhookExceptionMapper.java
+++ b/src/main/java/uk/gov/pay/webhooks/webhook/exception/WebhookExceptionMapper.java
@@ -1,0 +1,14 @@
+package uk.gov.pay.webhooks.webhook.exception;
+
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+
+public class WebhookExceptionMapper implements ExceptionMapper<WebhooksException> {
+
+    @Override
+    public Response toResponse(WebhooksException e) {
+        return Response.status(Response.Status.BAD_REQUEST)
+                .entity(new ErrorResponse(e.getErrorIdentifier(), e.getMessage()))
+                .build();
+    }
+}

--- a/src/main/java/uk/gov/pay/webhooks/webhook/exception/WebhooksErrorIdentifier.java
+++ b/src/main/java/uk/gov/pay/webhooks/webhook/exception/WebhooksErrorIdentifier.java
@@ -1,0 +1,8 @@
+package uk.gov.pay.webhooks.webhook.exception;
+
+public enum WebhooksErrorIdentifier {
+    GENERIC,
+    CALLBACK_URL_NOT_ON_ALLOW_LIST,
+    CALLBACK_URL_MALFORMED,
+    CALLBACK_URL_PROTOCOL_NOT_SUPPORTED
+}

--- a/src/main/java/uk/gov/pay/webhooks/webhook/exception/WebhooksException.java
+++ b/src/main/java/uk/gov/pay/webhooks/webhook/exception/WebhooksException.java
@@ -1,23 +1,18 @@
 package uk.gov.pay.webhooks.webhook.exception;
 
 public class WebhooksException extends RuntimeException {
-    protected static final String IDENTIFIER_GENERIC = "generic";
-    protected static final String IDENTIFIER_CALLBACK_URL_NOT_ON_ALLOW_LIST = "callback_url_not_on_allow_list";
-    protected static final String IDENTIFIER_CALLBACK_URL_MALFORMED = "callback_url_malformed";
-    protected static final String IDENTIFIER_CALLBACK_URL_PROTOCOL_NOT_SUPPORTED = "callback_url_protocol_not_supported";
-
-    private String errorIdentifier = IDENTIFIER_GENERIC;
+    private WebhooksErrorIdentifier errorIdentifier = WebhooksErrorIdentifier.GENERIC;
 
     public WebhooksException(String message) {
         super(message);
     }
 
-    public WebhooksException(String message, String errorIdentifier) {
+    public WebhooksException(String message, WebhooksErrorIdentifier errorIdentifier) {
         super(message);
         this.errorIdentifier = errorIdentifier;
     }
 
-    public String getErrorIdentifier() {
+    public WebhooksErrorIdentifier getErrorIdentifier() {
         return errorIdentifier;
     }
 }

--- a/src/main/java/uk/gov/pay/webhooks/webhook/exception/WebhooksException.java
+++ b/src/main/java/uk/gov/pay/webhooks/webhook/exception/WebhooksException.java
@@ -1,0 +1,23 @@
+package uk.gov.pay.webhooks.webhook.exception;
+
+public class WebhooksException extends RuntimeException {
+    protected static final String IDENTIFIER_GENERIC = "generic";
+    protected static final String IDENTIFIER_CALLBACK_URL_NOT_ON_ALLOW_LIST = "callback_url_not_on_allow_list";
+    protected static final String IDENTIFIER_CALLBACK_URL_MALFORMED = "callback_url_malformed";
+    protected static final String IDENTIFIER_CALLBACK_URL_PROTOCOL_NOT_SUPPORTED = "callback_url_protocol_not_supported";
+
+    private String errorIdentifier = IDENTIFIER_GENERIC;
+
+    public WebhooksException(String message) {
+        super(message);
+    }
+
+    public WebhooksException(String message, String errorIdentifier) {
+        super(message);
+        this.errorIdentifier = errorIdentifier;
+    }
+
+    public String getErrorIdentifier() {
+        return errorIdentifier;
+    }
+}

--- a/src/test/java/uk/gov/pay/webhooks/validations/CallbackUrlServiceTest.java
+++ b/src/test/java/uk/gov/pay/webhooks/validations/CallbackUrlServiceTest.java
@@ -23,63 +23,63 @@ class CallbackUrlServiceTest {
 
     @Test
     public void callbackUrlWithExactDomainInAllowListShouldBeAllowed() {
-        when(webhooksConfig.getLiveDataAllowHosts()).thenReturn(Set.of("gov.uk"));
+        when(webhooksConfig.getLiveDataAllowDomains()).thenReturn(Set.of("gov.uk"));
         callbackUrlService = new CallbackUrlService(webhooksConfig);
         assertDoesNotThrow(() -> callbackUrlService.validateCallbackUrl("https://gov.uk/my/callback/endpoint", true));
     }
 
     @Test
     public void callbackUrlWithFinalDotAndExactDomainInAllowListShouldBeAllowed() {
-        when(webhooksConfig.getLiveDataAllowHosts()).thenReturn(Set.of("gov.uk"));
+        when(webhooksConfig.getLiveDataAllowDomains()).thenReturn(Set.of("gov.uk"));
         callbackUrlService = new CallbackUrlService(webhooksConfig);
         assertDoesNotThrow(() -> callbackUrlService.validateCallbackUrl("https://gov.uk./my/callback/endpoint", true));
     }
 
     @Test
     public void callbackUrlWithExactDomainButDifferentCaseInAllowListShouldBeAllowed() {
-        when(webhooksConfig.getLiveDataAllowHosts()).thenReturn(Set.of("gov.uk"));
+        when(webhooksConfig.getLiveDataAllowDomains()).thenReturn(Set.of("gov.uk"));
         callbackUrlService = new CallbackUrlService(webhooksConfig);
         assertDoesNotThrow(() -> callbackUrlService.validateCallbackUrl("https://GOV.UK/my/callback/endpoint", true));
     }
 
     @Test
     public void callbackUrlWithPortAndExactDomainInAllowListShouldBeAllowed() {
-        when(webhooksConfig.getLiveDataAllowHosts()).thenReturn(Set.of("gov.uk"));
+        when(webhooksConfig.getLiveDataAllowDomains()).thenReturn(Set.of("gov.uk"));
         callbackUrlService = new CallbackUrlService(webhooksConfig);
         assertDoesNotThrow(() -> callbackUrlService.validateCallbackUrl("https://gov.uk:443/my/callback/endpoint", true));
     }
 
     @Test
     public void callbackUrlWithDomainThatIsSingleSubdomainOfDomainInAllowListShouldBeAllowed() {
-        when(webhooksConfig.getLiveDataAllowHosts()).thenReturn(Set.of("gov.uk"));
+        when(webhooksConfig.getLiveDataAllowDomains()).thenReturn(Set.of("gov.uk"));
         callbackUrlService = new CallbackUrlService(webhooksConfig);
         assertDoesNotThrow(() -> callbackUrlService.validateCallbackUrl("https://www.gov.uk/my/callback/endpoint", true));
     }
 
     @Test
     public void callbackUrlWithDomainThatIsMultipleSubdomainsOfDomainInAllowListShouldBeAllowed() {
-        when(webhooksConfig.getLiveDataAllowHosts()).thenReturn(Set.of("gov.uk"));
+        when(webhooksConfig.getLiveDataAllowDomains()).thenReturn(Set.of("gov.uk"));
         callbackUrlService = new CallbackUrlService(webhooksConfig);
         assertDoesNotThrow(() -> callbackUrlService.validateCallbackUrl("https://www.example.service.gov.uk/my/callback/endpoint", true));
     }
 
     @Test
     public void callbackUrlWithExactIdnDomainInAllowListShouldBeAllowed() {
-        when(webhooksConfig.getLiveDataAllowHosts()).thenReturn(Set.of("网络.test"));
+        when(webhooksConfig.getLiveDataAllowDomains()).thenReturn(Set.of("网络.test"));
         callbackUrlService = new CallbackUrlService(webhooksConfig);
         assertDoesNotThrow(() -> callbackUrlService.validateCallbackUrl("https://网络.test/my/callback/endpoint", true));
     }
 
     @Test
     public void callbackUrlWithExactPunycodeDomainInAllowListShouldBeAllowed() {
-        when(webhooksConfig.getLiveDataAllowHosts()).thenReturn(Set.of("xn--io0a7i.test"));
+        when(webhooksConfig.getLiveDataAllowDomains()).thenReturn(Set.of("xn--io0a7i.test"));
         callbackUrlService = new CallbackUrlService(webhooksConfig);
         assertDoesNotThrow(() -> callbackUrlService.validateCallbackUrl("https://xn--io0a7i.test/my/callback/endpoint", true));
     }
 
     @Test
     public void callbackUrlWithDomainNotInAllowListShouldThrowException() {
-        when(webhooksConfig.getLiveDataAllowHosts()).thenReturn(Set.of("gov.uk"));
+        when(webhooksConfig.getLiveDataAllowDomains()).thenReturn(Set.of("gov.uk"));
         callbackUrlService = new CallbackUrlService(webhooksConfig);
         assertThrows(CallbackUrlDomainNotOnAllowListException.class,
                 () -> callbackUrlService.validateCallbackUrl("https://www.url.service.test/is/not/in/list", true));
@@ -87,7 +87,7 @@ class CallbackUrlServiceTest {
 
     @Test
     public void callbackUrlWithDomainWhereBeginningIsInAllowListShouldThrowException() {
-        when(webhooksConfig.getLiveDataAllowHosts()).thenReturn(Set.of("gov.uk"));
+        when(webhooksConfig.getLiveDataAllowDomains()).thenReturn(Set.of("gov.uk"));
         callbackUrlService = new CallbackUrlService(webhooksConfig);
         assertThrows(CallbackUrlDomainNotOnAllowListException.class,
                 () -> callbackUrlService.validateCallbackUrl("https://gov.uk.test/is/not/in/list", true));
@@ -95,7 +95,7 @@ class CallbackUrlServiceTest {
 
     @Test
     public void callbackUrlWithIdnDomainWherePunycodeEquivalentInAllowListShouldThrowException() {
-        when(webhooksConfig.getLiveDataAllowHosts()).thenReturn(Set.of("xn--io0a7i.test"));
+        when(webhooksConfig.getLiveDataAllowDomains()).thenReturn(Set.of("xn--io0a7i.test"));
         callbackUrlService = new CallbackUrlService(webhooksConfig);
         assertThrows(CallbackUrlDomainNotOnAllowListException.class,
                 () -> callbackUrlService.validateCallbackUrl("https://网络.test/is/not/in/list", true));
@@ -103,7 +103,7 @@ class CallbackUrlServiceTest {
 
     @Test
     public void callbackUrlWithIPunycodeDomainWhereIdnEquivalentInAllowListShouldThrowException() {
-        when(webhooksConfig.getLiveDataAllowHosts()).thenReturn(Set.of("网络.test"));
+        when(webhooksConfig.getLiveDataAllowDomains()).thenReturn(Set.of("网络.test"));
         callbackUrlService = new CallbackUrlService(webhooksConfig);
         assertThrows(CallbackUrlDomainNotOnAllowListException.class,
                 () -> callbackUrlService.validateCallbackUrl("https://xn--io0a7i.test/is/not/in/list", true));
@@ -111,7 +111,7 @@ class CallbackUrlServiceTest {
 
     @Test
     public void callbackUrlWithSinglePartDomainWithExactDomainInAllowListShouldThrowException() {
-        when(webhooksConfig.getLiveDataAllowHosts()).thenReturn(Set.of("test"));
+        when(webhooksConfig.getLiveDataAllowDomains()).thenReturn(Set.of("test"));
         callbackUrlService = new CallbackUrlService(webhooksConfig);
         assertThrows(CallbackUrlDomainNotOnAllowListException.class,
                 () -> callbackUrlService.validateCallbackUrl("https://test/is/not/in/list", true));
@@ -119,7 +119,7 @@ class CallbackUrlServiceTest {
 
     @Test
     public void callbackUrlWithIpv4AddressShouldThrowException() {
-        when(webhooksConfig.getLiveDataAllowHosts()).thenReturn(Set.of("gov.uk"));
+        when(webhooksConfig.getLiveDataAllowDomains()).thenReturn(Set.of("gov.uk"));
         callbackUrlService = new CallbackUrlService(webhooksConfig);
         assertThrows(CallbackUrlMalformedException.class,
                 () -> callbackUrlService.validateCallbackUrl("https://203.0.113.1/is/not/in/list", true));
@@ -127,7 +127,7 @@ class CallbackUrlServiceTest {
 
     @Test
     public void callbackUrlWithIpv6AddressShouldThrowException() {
-        when(webhooksConfig.getLiveDataAllowHosts()).thenReturn(Set.of("gov.uk"));
+        when(webhooksConfig.getLiveDataAllowDomains()).thenReturn(Set.of("gov.uk"));
         callbackUrlService = new CallbackUrlService(webhooksConfig);
         assertThrows(CallbackUrlMalformedException.class,
                 () -> callbackUrlService.validateCallbackUrl("https://[2001:0db8:85a3:0000:0000:8a2e:0370:7334]/is/not/in/list", true));
@@ -135,7 +135,7 @@ class CallbackUrlServiceTest {
 
     @Test
     public void callbackUrlWithNoHostShouldThrowException() {
-        when(webhooksConfig.getLiveDataAllowHosts()).thenReturn(Set.of("gov.uk"));
+        when(webhooksConfig.getLiveDataAllowDomains()).thenReturn(Set.of("gov.uk"));
         callbackUrlService = new CallbackUrlService(webhooksConfig);
         assertThrows(CallbackUrlMalformedException.class,
                 () -> callbackUrlService.validateCallbackUrl("https:///is/not/in/list", true));
@@ -144,7 +144,7 @@ class CallbackUrlServiceTest {
     @ParameterizedTest
     @ValueSource(strings = { "http", "ftp", "file" })
     public void callbackUrlWithInvalidProtocolShouldThrowException(String protocol) {
-        when(webhooksConfig.getLiveDataAllowHosts()).thenReturn(Set.of("gov.uk"));
+        when(webhooksConfig.getLiveDataAllowDomains()).thenReturn(Set.of("gov.uk"));
         callbackUrlService = new CallbackUrlService(webhooksConfig);
         assertThrows(CallbackUrlProtocolNotSupported.class,
                 () -> callbackUrlService.validateCallbackUrl(protocol + "://gov.uk", true));
@@ -153,7 +153,7 @@ class CallbackUrlServiceTest {
     @ParameterizedTest
     @ValueSource(strings = { "https", "hTtPs", "HTTPS"})
     public void callbackUrlWithValidProtocolIsCaseInsensitive(String protocol) {
-        when(webhooksConfig.getLiveDataAllowHosts()).thenReturn(Set.of("gov.uk"));
+        when(webhooksConfig.getLiveDataAllowDomains()).thenReturn(Set.of("gov.uk"));
         callbackUrlService = new CallbackUrlService(webhooksConfig);
         assertDoesNotThrow(() -> callbackUrlService.validateCallbackUrl(protocol + "://gov.uk", true));
     }

--- a/src/test/java/uk/gov/pay/webhooks/validations/WebhookRequestValidatorTest.java
+++ b/src/test/java/uk/gov/pay/webhooks/validations/WebhookRequestValidatorTest.java
@@ -3,81 +3,85 @@ package uk.gov.pay.webhooks.validations;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import uk.gov.pay.webhooks.app.WebhooksConfig;
 import uk.gov.service.payments.commons.api.exception.ValidationException;
 
 import java.util.Collections;
 import java.util.Map;
+import java.util.Set;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 class WebhookRequestValidatorTest {
-    private WebhookRequestValidator webhookRequestValidator;
+    private WebhooksConfig webhooksConfig = mock(WebhooksConfig.class);
+    private WebhookRequestValidator webhookRequestValidator = new WebhookRequestValidator(new CallbackUrlService(webhooksConfig));
+
+    @BeforeEach
+    public void setUp() {
+        when(webhooksConfig.getLiveDataAllowDomains()).thenReturn(Set.of("gov.uk"));
+    }
 
     @Test
     public void descriptionShouldBeString() {
-        webhookRequestValidator = new WebhookRequestValidator();
         var objectMapper = new ObjectMapper();
         JsonNode request = objectMapper.valueToTree(
                 Collections.singletonList(Map.of("path", "description",
                         "op", "replace",
                         "value", true)));
-        var thrown = assertThrows(ValidationException.class, () -> webhookRequestValidator.validateJsonPatch(request));
+        var thrown = assertThrows(ValidationException.class, () -> webhookRequestValidator.validate(request, false));
         assertThat(thrown.getErrors().get(0), is("Value for path [description] must be a string"));
     }     
 
     @Test
     public void emptyStringDescriptionShouldBeValid() {
-        webhookRequestValidator = new WebhookRequestValidator();
         var objectMapper = new ObjectMapper();
         JsonNode request = objectMapper.valueToTree(
                 Collections.singletonList(Map.of("path", "description",
                         "op", "replace",
                         "value", "")));
-        assertDoesNotThrow(() -> webhookRequestValidator.validateJsonPatch(request));
+        assertDoesNotThrow(() -> webhookRequestValidator.validate(request, false));
     }    
     
     @Test
     public void callbackUrlNotUrlShouldThrowError() {
-        webhookRequestValidator = new WebhookRequestValidator();
         var objectMapper = new ObjectMapper();
         JsonNode request = objectMapper.valueToTree(
                 Collections.singletonList(Map.of("path", "callback_url",
                         "op", "replace",
                         "value", "foo bar")));
-        var thrown = assertThrows(ValidationException.class, () -> webhookRequestValidator.validateJsonPatch(request));
-        assertThat(thrown.getErrors().get(0), is("Value for path [callback_url] must be a URL"));
+        var thrown = assertThrows(CallbackUrlMalformedException.class, () -> webhookRequestValidator.validate(request, false));
     }     
     
     @Test
     public void invalidStatusEnumShouldThrowError() {
-        webhookRequestValidator = new WebhookRequestValidator();
         var objectMapper = new ObjectMapper();
         JsonNode request = objectMapper.valueToTree(
                 Collections.singletonList(Map.of("path", "status",
                         "op", "replace",
                         "value", "foo bar")));
-        var thrown = assertThrows(ValidationException.class, () -> webhookRequestValidator.validateJsonPatch(request));
+        var thrown = assertThrows(ValidationException.class, () -> webhookRequestValidator.validate(request, false));
         assertThat(thrown.getErrors().get(0), is("Value for path [status] must be one of ACTIVE or INACTIVE"));
     }
 
     @Test
     public void validStatusEnumShouldNotThrowError() {
-        webhookRequestValidator = new WebhookRequestValidator();
         var objectMapper = new ObjectMapper();
         JsonNode request = objectMapper.valueToTree(
                 Collections.singletonList(Map.of("path", "status",
                         "op", "replace",
                         "value", "INACTIVE")));
-        assertDoesNotThrow(() -> webhookRequestValidator.validateJsonPatch(request));
+        assertDoesNotThrow(() -> webhookRequestValidator.validate(request, false));
     }
 
     @Test
     public void unknownItemInSubscriptionArrayShouldThrowError() throws JsonProcessingException {
-        webhookRequestValidator = new WebhookRequestValidator();
         var objectMapper = new ObjectMapper();
         JsonNode request = objectMapper.readTree(
                 """
@@ -90,13 +94,12 @@ class WebhookRequestValidatorTest {
                           ]
                         """
         );
-        var thrown = assertThrows(ValidationException.class, () -> webhookRequestValidator.validateJsonPatch(request));
+        var thrown = assertThrows(ValidationException.class, () -> webhookRequestValidator.validate(request, false));
         assertThat(thrown.getErrors().get(0), is("Value for path [subscriptions] must be array of [card_payment_started, card_payment_succeeded, card_payment_captured, card_payment_refunded]"));
     }
 
     @Test
     public void nonArrayInSubscriptionShouldThrowError() throws JsonProcessingException {
-        webhookRequestValidator = new WebhookRequestValidator();
         var objectMapper = new ObjectMapper();
         JsonNode request = objectMapper.readTree(
                 """
@@ -109,18 +112,17 @@ class WebhookRequestValidatorTest {
                           ]
                         """
         );
-        var thrown = assertThrows(ValidationException.class, () -> webhookRequestValidator.validateJsonPatch(request));
+        var thrown = assertThrows(ValidationException.class, () -> webhookRequestValidator.validate(request, false));
         assertThat(thrown.getErrors().get(0), is("Value for path [subscriptions] must be array of [card_payment_started, card_payment_succeeded, card_payment_captured, card_payment_refunded]"));
     }
 
     @Test
     public void httpsCallbackUrlShouldNotThrowError() {
-        webhookRequestValidator = new WebhookRequestValidator();
         var objectMapper = new ObjectMapper();
         JsonNode request = objectMapper.valueToTree(
                 Collections.singletonList(Map.of("path", "callback_url",
                         "op", "replace",
                         "value", "https://gov.uk")));
-        assertDoesNotThrow(() -> webhookRequestValidator.validateJsonPatch(request));
+        assertDoesNotThrow(() -> webhookRequestValidator.validate(request, false));
     }
 }

--- a/src/test/java/uk/gov/pay/webhooks/webhook/resource/WebhookListIT.java
+++ b/src/test/java/uk/gov/pay/webhooks/webhook/resource/WebhookListIT.java
@@ -36,7 +36,7 @@ public class WebhookListIT {
         var json = """
                 {
                   "service_id": "test_service_id",
-                  "live": true,
+                  "live": false,
                   "callback_url": "https://example.com",
                   "description": "description",
                   "subscriptions": ["card_payment_captured"]
@@ -56,7 +56,7 @@ public class WebhookListIT {
 
         var listResponse = given().port(port)
                 .contentType(JSON)
-                .get("/v1/webhook?service_id=test_service_id&live=true".formatted(externalId, serviceId))
+                .get("/v1/webhook?service_id=test_service_id&live=false".formatted(externalId, serviceId))
                 .then()
                 .extract().as(List.class);
             assertThat(listResponse.size(),is(equalTo(1)));
@@ -69,7 +69,7 @@ public class WebhookListIT {
         var serviceOne = """
                 {
                   "service_id": "service_one",
-                  "live": true,
+                  "live": false,
                   "callback_url": "https://example.com",
                   "description": "description",
                   "subscriptions": ["card_payment_captured"]
@@ -79,7 +79,7 @@ public class WebhookListIT {
         var serviceTwo = """
                 {
                   "service_id": "service_two",
-                  "live": true,
+                  "live": false,
                   "callback_url": "https://example.com",
                   "description": "description",
                   "subscriptions": ["card_payment_captured"]
@@ -95,7 +95,7 @@ public class WebhookListIT {
         
         var jsonNodeResponse = given().port(port)
                 .contentType(JSON)
-                .get("/v1/webhook?override_service_id_restriction=true&live=true")
+                .get("/v1/webhook?override_service_id_restriction=true&live=false")
                 .then()
                 .extract().as(JsonNode.class);
         

--- a/src/test/java/uk/gov/pay/webhooks/webhook/resource/WebhookResourceIT.java
+++ b/src/test/java/uk/gov/pay/webhooks/webhook/resource/WebhookResourceIT.java
@@ -34,7 +34,7 @@ public class WebhookResourceIT {
         var json = """
                 {
                   "service_id": "test_service_id",
-                  "live": true,
+                  "live": false,
                   "callback_url": "https://example.com",
                   "description": "description",
                   "subscriptions": ["card_payment_captured"]
@@ -48,7 +48,7 @@ public class WebhookResourceIT {
                 .then()
                 .statusCode(Response.Status.OK.getStatusCode())
                 .body("service_id", is("test_service_id"))
-                .body("live", is(true))
+                .body("live", is(false))
                 .body("callback_url", is("https://example.com"))
                 .body("description", is("description"))
                 .body("status", is("ACTIVE"))
@@ -65,7 +65,7 @@ public class WebhookResourceIT {
                 .then()
                 .statusCode(Response.Status.OK.getStatusCode())
                 .body("service_id", is("test_service_id"))
-                .body("live", is(true))
+                .body("live", is(false))
                 .body("callback_url", is("https://example.com"))
                 .body("description", is("description"))
                 .body("status", is("ACTIVE"))

--- a/src/test/java/uk/gov/pay/webhooks/webhook/resource/WebhookResourceIT.java
+++ b/src/test/java/uk/gov/pay/webhooks/webhook/resource/WebhookResourceIT.java
@@ -73,7 +73,7 @@ public class WebhookResourceIT {
                 .post("/v1/webhook")
                 .then()
                 .statusCode(Response.Status.BAD_REQUEST.getStatusCode())
-                .body("error_identifier", is("callback_url_protocol_not_supported"));
+                .body("error_identifier", is("CALLBACK_URL_PROTOCOL_NOT_SUPPORTED"));
         given()
                 .port(port)
                 .contentType(JSON)
@@ -81,7 +81,7 @@ public class WebhookResourceIT {
                 .post("/v1/webhook")
                 .then()
                 .statusCode(Response.Status.BAD_REQUEST.getStatusCode())
-                .body("error_identifier", is("callback_url_malformed"));
+                .body("error_identifier", is("CALLBACK_URL_MALFORMED"));
         given()
                 .port(port)
                 .contentType(JSON)
@@ -89,7 +89,7 @@ public class WebhookResourceIT {
                 .post("/v1/webhook")
                 .then()
                 .statusCode(Response.Status.BAD_REQUEST.getStatusCode())
-                .body("error_identifier", is("callback_url_not_on_allow_list"));
+                .body("error_identifier", is("CALLBACK_URL_NOT_ON_ALLOW_LIST"));
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/webhooks/webhook/resource/WebhookSigningKeyIT.java
+++ b/src/test/java/uk/gov/pay/webhooks/webhook/resource/WebhookSigningKeyIT.java
@@ -59,7 +59,7 @@ public class WebhookSigningKeyIT {
                 .get("/v1/webhook/%s/signing-key?service_id=%s".formatted(externalId, serviceId))
                 .then()
                 .statusCode(200)
-                .body("signing_key", startsWith("webhook_live_"))
+                .body("signing_key", startsWith("webhook_test_"))
                 .extract()
                 .as(Map.class);
 
@@ -72,7 +72,7 @@ public class WebhookSigningKeyIT {
                 .then()
                 .statusCode(200)
                 .body("signing_key", not(originalSigningKey))
-                .body("signing_key", startsWith("webhook_live_"))
+                .body("signing_key", startsWith("webhook_test_"))
                 .extract()
                 .as(Map.class);
 

--- a/src/test/java/uk/gov/pay/webhooks/webhook/resource/WebhookSigningKeyIT.java
+++ b/src/test/java/uk/gov/pay/webhooks/webhook/resource/WebhookSigningKeyIT.java
@@ -36,7 +36,7 @@ public class WebhookSigningKeyIT {
         var json = """
                 {
                   "service_id": "test_service_id",
-                  "live": true,
+                  "live": false,
                   "callback_url": "https://example.com",
                   "description": "description",
                   "subscriptions": ["card_payment_captured"]

--- a/src/test/java/uk/gov/pay/webhooks/webhook/resource/WebhookUpdateIT.java
+++ b/src/test/java/uk/gov/pay/webhooks/webhook/resource/WebhookUpdateIT.java
@@ -35,7 +35,7 @@ public class WebhookUpdateIT {
         var json = """
                 {
                   "service_id": "test_service_id",
-                  "live": true,
+                  "live": false,
                   "callback_url": "https://example.com",
                   "description": "original description",
                   "subscriptions": ["card_payment_captured"]
@@ -59,7 +59,7 @@ public class WebhookUpdateIT {
                         {
                             "path": "callback_url",
                             "op": "replace",
-                            "value": "http://example.org"
+                            "value": "https://example.org"
                         }
                     ]
                 """;
@@ -73,7 +73,7 @@ public class WebhookUpdateIT {
                 .then()
                 .statusCode(200)
                 .body("description", is("new description"))
-                .body("callback_url", is("http://example.org"));
+                .body("callback_url", is("https://example.org"));
 
         given().port(port)
                 .contentType(JSON)
@@ -81,7 +81,7 @@ public class WebhookUpdateIT {
                 .then()
                 .statusCode(200)
                 .body("description", is("new description"))
-                .body("callback_url", is("http://example.org"));
+                .body("callback_url", is("https://example.org"));
     }
 
     @Test
@@ -89,7 +89,7 @@ public class WebhookUpdateIT {
         var json = """
                 {
                   "service_id": "test_service_id",
-                  "live": true,
+                  "live": false,
                   "callback_url": "https://example.com",
                   "description": "original description",
                   "subscriptions": ["card_payment_captured"]
@@ -128,7 +128,7 @@ public class WebhookUpdateIT {
         var json = """
                 {
                   "service_id": "test_service_id",
-                  "live": true,
+                  "live": false,
                   "callback_url": "https://example.com",
                   "description": "original description",
                   "subscriptions": []

--- a/src/test/java/uk/gov/pay/webhooks/webhook/resource/WebhookUpdateIT.java
+++ b/src/test/java/uk/gov/pay/webhooks/webhook/resource/WebhookUpdateIT.java
@@ -198,6 +198,6 @@ public class WebhookUpdateIT {
                 .patch(format("/v1/webhook/%s?service_id=%s", externalId, serviceId))
                 .then()
                 .statusCode(400)
-                .body("error_identifier", is("callback_url_not_on_allow_list"));
+                .body("error_identifier", is("CALLBACK_URL_NOT_ON_ALLOW_LIST"));
     }
 }

--- a/src/test/resources/config/test-config.yaml
+++ b/src/test/resources/config/test-config.yaml
@@ -59,3 +59,5 @@ queueMessageReceiverConfig:
   threadDelayInMilliseconds: ${QUEUE_MESSAGE_RECEIVER_THREAD_DELAY_IN_MILLISECONDS:-1}
   numberOfThreads: ${QUEUE_MESSAGE_RECEIVER_NUMBER_OF_THREADS:-1}
   messageRetryDelayInSeconds: ${QUEUE_MESSAGE_RETRY_DELAY_IN_SECONDS:-1}
+
+liveDataAllowDomains: ["gov.uk"]


### PR DESCRIPTION
Follows on from https://github.com/alphagov/pay-webhooks/pull/362

Include a call to the the callback url service on the create and update
webhook resource to ensure the url is validated whenever a webhook is
mutated. This requires passing down the live context for any given
webhook resource.

There's a remaining developer note to demonstrate that we could move the
create webhook validation to a custom constraint validator to bring it
inline with other basic validation done for create requests. Currently
this is entirely separate from the validation done against the json
patch logic (which is something else that could be improved in the
future).

For now this will throw separate and one off exceptions for the callback
url on the update endpoint, rather than throwing a `ValidationException`
to be caught by the commons code and wrapped into a list of exceptions
to be returned at once. This allows the `error_identifier` to be simply
returned to the frontend without having consider how this would be
_optionally_ represented and nested nested in the java commons code.
Further work could refine this to support nested and batch error
identifiers however currently the frontend will only be leaning on the
backend webhooks resource to do business logic validation around the
URL provided.

Splits the json patch validator into two depending on the live context
of the webhook, this feels like a good compromise between instantiating
the objects once but allowing the validation to be live context
dependant.