### PR TITLE
PP-9865 Don't send or enqueue messages for non-active webhooks

### DIFF
--- a/src/main/java/uk/gov/pay/webhooks/deliveryqueue/WebhookNotActiveException.java
+++ b/src/main/java/uk/gov/pay/webhooks/deliveryqueue/WebhookNotActiveException.java
@@ -1,0 +1,9 @@
+package uk.gov.pay.webhooks.deliveryqueue;
+
+import uk.gov.pay.webhooks.webhook.exception.WebhooksException;
+
+public class WebhookNotActiveException extends WebhooksException {
+    public WebhookNotActiveException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/uk/gov/pay/webhooks/deliveryqueue/managed/SendAttempter.java
+++ b/src/main/java/uk/gov/pay/webhooks/deliveryqueue/managed/SendAttempter.java
@@ -5,6 +5,7 @@ import io.dropwizard.setup.Environment;
 import net.logstash.logback.marker.Markers;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import uk.gov.pay.webhooks.deliveryqueue.WebhookNotActiveException;
 import uk.gov.pay.webhooks.deliveryqueue.dao.WebhookDeliveryQueueDao;
 import uk.gov.pay.webhooks.deliveryqueue.dao.WebhookDeliveryQueueEntity;
 import uk.gov.pay.webhooks.message.WebhookMessageSender;
@@ -92,6 +93,9 @@ public class SendAttempter {
                     "Exception caught by request"
             );
             handleResponse(queueItem, WebhookDeliveryQueueEntity.DeliveryStatus.FAILED, null, e.getMessage(), retryCount, start);
+        } catch (WebhookNotActiveException e) {
+            LOGGER.info("Not sending webhook message for non-active webhook");
+            handleResponse(queueItem, WebhookDeliveryQueueEntity.DeliveryStatus.WILL_NOT_SEND, null, "Webhook not active", retryCount, start);
         } catch (CallbackUrlDomainNotOnAllowListException e) {
             LOGGER.error(
                     Markers.append(WEBHOOK_CALLBACK_URL_DOMAIN, e.getUrl()),

--- a/src/main/java/uk/gov/pay/webhooks/message/WebhookMessageSender.java
+++ b/src/main/java/uk/gov/pay/webhooks/message/WebhookMessageSender.java
@@ -1,9 +1,11 @@
 package uk.gov.pay.webhooks.message;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import uk.gov.pay.webhooks.deliveryqueue.WebhookNotActiveException;
 import uk.gov.pay.webhooks.message.dao.entity.WebhookMessageEntity;
 import uk.gov.pay.webhooks.validations.CallbackUrlDomainNotOnAllowListException;
 import uk.gov.pay.webhooks.validations.CallbackUrlService;
+import uk.gov.pay.webhooks.webhook.dao.entity.WebhookStatus;
 
 import javax.inject.Inject;
 import java.io.IOException;
@@ -40,6 +42,9 @@ public class WebhookMessageSender {
 
         if (webhook.isLive()) {
             callbackUrlService.validateCallbackUrl(webhook.getCallbackUrl(), webhook.isLive());
+        }
+        if (webhook.getStatus() != WebhookStatus.ACTIVE) {
+            throw new WebhookNotActiveException("Webhook must be active to send messages");
         }
 
         URI uri = URI.create(webhookMessage.getWebhookEntity().getCallbackUrl());

--- a/src/test/java/uk/gov/pay/webhooks/message/WebhookMessageSenderTest.java
+++ b/src/test/java/uk/gov/pay/webhooks/message/WebhookMessageSenderTest.java
@@ -15,6 +15,7 @@ import uk.gov.pay.webhooks.message.dao.entity.WebhookMessageEntity;
 import uk.gov.pay.webhooks.validations.CallbackUrlDomainNotOnAllowListException;
 import uk.gov.pay.webhooks.validations.CallbackUrlService;
 import uk.gov.pay.webhooks.webhook.dao.entity.WebhookEntity;
+import uk.gov.pay.webhooks.webhook.dao.entity.WebhookStatus;
 
 import java.io.IOException;
 import java.net.URI;
@@ -81,6 +82,7 @@ class WebhookMessageSenderTest {
         jsonPayload = objectMapper.readTree(PAYLOAD);
 
         webhookEntity = new WebhookEntity(); 
+        webhookEntity.setStatus(WebhookStatus.ACTIVE);
         webhookEntity.setCallbackUrl(CALLBACK_URL.toString());
         webhookEntity.setSigningKey(SIGNING_KEY);
         webhookEntity.setLive(true);


### PR DESCRIPTION
If a webhook has been moved into the `INACTIVE` or `DISABLED` states it
should not attempt to send webhook messages.

Check the webhook status when actually sending the message to ensure
there are no edge cases allowing messages through.