### PR TITLE
PP-9016 Check allow list at point of sending a message

### DIFF
--- a/src/main/java/uk/gov/pay/webhooks/app/WebhooksModule.java
+++ b/src/main/java/uk/gov/pay/webhooks/app/WebhooksModule.java
@@ -13,9 +13,6 @@ import io.dropwizard.hibernate.HibernateBundle;
 import io.dropwizard.hibernate.UnitOfWorkAwareProxyFactory;
 import io.dropwizard.setup.Environment;
 import org.hibernate.SessionFactory;
-import uk.gov.pay.webhooks.deliveryqueue.dao.WebhookDeliveryQueueDao;
-import uk.gov.pay.webhooks.deliveryqueue.managed.SendAttempter;
-import uk.gov.pay.webhooks.deliveryqueue.managed.WebhookMessagePollingService;
 import uk.gov.pay.webhooks.message.WebhookMessageSender;
 import uk.gov.pay.webhooks.message.WebhookMessageSignatureGenerator;
 import uk.gov.pay.webhooks.util.IdGenerator;
@@ -63,9 +60,8 @@ public class WebhooksModule extends AbstractModule {
 
     @Provides
     @Singleton
-    public WebhookMessageSender webhookMessageSender() {
-        return new WebhookMessageSender(httpClient(), new ObjectMapper().registerModule(new Jdk8Module()),
-                new WebhookMessageSignatureGenerator());
+    public WebhookMessageSignatureGenerator webhookMessageSignatureGenerator() {
+        return new WebhookMessageSignatureGenerator();
     }
 
     @Provides

--- a/src/main/java/uk/gov/pay/webhooks/deliveryqueue/dao/WebhookDeliveryQueueEntity.java
+++ b/src/main/java/uk/gov/pay/webhooks/deliveryqueue/dao/WebhookDeliveryQueueEntity.java
@@ -76,7 +76,7 @@ public class WebhookDeliveryQueueEntity {
         PENDING,
         SUCCESSFUL,
         FAILED,
-        WONT_SEND
+        WILL_NOT_SEND
     }
 
 

--- a/src/main/java/uk/gov/pay/webhooks/deliveryqueue/dao/WebhookDeliveryQueueEntity.java
+++ b/src/main/java/uk/gov/pay/webhooks/deliveryqueue/dao/WebhookDeliveryQueueEntity.java
@@ -75,7 +75,8 @@ public class WebhookDeliveryQueueEntity {
     public enum DeliveryStatus {
         PENDING,
         SUCCESSFUL,
-        FAILED
+        FAILED,
+        WONT_SEND
     }
 
 

--- a/src/main/java/uk/gov/pay/webhooks/validations/CallbackUrlDomainNotOnAllowListException.java
+++ b/src/main/java/uk/gov/pay/webhooks/validations/CallbackUrlDomainNotOnAllowListException.java
@@ -3,10 +3,16 @@ package uk.gov.pay.webhooks.validations;
 import uk.gov.pay.webhooks.webhook.exception.WebhooksErrorIdentifier;
 import uk.gov.pay.webhooks.webhook.exception.WebhooksException;
 
-public class CallbackUrlDomainNotOnAllowListException extends WebhooksException {
+import java.net.URL;
 
-    public CallbackUrlDomainNotOnAllowListException(String message) {
+public class CallbackUrlDomainNotOnAllowListException extends WebhooksException {
+    private final URL url;
+    public CallbackUrlDomainNotOnAllowListException(String message, URL url) {
         super(message, WebhooksErrorIdentifier.CALLBACK_URL_NOT_ON_ALLOW_LIST);
+        this.url = url;
     }
 
+    public URL getUrl() {
+        return url;
+    }
 }

--- a/src/main/java/uk/gov/pay/webhooks/validations/CallbackUrlService.java
+++ b/src/main/java/uk/gov/pay/webhooks/validations/CallbackUrlService.java
@@ -68,6 +68,6 @@ public class CallbackUrlService {
                         .and(Markers.append(WEBHOOK_CALLBACK_URL_DOMAIN, callbackUrl.getHost())),
                 "Cannot set domains not found in allow list"
         );
-        throw new CallbackUrlDomainNotOnAllowListException(callbackUrl.getHost() + " is not in the allow list");
+        throw new CallbackUrlDomainNotOnAllowListException(callbackUrl.getHost() + " is not in the allow list", callbackUrl);
     }
 }

--- a/src/main/java/uk/gov/pay/webhooks/validations/CallbackUrlService.java
+++ b/src/main/java/uk/gov/pay/webhooks/validations/CallbackUrlService.java
@@ -2,7 +2,10 @@ package uk.gov.pay.webhooks.validations;
 
 import com.google.common.net.InternetDomainName;
 import com.google.inject.Inject;
+import net.logstash.logback.marker.Markers;
 import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import uk.gov.pay.webhooks.app.WebhooksConfig;
 
 import java.net.MalformedURLException;
@@ -10,8 +13,11 @@ import java.net.URL;
 import java.util.Set;
 
 import static java.util.stream.Collectors.toUnmodifiableSet;
+import static uk.gov.pay.webhooks.app.WebhooksKeys.WEBHOOK_CALLBACK_URL;
+import static uk.gov.pay.webhooks.app.WebhooksKeys.WEBHOOK_CALLBACK_URL_DOMAIN;
 
 public class CallbackUrlService {
+    private static final Logger LOGGER = LoggerFactory.getLogger(CallbackUrlService.class);
     private final Set<InternetDomainName> allowedDomains;
 
     @Inject
@@ -57,6 +63,11 @@ public class CallbackUrlService {
             }
             domain = domain.parent();
         }
+        LOGGER.warn(
+                Markers.append(WEBHOOK_CALLBACK_URL, callbackUrl.toString())
+                        .and(Markers.append(WEBHOOK_CALLBACK_URL_DOMAIN, callbackUrl.getHost())),
+                "Cannot set domains not found in allow list"
+        );
         throw new CallbackUrlDomainNotOnAllowListException(callbackUrl.getHost() + " is not in the allow list");
     }
 }

--- a/src/test/java/uk/gov/pay/webhooks/deliveryqueue/managed/SendAttempterTest.java
+++ b/src/test/java/uk/gov/pay/webhooks/deliveryqueue/managed/SendAttempterTest.java
@@ -151,6 +151,6 @@ class SendAttempterTest {
         var enqueuedItem = webhookDeliveryQueueDao.enqueueFrom(webhookMessage, WebhookDeliveryQueueEntity.DeliveryStatus.PENDING, instantSource.instant());
 
         sendAttempter.attemptSend(enqueuedItem);
-        assertThat(enqueuedItem.getDeliveryStatus(), is(WebhookDeliveryQueueEntity.DeliveryStatus.WONT_SEND));
+        assertThat(enqueuedItem.getDeliveryStatus(), is(WebhookDeliveryQueueEntity.DeliveryStatus.WILL_NOT_SEND));
     }
 }


### PR DESCRIPTION
Adds `WONT_SEND` status for message delivery attempts.

For live messages only, validates that the callback url being delivered
to at the time is in the allow list.

Adds logging expected by ticket for tying into protective monitoring.