### PR TITLE
PP-9685 Dont process events for disabled webhook

### DIFF
--- a/src/main/java/uk/gov/pay/webhooks/webhook/WebhookService.java
+++ b/src/main/java/uk/gov/pay/webhooks/webhook/WebhookService.java
@@ -131,7 +131,12 @@ public class WebhookService {
         return list(event.live(), event.serviceId())
                 .stream()
                 .filter(webhook -> webhookHasSubscriptionForEvent(webhook, event))
+                .filter(this::webhookIsNotDisabled)
                 .toList();
+    }
+
+    private boolean webhookIsNotDisabled(WebhookEntity webhook) {
+        return webhook.getStatus() != WebhookStatus.DISABLED;
     }
 
     private boolean webhookHasSubscriptionForEvent(WebhookEntity webhook, InternalEvent event) {

--- a/src/main/java/uk/gov/pay/webhooks/webhook/dao/entity/WebhookStatus.java
+++ b/src/main/java/uk/gov/pay/webhooks/webhook/dao/entity/WebhookStatus.java
@@ -3,7 +3,7 @@ package uk.gov.pay.webhooks.webhook.dao.entity;
 import java.util.stream.Stream;
 
 public enum WebhookStatus {
-    ACTIVE, INACTIVE;
+    ACTIVE, INACTIVE, DISABLED;
 
     public static WebhookStatus of(String name) {
         return Stream.of(WebhookStatus.values())

--- a/src/test/java/uk/gov/pay/webhooks/validations/WebhookRequestValidatorTest.java
+++ b/src/test/java/uk/gov/pay/webhooks/validations/WebhookRequestValidatorTest.java
@@ -67,7 +67,7 @@ class WebhookRequestValidatorTest {
                         "op", "replace",
                         "value", "foo bar")));
         var thrown = assertThrows(ValidationException.class, () -> webhookRequestValidator.validate(request, false));
-        assertThat(thrown.getErrors().get(0), is("Value for path [status] must be one of ACTIVE or INACTIVE"));
+        assertThat(thrown.getErrors().get(0), is("Value for path [status] must be one of ACTIVE or INACTIVE or DISABLED"));
     }
 
     @Test


### PR DESCRIPTION
Depends on https://github.com/alphagov/pay-webhooks/pull/380

When a webhook has status `DISABLED` do not include it in the valid
webhook subscriptions.

Add additional coverage to assert a webhook can be moved into this
state by consumers.