### PR TITLE
PP-9274 Update internal hooks for subscriptions

### DIFF
--- a/src/main/java/uk/gov/pay/webhooks/eventtype/EventTypeName.java
+++ b/src/main/java/uk/gov/pay/webhooks/eventtype/EventTypeName.java
@@ -12,7 +12,11 @@ public enum EventTypeName {
     @JsonProperty("card_payment_captured")
     CARD_PAYMENT_CAPTURED("card_payment_captured"),
     @JsonProperty("card_payment_refunded")
-    CARD_PAYMENT_REFUNDED("card_payment_refunded");
+    CARD_PAYMENT_REFUNDED("card_payment_refunded"),
+    @JsonProperty("card_payment_failed")
+    CARD_PAYMENT_FAILED("card_payment_failed"),
+    @JsonProperty("card_payment_expired")
+    CARD_PAYMENT_EXPIRED("card_payment_expired");
 
     private final String name;
     

--- a/src/main/java/uk/gov/pay/webhooks/message/EventMapper.java
+++ b/src/main/java/uk/gov/pay/webhooks/message/EventMapper.java
@@ -10,21 +10,30 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 
 public class EventMapper {
-    private static final Map<String, EventTypeName> internalToWebhook = Map.of(
-            "PAYMENT_STARTED", EventTypeName.CARD_PAYMENT_STARTED,
-            "AUTHORISATION_SUCCEEDED", EventTypeName.CARD_PAYMENT_SUCCEEDED,
-            "CAPTURE_CONFIRMED", EventTypeName.CARD_PAYMENT_CAPTURED,
-            "REFUND_SUCCEEDED", EventTypeName.CARD_PAYMENT_REFUNDED
+    private static final Map<String, EventTypeName> internalToWebhook = Map.ofEntries(
+            Map.entry("USER_APPROVED_FOR_CAPTURE", EventTypeName.CARD_PAYMENT_SUCCEEDED),
+            Map.entry("SERVICE_APPROVED_FOR_CAPTURE", EventTypeName.CARD_PAYMENT_SUCCEEDED),
+            Map.entry("QUEUED_FOR_CAPTURE", EventTypeName.CARD_PAYMENT_SUCCEEDED),
+            Map.entry("AUTHORISATION_REJECTED", EventTypeName.CARD_PAYMENT_FAILED),
+            Map.entry("AUTHORISATION_CANCELLED", EventTypeName.CARD_PAYMENT_FAILED),
+            Map.entry("GATEWAY_ERROR_DURING_AUTHORISATION", EventTypeName.CARD_PAYMENT_FAILED),
+            Map.entry("GATEWAY_TIMEOUT_DURING_AUTHORISATION", EventTypeName.CARD_PAYMENT_FAILED),
+            Map.entry("UNEXPECTED_GATEWAY_ERROR_DURING_AUTHORISATION", EventTypeName.CARD_PAYMENT_FAILED),
+            Map.entry("CANCELLED_BY_EXTERNAL_SERVICE", EventTypeName.CARD_PAYMENT_FAILED),
+            Map.entry("CANCELLED_BY_USER", EventTypeName.CARD_PAYMENT_FAILED),
+            Map.entry("CANCELLED_BY_EXPIRATION", EventTypeName.CARD_PAYMENT_EXPIRED),
+            Map.entry("CAPTURE_CONFIRMED", EventTypeName.CARD_PAYMENT_CAPTURED),
+            Map.entry("REFUND_SUCCEEDED", EventTypeName.CARD_PAYMENT_REFUNDED)
     );
 
-    private static final Map<EventTypeName, String> webhookToInternal = internalToWebhook
-            .entrySet()
+    private static final Map<EventTypeName, List<String>> webhookToInternal = internalToWebhook
+            .keySet()
             .stream()
-            .collect(Collectors.toMap(Map.Entry::getValue, Map.Entry::getKey));
+            .collect(Collectors.groupingBy(internalToWebhook::get));
 
     private static final List<EventTypeName> childEvents = List.of(EventTypeName.CARD_PAYMENT_REFUNDED);
 
-    public static Optional<String> getInternalEventNameFor(EventTypeName webhookEventTypeName) {
+    public static Optional<List<String>> getInternalEventNameFor(EventTypeName webhookEventTypeName) {
         return Optional.ofNullable(webhookToInternal.get(webhookEventTypeName));
     }
 

--- a/src/main/java/uk/gov/pay/webhooks/message/EventMapper.java
+++ b/src/main/java/uk/gov/pay/webhooks/message/EventMapper.java
@@ -1,47 +1,47 @@
 package uk.gov.pay.webhooks.message;
 
-import jdk.jfr.Event;
-import jdk.jfr.EventType;
 import uk.gov.pay.webhooks.eventtype.EventTypeName;
 
-import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 
+import static java.util.Map.entry;
+
 public class EventMapper {
-    private static final Map<String, EventTypeName> internalToWebhook = Map.ofEntries(
-            Map.entry("USER_APPROVED_FOR_CAPTURE", EventTypeName.CARD_PAYMENT_SUCCEEDED),
-            Map.entry("SERVICE_APPROVED_FOR_CAPTURE", EventTypeName.CARD_PAYMENT_SUCCEEDED),
-            Map.entry("QUEUED_FOR_CAPTURE", EventTypeName.CARD_PAYMENT_SUCCEEDED),
-            Map.entry("AUTHORISATION_REJECTED", EventTypeName.CARD_PAYMENT_FAILED),
-            Map.entry("AUTHORISATION_CANCELLED", EventTypeName.CARD_PAYMENT_FAILED),
-            Map.entry("GATEWAY_ERROR_DURING_AUTHORISATION", EventTypeName.CARD_PAYMENT_FAILED),
-            Map.entry("GATEWAY_TIMEOUT_DURING_AUTHORISATION", EventTypeName.CARD_PAYMENT_FAILED),
-            Map.entry("UNEXPECTED_GATEWAY_ERROR_DURING_AUTHORISATION", EventTypeName.CARD_PAYMENT_FAILED),
-            Map.entry("CANCELLED_BY_EXTERNAL_SERVICE", EventTypeName.CARD_PAYMENT_FAILED),
-            Map.entry("CANCELLED_BY_USER", EventTypeName.CARD_PAYMENT_FAILED),
-            Map.entry("CANCELLED_BY_EXPIRATION", EventTypeName.CARD_PAYMENT_EXPIRED),
-            Map.entry("CAPTURE_CONFIRMED", EventTypeName.CARD_PAYMENT_CAPTURED),
-            Map.entry("REFUND_SUCCEEDED", EventTypeName.CARD_PAYMENT_REFUNDED)
+    private static final Map<String, EventTypeName> INTERNAL_TO_WEBHOOK = Map.ofEntries(
+            entry("USER_APPROVED_FOR_CAPTURE", EventTypeName.CARD_PAYMENT_SUCCEEDED),
+            entry("SERVICE_APPROVED_FOR_CAPTURE", EventTypeName.CARD_PAYMENT_SUCCEEDED),
+            entry("QUEUED_FOR_CAPTURE", EventTypeName.CARD_PAYMENT_SUCCEEDED),
+            entry("AUTHORISATION_REJECTED", EventTypeName.CARD_PAYMENT_FAILED),
+            entry("AUTHORISATION_CANCELLED", EventTypeName.CARD_PAYMENT_FAILED),
+            entry("GATEWAY_ERROR_DURING_AUTHORISATION", EventTypeName.CARD_PAYMENT_FAILED),
+            entry("GATEWAY_TIMEOUT_DURING_AUTHORISATION", EventTypeName.CARD_PAYMENT_FAILED),
+            entry("UNEXPECTED_GATEWAY_ERROR_DURING_AUTHORISATION", EventTypeName.CARD_PAYMENT_FAILED),
+            entry("CANCELLED_BY_EXTERNAL_SERVICE", EventTypeName.CARD_PAYMENT_FAILED),
+            entry("CANCELLED_BY_USER", EventTypeName.CARD_PAYMENT_FAILED),
+            entry("CANCELLED_BY_EXPIRATION", EventTypeName.CARD_PAYMENT_EXPIRED),
+            entry("CAPTURE_CONFIRMED", EventTypeName.CARD_PAYMENT_CAPTURED),
+            entry("REFUND_SUCCEEDED", EventTypeName.CARD_PAYMENT_REFUNDED)
     );
 
-    private static final Map<EventTypeName, List<String>> webhookToInternal = internalToWebhook
+    private static final Map<EventTypeName, Set<String>> WEBHOOK_TO_INTERNAL = INTERNAL_TO_WEBHOOK
             .keySet()
             .stream()
-            .collect(Collectors.groupingBy(internalToWebhook::get));
+            .collect(Collectors.groupingBy(INTERNAL_TO_WEBHOOK::get, Collectors.toUnmodifiableSet()));
 
-    private static final List<EventTypeName> childEvents = List.of(EventTypeName.CARD_PAYMENT_REFUNDED);
+    private static final Set<EventTypeName> CHILD_EVENTS = Set.of(EventTypeName.CARD_PAYMENT_REFUNDED);
 
-    public static Optional<List<String>> getInternalEventNameFor(EventTypeName webhookEventTypeName) {
-        return Optional.ofNullable(webhookToInternal.get(webhookEventTypeName));
+    public static Set<String> getInternalEventNamesFor(EventTypeName webhookEventTypeName) {
+        return Optional.ofNullable(WEBHOOK_TO_INTERNAL.get(webhookEventTypeName)).orElse(Set.of());
     }
 
     public static EventTypeName getWebhookEventNameFor(String webhookEventName) {
-        return internalToWebhook.get(webhookEventName);
+        return INTERNAL_TO_WEBHOOK.get(webhookEventName);
     }
 
     public static boolean isChildEvent(EventTypeName webhookEventTypeName) {
-        return childEvents.contains(webhookEventTypeName);
+        return CHILD_EVENTS.contains(webhookEventTypeName);
     }
 }

--- a/src/main/java/uk/gov/pay/webhooks/webhook/WebhookService.java
+++ b/src/main/java/uk/gov/pay/webhooks/webhook/WebhookService.java
@@ -139,6 +139,6 @@ public class WebhookService {
                 .map(EventTypeEntity::getName)
                 .map(EventMapper::getInternalEventNameFor)
                 .flatMap(Optional::stream)
-                .anyMatch(internalEventName -> internalEventName.equals(event.eventType()));
+                .anyMatch(internalEventName -> internalEventName.contains(event.eventType()));
     }
 }

--- a/src/main/java/uk/gov/pay/webhooks/webhook/WebhookService.java
+++ b/src/main/java/uk/gov/pay/webhooks/webhook/WebhookService.java
@@ -1,13 +1,11 @@
 package uk.gov.pay.webhooks.webhook;
 
 import uk.gov.pay.webhooks.deliveryqueue.dao.WebhookDeliveryQueueDao;
-import uk.gov.pay.webhooks.deliveryqueue.dao.WebhookDeliveryQueueEntity;
 import uk.gov.pay.webhooks.eventtype.EventTypeName;
 import uk.gov.pay.webhooks.eventtype.dao.EventTypeDao;
 import uk.gov.pay.webhooks.eventtype.dao.EventTypeEntity;
 import uk.gov.pay.webhooks.message.EventMapper;
 import uk.gov.pay.webhooks.message.dao.WebhookMessageDao;
-import uk.gov.pay.webhooks.message.dao.entity.WebhookMessageEntity;
 import uk.gov.pay.webhooks.message.resource.WebhookDeliveryQueueResponse;
 import uk.gov.pay.webhooks.message.resource.WebhookMessageResponse;
 import uk.gov.pay.webhooks.message.resource.WebhookMessageSearchResponse;
@@ -137,8 +135,7 @@ public class WebhookService {
     private boolean webhookHasSubscriptionForEvent(WebhookEntity webhook, InternalEvent event) {
         return webhook.getSubscriptions().stream()
                 .map(EventTypeEntity::getName)
-                .map(EventMapper::getInternalEventNameFor)
-                .flatMap(Optional::stream)
-                .anyMatch(internalEventName -> internalEventName.contains(event.eventType()));
+                .map(EventMapper::getInternalEventNamesFor)
+                .anyMatch(internalEventNames -> internalEventNames.contains(event.eventType()));
     }
 }

--- a/src/test/java/uk/gov/pay/webhooks/validations/WebhookRequestValidatorTest.java
+++ b/src/test/java/uk/gov/pay/webhooks/validations/WebhookRequestValidatorTest.java
@@ -95,7 +95,7 @@ class WebhookRequestValidatorTest {
                         """
         );
         var thrown = assertThrows(ValidationException.class, () -> webhookRequestValidator.validate(request, false));
-        assertThat(thrown.getErrors().get(0), is("Value for path [subscriptions] must be array of [card_payment_started, card_payment_succeeded, card_payment_captured, card_payment_refunded]"));
+        assertThat(thrown.getErrors().get(0), is("Value for path [subscriptions] must be array of [card_payment_started, card_payment_succeeded, card_payment_captured, card_payment_refunded, card_payment_failed, card_payment_expired]"));
     }
 
     @Test
@@ -113,7 +113,7 @@ class WebhookRequestValidatorTest {
                         """
         );
         var thrown = assertThrows(ValidationException.class, () -> webhookRequestValidator.validate(request, false));
-        assertThat(thrown.getErrors().get(0), is("Value for path [subscriptions] must be array of [card_payment_started, card_payment_succeeded, card_payment_captured, card_payment_refunded]"));
+        assertThat(thrown.getErrors().get(0), is("Value for path [subscriptions] must be array of [card_payment_started, card_payment_succeeded, card_payment_captured, card_payment_refunded, card_payment_failed, card_payment_expired]"));
     }
 
     @Test


### PR DESCRIPTION
Depends on https://github.com/alphagov/pay-webhooks/pull/386

Introduces new failed and expired mappings to internal events.

Update successful event mappings, previous "authorisation success" had
been used however this event is reached before a paying user "confirms"
a payment and the payment can still be cancelled at this point in time.
Instead of this use the confirmed for capture event which will guarantee
that the payment will be taken.