### PR TITLE
PP-9016 Extend delivery status postgres check for WILL_NOT_SEND

### DIFF
--- a/src/main/resources/migrations/0010_alter_table_webhook_delivery_queue_alter_check_status_constraint.sql
+++ b/src/main/resources/migrations/0010_alter_table_webhook_delivery_queue_alter_check_status_constraint.sql
@@ -1,0 +1,5 @@
+ALTER TABLE webhook_delivery_queue
+DROP CONSTRAINT IF EXISTS webhook_delivery_queue_delivery_status_check;
+
+ALTER TABLE webhook_delivery_queue
+ADD CONSTRAINT webhook_delivery_queue_delivery_status_check CHECK (delivery_status in ('SUCCESSFUL', 'FAILED', 'PENDING', 'WILL_NOT_SEND'));

--- a/src/test/java/uk/gov/pay/webhooks/deliveryqueue/WebhookDeliveryQueueIT.java
+++ b/src/test/java/uk/gov/pay/webhooks/deliveryqueue/WebhookDeliveryQueueIT.java
@@ -1,0 +1,32 @@
+package uk.gov.pay.webhooks.deliveryqueue;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import uk.gov.pay.extension.AppWithPostgresAndSqsExtension;
+import uk.gov.pay.webhooks.deliveryqueue.dao.WebhookDeliveryQueueEntity;
+import uk.gov.pay.webhooks.util.DatabaseTestHelper;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+
+public class WebhookDeliveryQueueIT {
+    @RegisterExtension
+    public static AppWithPostgresAndSqsExtension app = new AppWithPostgresAndSqsExtension();
+    private DatabaseTestHelper dbHelper;
+
+    @BeforeEach
+    public void setUp() {
+        dbHelper = DatabaseTestHelper.aDatabaseTestHelper(app.getJdbi());
+        dbHelper.truncateAllData();
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = WebhookDeliveryQueueEntity.DeliveryStatus.class)
+    public void deliveryStatusEnumIsConsistentWithDatabase(WebhookDeliveryQueueEntity.DeliveryStatus status) {
+        app.getJdbi().withHandle(h -> h.execute("INSERT INTO webhooks VALUES (1, '2022-01-01', 'webhook-external-id', 'signing-key', 'service-id', true, 'https://callback-url.test', 'description', 'ACTIVE')"));
+        app.getJdbi().withHandle(h -> h.execute("INSERT INTO webhook_messages VALUES (1, 'message-external-id', '2022-01-01', 1, '2022-01-01', 1, '{}', 'transaction-external-id', 'payment')"));
+        assertDoesNotThrow(() -> app.getJdbi().withHandle(h -> h.execute("INSERT INTO webhook_delivery_queue VALUES (1, '2022-01-01', '2022-01-01', '200', 200, 1, '%s', 1250)".formatted(status))));
+    }
+}


### PR DESCRIPTION
Add `WILL_NOT_SEND` to postgres status values check. Exactly what this
constraint protects against should be reviewed in a subsequent change.

For the meantime, add a parameterised assertion that ensures that for any given
delivery status enum can be persisted in the real database.