### PR TITLE
PP-9016: Compare apache and java net http client

### DIFF
--- a/src/main/java/uk/gov/pay/webhooks/app/WebhooksModule.java
+++ b/src/main/java/uk/gov/pay/webhooks/app/WebhooksModule.java
@@ -56,6 +56,12 @@ public class WebhooksModule extends AbstractModule {
 
     @Provides
     @Singleton
+    public java.net.http.HttpClient netHttpClient() {
+        return java.net.http.HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(5)).build();
+    }
+
+    @Provides
+    @Singleton
     public HttpClient httpClient() {
         var timeoutInMillis = Math.toIntExact(Duration.ofSeconds(5).toMillis());
         var config = RequestConfig.custom()

--- a/src/main/java/uk/gov/pay/webhooks/deliveryqueue/managed/SendAttempter.java
+++ b/src/main/java/uk/gov/pay/webhooks/deliveryqueue/managed/SendAttempter.java
@@ -89,7 +89,7 @@ public class SendAttempter {
                 handleResponse(queueItem, WebhookDeliveryQueueEntity.DeliveryStatus.FAILED, statusCode, getReasonFromStatusCode(statusCode), retryCount, start);
             }
         } catch (SocketTimeoutException | HttpTimeoutException | NoHttpResponseException | ConnectTimeoutException e) {
-            LOGGER.info("Request timed out");
+            LOGGER.info("Request timed out %s [%s]".formatted(e.getMessage(), e), e);
             handleResponse(queueItem, WebhookDeliveryQueueEntity.DeliveryStatus.FAILED, null, "HTTP Timeout", retryCount, start);
         } catch (IOException | InterruptedException | InvalidKeyException e) {
             LOGGER.info(

--- a/src/main/java/uk/gov/pay/webhooks/message/WebhookMessageSender.java
+++ b/src/main/java/uk/gov/pay/webhooks/message/WebhookMessageSender.java
@@ -1,6 +1,10 @@
 package uk.gov.pay.webhooks.message;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.http.HttpResponse;
+import org.apache.http.client.HttpClient;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.entity.StringEntity;
 import uk.gov.pay.webhooks.deliveryqueue.WebhookNotActiveException;
 import uk.gov.pay.webhooks.message.dao.entity.WebhookMessageEntity;
 import uk.gov.pay.webhooks.validations.CallbackUrlDomainNotOnAllowListException;
@@ -10,9 +14,6 @@ import uk.gov.pay.webhooks.webhook.dao.entity.WebhookStatus;
 import javax.inject.Inject;
 import java.io.IOException;
 import java.net.URI;
-import java.net.http.HttpClient;
-import java.net.http.HttpRequest;
-import java.net.http.HttpResponse;
 import java.security.InvalidKeyException;
 import java.time.Duration;
 
@@ -37,7 +38,7 @@ public class WebhookMessageSender {
         this.objectMapper = objectMapper;
     }
 
-    public HttpResponse<String> sendWebhookMessage(WebhookMessageEntity webhookMessage) throws IOException, InterruptedException, InvalidKeyException, CallbackUrlDomainNotOnAllowListException {
+    public HttpResponse sendWebhookMessage(WebhookMessageEntity webhookMessage) throws IOException, InterruptedException, InvalidKeyException, CallbackUrlDomainNotOnAllowListException {
         var webhook = webhookMessage.getWebhookEntity();
 
         if (webhook.isLive()) {
@@ -52,14 +53,11 @@ public class WebhookMessageSender {
         String signingKey = webhookMessage.getWebhookEntity().getSigningKey();
         String signature = webhookMessageSignatureGenerator.generate(body, signingKey);
 
-        var httpRequest = HttpRequest.newBuilder(uri)
-                .timeout(TIMEOUT)
-                .header("Content-Type", "application/json")
-                .header(SIGNATURE_HEADER_NAME, signature)
-                .POST(HttpRequest.BodyPublishers.ofString(body))
-                .build();
-
-        return httpClient.send(httpRequest, HttpResponse.BodyHandlers.ofString());
+        var request = new HttpPost(uri);
+        request.addHeader("Content-Type", "application/json");
+        request.addHeader(SIGNATURE_HEADER_NAME, signature);
+        request.setEntity(new StringEntity(body));
+        return httpClient.execute(request);
     }
 
 }

--- a/src/test/java/uk/gov/pay/webhooks/deliveryqueue/managed/WebhookMessagePollingServiceTest.java
+++ b/src/test/java/uk/gov/pay/webhooks/deliveryqueue/managed/WebhookMessagePollingServiceTest.java
@@ -5,6 +5,8 @@ import io.dropwizard.hibernate.UnitOfWorkAwareProxyFactory;
 import io.dropwizard.setup.Environment;
 import io.dropwizard.testing.junit5.DAOTestExtension;
 import io.dropwizard.testing.junit5.DropwizardExtensionsSupport;
+import org.apache.http.HttpResponse;
+import org.apache.http.StatusLine;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -25,7 +27,6 @@ import uk.gov.pay.webhooks.webhook.dao.WebhookDao;
 import uk.gov.pay.webhooks.webhook.dao.entity.WebhookEntity;
 
 import java.io.IOException;
-import java.net.http.HttpResponse;
 import java.security.InvalidKeyException;
 import java.time.Instant;
 import java.time.InstantSource;
@@ -60,13 +61,16 @@ class WebhookMessagePollingServiceTest {
     private SendAttempter sendAttempter;
     @Mock
     private HttpResponse response;
+    @Mock
+    private StatusLine statusLine;
 
     @BeforeEach
     void setUp() throws IOException, InvalidKeyException, InterruptedException {
         var environment = mock(Environment.class);
 
         when(environment.metrics()).thenReturn(mock(MetricRegistry.class));
-        when(response.statusCode()).thenReturn(200);
+        when(response.getStatusLine()).thenReturn(statusLine);
+        when(statusLine.getStatusCode()).thenReturn(200);
         webhookMessageSenderMock = mock(WebhookMessageSender.class);
         when(webhookMessageSenderMock.sendWebhookMessage(any(WebhookMessageEntity.class))).thenReturn(response);
         instantSource = InstantSource.fixed(Instant.now());
@@ -119,7 +123,7 @@ class WebhookMessagePollingServiceTest {
 
     @Test
     public void shouldAppropriatelyHandleFailedEmitAndNotTryAgainImmediately() {
-        when(response.statusCode()).thenReturn(500);
+        when(statusLine.getStatusCode()).thenReturn(500);
         setupOrderedDeliveryQueueWith(List.of("first-external-id"));
 
         database.inTransaction(() -> {

--- a/src/test/java/uk/gov/pay/webhooks/message/WebhookMessageSenderTest.java
+++ b/src/test/java/uk/gov/pay/webhooks/message/WebhookMessageSenderTest.java
@@ -3,6 +3,9 @@ package uk.gov.pay.webhooks.message;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.http.HttpResponse;
+import org.apache.http.client.HttpClient;
+import org.apache.http.client.methods.HttpUriRequest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -19,23 +22,16 @@ import uk.gov.pay.webhooks.webhook.dao.entity.WebhookStatus;
 
 import java.io.IOException;
 import java.net.URI;
-import java.net.http.HttpClient;
-import java.net.http.HttpRequest;
-import java.net.http.HttpResponse;
 import java.security.InvalidKeyException;
 import java.time.Instant;
-import java.util.Optional;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.when;
 import static uk.gov.pay.webhooks.message.WebhookMessageSender.SIGNATURE_HEADER_NAME;
-import static uk.gov.pay.webhooks.message.WebhookMessageSender.TIMEOUT;
 
 @ExtendWith(MockitoExtension.class)
 class WebhookMessageSenderTest {
@@ -69,7 +65,7 @@ class WebhookMessageSenderTest {
     private CallbackUrlService callbackUrlService;
 
     @Mock
-    private HttpResponse<String> mockHttpResponse;
+    private HttpResponse mockHttpResponse;
     
     private final ObjectMapper objectMapper = new ObjectMapper();
     private WebhookMessageSender webhookMessageSender;
@@ -102,33 +98,24 @@ class WebhookMessageSenderTest {
 
     @Test
     void constructsHttpRequestAndReturnsHttpResponse() throws IOException, InvalidKeyException, InterruptedException {
-        var httpRequestArgumentCaptor = ArgumentCaptor.forClass(HttpRequest.class);
+        var httpRequestArgumentCaptor = ArgumentCaptor.forClass(HttpUriRequest.class);
         given(mockWebhookMessageSignatureGenerator.generate(objectMapper.writeValueAsString(WebhookMessageBody.from(webhookMessageEntity)), SIGNING_KEY)).willReturn(SIGNATURE);
-        given(mockHttpClient.send(httpRequestArgumentCaptor.capture(), eq(HttpResponse.BodyHandlers.ofString()))).willReturn(mockHttpResponse);
+        given(mockHttpClient.execute(httpRequestArgumentCaptor.capture())).willReturn(mockHttpResponse);
 
-        HttpResponse<String> result = webhookMessageSender.sendWebhookMessage(webhookMessageEntity);
+        HttpResponse result = webhookMessageSender.sendWebhookMessage(webhookMessageEntity);
 
-        HttpRequest httpRequest = httpRequestArgumentCaptor.getValue();
-        assertThat(httpRequest.uri(), is(CALLBACK_URL));
-        assertThat(httpRequest.timeout(), is(Optional.of(TIMEOUT)));
-        assertThat(httpRequest.headers().firstValue("Content-Type"), is(Optional.of("application/json")));
-        assertThat(httpRequest.headers().firstValue(SIGNATURE_HEADER_NAME), is(Optional.of(SIGNATURE)));
-
+        HttpUriRequest httpRequest = httpRequestArgumentCaptor.getValue();
+        assertThat(httpRequest.getURI(), is(CALLBACK_URL));
+        assertThat(httpRequest.getFirstHeader("Content-Type").getValue(), is("application/json"));
+        assertThat(httpRequest.getFirstHeader(SIGNATURE_HEADER_NAME).getValue(), is(SIGNATURE));
         assertThat(result, is(mockHttpResponse));
     }
 
     @Test
     void propagatesIOException() throws IOException, InterruptedException, InvalidKeyException {
-        given(mockHttpClient.send(any(HttpRequest.class), eq(HttpResponse.BodyHandlers.ofString()))).willThrow(IOException.class);
+        given(mockHttpClient.execute(any(HttpUriRequest.class))).willThrow(IOException.class);
         given(mockWebhookMessageSignatureGenerator.generate(objectMapper.writeValueAsString(WebhookMessageBody.from(webhookMessageEntity)), SIGNING_KEY)).willReturn(SIGNATURE);
         assertThrows(IOException.class, () -> webhookMessageSender.sendWebhookMessage(webhookMessageEntity));
-    }
-
-    @Test
-    void propagatesInterruptedException() throws IOException, InterruptedException, InvalidKeyException {
-        given(mockHttpClient.send(any(HttpRequest.class), eq(HttpResponse.BodyHandlers.ofString()))).willThrow(InterruptedException.class);
-        given(mockWebhookMessageSignatureGenerator.generate(objectMapper.writeValueAsString(WebhookMessageBody.from(webhookMessageEntity)), SIGNING_KEY)).willReturn(SIGNATURE);
-        assertThrows(InterruptedException.class, () -> webhookMessageSender.sendWebhookMessage(webhookMessageEntity));
     }
 
     @Test


### PR DESCRIPTION
The apache client gives us more control over:
- connection pool behaviour, specifically around timeout behaviours for
  connection pools where we have no control over the receiving servers
  connection behaviour. We suspect these connection pools being
  terminated result in intermittent "Connection Reset" errors
- ease of specifying TLS and cipher requirements