### PR TITLE
PP-9016 Compare apache and java net http client

### DIFF
--- a/src/main/java/uk/gov/pay/webhooks/app/QueueMessageReceiverConfig.java
+++ b/src/main/java/uk/gov/pay/webhooks/app/QueueMessageReceiverConfig.java
@@ -1,6 +1,7 @@
 package uk.gov.pay.webhooks.app;
 
 import io.dropwizard.Configuration;
+import io.dropwizard.util.Duration;
 
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
@@ -21,6 +22,10 @@ public class QueueMessageReceiverConfig extends Configuration {
     @Valid
     @NotNull
     private int messageRetryDelayInSeconds;
+    @NotNull
+    private Duration connectionPoolTimeToLive;
+    @NotNull
+    private Duration requestTimeout;
 
     public int getThreadDelayInMilliseconds() {
         return threadDelayInMilliseconds;
@@ -35,4 +40,12 @@ public class QueueMessageReceiverConfig extends Configuration {
     }
 
     public boolean isBackgroundProcessingEnabled() { return backgroundProcessingEnabled; }
+
+    public Duration getConnectionPoolTimeToLive() {
+        return connectionPoolTimeToLive;
+    }
+
+    public Duration getRequestTimeout() {
+        return requestTimeout;
+    }
 }

--- a/src/main/java/uk/gov/pay/webhooks/app/WebhooksModule.java
+++ b/src/main/java/uk/gov/pay/webhooks/app/WebhooksModule.java
@@ -10,13 +10,10 @@ import com.google.inject.Provides;
 import io.dropwizard.hibernate.HibernateBundle;
 import io.dropwizard.hibernate.UnitOfWorkAwareProxyFactory;
 import io.dropwizard.setup.Environment;
-import org.apache.http.client.HttpClient;
 import org.apache.http.client.config.RequestConfig;
 import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
 import org.apache.http.impl.client.CloseableHttpClient;
-import org.apache.http.impl.client.DefaultHttpClient;
 import org.apache.http.impl.client.HttpClientBuilder;
-import org.apache.http.impl.client.HttpClients;
 import org.apache.http.ssl.SSLContexts;
 import org.hibernate.SessionFactory;
 import uk.gov.pay.webhooks.message.WebhookMessageSignatureGenerator;
@@ -66,7 +63,7 @@ public class WebhooksModule extends AbstractModule {
     @Provides
     @Singleton
     public CloseableHttpClient httpClient() {
-        var timeoutInMillis = Math.toIntExact(Duration.ofSeconds(5).toMillis());
+        var timeoutInMillis = Math.toIntExact(configuration.getQueueMessageReceiverConfig().getRequestTimeout().toMilliseconds());
         var config = RequestConfig.custom()
                 .setConnectTimeout(timeoutInMillis)
                 .setConnectionRequestTimeout(timeoutInMillis)
@@ -82,7 +79,7 @@ public class WebhooksModule extends AbstractModule {
 
         return HttpClientBuilder.create()
                 .useSystemProperties()
-                .setConnectionTimeToLive(60L, TimeUnit.SECONDS)
+                .setConnectionTimeToLive(configuration.getQueueMessageReceiverConfig().getConnectionPoolTimeToLive().toSeconds(), TimeUnit.SECONDS)
                 .setSSLSocketFactory(sslsf)
                 .setDefaultRequestConfig(config)
                 .build();

--- a/src/main/java/uk/gov/pay/webhooks/app/WebhooksModule.java
+++ b/src/main/java/uk/gov/pay/webhooks/app/WebhooksModule.java
@@ -5,22 +5,27 @@ import com.amazonaws.auth.BasicAWSCredentials;
 import com.amazonaws.client.builder.AwsClientBuilder;
 import com.amazonaws.services.sqs.AmazonSQS;
 import com.amazonaws.services.sqs.AmazonSQSClientBuilder;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.google.inject.AbstractModule;
 import com.google.inject.Provides;
 import io.dropwizard.hibernate.HibernateBundle;
 import io.dropwizard.hibernate.UnitOfWorkAwareProxyFactory;
 import io.dropwizard.setup.Environment;
+import org.apache.http.client.HttpClient;
+import org.apache.http.client.config.RequestConfig;
+import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.DefaultHttpClient;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.impl.client.HttpClients;
+import org.apache.http.ssl.SSLContexts;
 import org.hibernate.SessionFactory;
-import uk.gov.pay.webhooks.message.WebhookMessageSender;
 import uk.gov.pay.webhooks.message.WebhookMessageSignatureGenerator;
 import uk.gov.pay.webhooks.util.IdGenerator;
 
 import javax.inject.Singleton;
-import java.net.http.HttpClient;
 import java.time.Duration;
 import java.time.InstantSource;
+import java.util.concurrent.TimeUnit;
 
 public class WebhooksModule extends AbstractModule {
     private final WebhooksConfig configuration;
@@ -54,8 +59,33 @@ public class WebhooksModule extends AbstractModule {
 
     @Provides
     @Singleton
-    public HttpClient httpClient() {
-        return HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(5)).build();
+    public java.net.http.HttpClient netHttpClient() {
+        return java.net.http.HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(5)).build();
+    }
+
+    @Provides
+    @Singleton
+    public CloseableHttpClient httpClient() {
+        var timeoutInMillis = Math.toIntExact(Duration.ofSeconds(5).toMillis());
+        var config = RequestConfig.custom()
+                .setConnectTimeout(timeoutInMillis)
+                .setConnectionRequestTimeout(timeoutInMillis)
+                .setSocketTimeout(timeoutInMillis)
+                .build();
+
+        var sslsf = new SSLConnectionSocketFactory(
+                SSLContexts.createDefault(),
+                new String[] { "TLSv1.2", "TLSv1.3" },
+                null,
+                SSLConnectionSocketFactory.getDefaultHostnameVerifier()
+        );
+
+        return HttpClientBuilder.create()
+                .useSystemProperties()
+                .setConnectionTimeToLive(60L, TimeUnit.SECONDS)
+                .setSSLSocketFactory(sslsf)
+                .setDefaultRequestConfig(config)
+                .build();
     }
 
     @Provides

--- a/src/main/java/uk/gov/pay/webhooks/message/WebhookMessageSender.java
+++ b/src/main/java/uk/gov/pay/webhooks/message/WebhookMessageSender.java
@@ -22,7 +22,6 @@ import java.time.Duration;
 public class WebhookMessageSender {
 
     public static final String SIGNATURE_HEADER_NAME = "Pay-Signature";
-    public static final Duration TIMEOUT = Duration.ofSeconds(5);
 
     private final CloseableHttpClient httpClient;
     private final WebhookMessageSignatureGenerator webhookMessageSignatureGenerator;

--- a/src/main/resources/config/config.yaml
+++ b/src/main/resources/config/config.yaml
@@ -83,5 +83,7 @@ webhookMessageSendingQueueProcessorConfig:
   numberOfThreads: ${WEBHOOK_MESSAGE_SENDING_QUEUE_NUMBER_OF_THREADS:-1}
   initialDelayInMilliseconds: ${WEBHOOK_MESSAGE_SENDING_QUEUE_INITIAL_DELAY_IN_MILLISECONDS:-30000}
   threadDelayInMilliseconds: ${WEBHOOK_MESSAGE_SENDING_QUEUE_THREAD_DELAY_IN_MILLISECONDS:-1000}
+  connectionPoolTimeToLive: ${WEBHOOK_MESSAGE_SENDER_CONNECTION_POOL_TIME_TO_LIVE:-60s}
+  requestTimeout: ${WEBHOOK_MESSAGE_SENDER_REQUEST_TIMEOUT:-5s}
 
 liveDataAllowDomains: ["gov.uk"]

--- a/src/test/java/uk/gov/pay/webhooks/deliveryqueue/managed/SendAttempterTest.java
+++ b/src/test/java/uk/gov/pay/webhooks/deliveryqueue/managed/SendAttempterTest.java
@@ -4,6 +4,9 @@ import com.codahale.metrics.MetricRegistry;
 import io.dropwizard.setup.Environment;
 import io.dropwizard.testing.junit5.DAOTestExtension;
 import io.dropwizard.testing.junit5.DropwizardExtensionsSupport;
+import org.apache.http.HttpResponse;
+import org.apache.http.StatusLine;
+import org.apache.http.client.methods.CloseableHttpResponse;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -21,7 +24,6 @@ import uk.gov.pay.webhooks.webhook.dao.WebhookDao;
 import uk.gov.pay.webhooks.webhook.dao.entity.WebhookEntity;
 
 import java.io.IOException;
-import java.net.http.HttpResponse;
 import java.net.http.HttpTimeoutException;
 import java.security.InvalidKeyException;
 import java.time.Instant;
@@ -56,7 +58,8 @@ class SendAttempterTest {
     private WebhookMessageSender mockWebhookMessageSender;
     
     @Mock
-    private HttpResponse mockHttpResponse;
+    private CloseableHttpResponse mockHttpResponse;
+    @Mock private StatusLine mockStatusLine;
     
     @Mock
     private Environment mockEnvironment;    
@@ -85,12 +88,13 @@ class SendAttempterTest {
     
     @Test
     void sendAttempterSetsDeliveryStatusBasedOnStatusCode() throws IOException, InterruptedException, InvalidKeyException {
+        given(mockHttpResponse.getStatusLine()).willReturn(mockStatusLine);
         given(mockWebhookMessageSender.sendWebhookMessage(any(WebhookMessageEntity.class))).willReturn(mockHttpResponse);
         
         var webhookMessage = webhookMessageDao.create(webhookMessageEntity);
         var sendAttempter = new SendAttempter(webhookDeliveryQueueDao, instantSource, mockWebhookMessageSender, mockEnvironment);
         var enqueuedItem = webhookDeliveryQueueDao.enqueueFrom(webhookMessage, WebhookDeliveryQueueEntity.DeliveryStatus.PENDING, instantSource.instant());
-        given(mockHttpResponse.statusCode()).willReturn(404, 200);
+        given(mockStatusLine.getStatusCode()).willReturn(404, 200);
         
         sendAttempter.attemptSend(enqueuedItem);
         assertThat(enqueuedItem.getDeliveryStatus(), is(WebhookDeliveryQueueEntity.DeliveryStatus.FAILED));
@@ -102,19 +106,19 @@ class SendAttempterTest {
     
     @Test
     void sendAttempterEmitsDeliveryStatusMetric() throws IOException, InvalidKeyException, InterruptedException {
+        given(mockHttpResponse.getStatusLine()).willReturn(mockStatusLine);
         given(mockWebhookMessageSender.sendWebhookMessage(any(WebhookMessageEntity.class))).willReturn(mockHttpResponse);
         
         var webhookMessage = webhookMessageDao.create(webhookMessageEntity);
         var sendAttempter = new SendAttempter(webhookDeliveryQueueDao, instantSource, mockWebhookMessageSender, mockEnvironment);
         var enqueuedItem = webhookDeliveryQueueDao.enqueueFrom(webhookMessage, WebhookDeliveryQueueEntity.DeliveryStatus.PENDING, instantSource.instant());
-        given(mockHttpResponse.statusCode()).willReturn(200);
+        given(mockStatusLine.getStatusCode()).willReturn(200);
         sendAttempter.attemptSend(enqueuedItem);
         verify(mockMetricRegistry).counter("delivery-status.SUCCESSFUL");
     }
 
     @Test
     void sendAttempterCatchesExceptions() throws IOException, InterruptedException, InvalidKeyException {
-
         var webhookMessage = webhookMessageDao.create(webhookMessageEntity);
         var sendAttempter = new SendAttempter(webhookDeliveryQueueDao, instantSource, mockWebhookMessageSender, mockEnvironment);
         var enqueuedItem = webhookDeliveryQueueDao.enqueueFrom(webhookMessage, WebhookDeliveryQueueEntity.DeliveryStatus.PENDING, instantSource.instant());
@@ -129,11 +133,12 @@ class SendAttempterTest {
     
     @Test
     void sendAttempterEnqueuesRetriesIfFailure() throws IOException, InvalidKeyException, InterruptedException {
+        given(mockHttpResponse.getStatusLine()).willReturn(mockStatusLine);
         given(mockWebhookMessageSender.sendWebhookMessage(any(WebhookMessageEntity.class))).willReturn(mockHttpResponse);
         var webhookMessage = webhookMessageDao.create(webhookMessageEntity);
         var sendAttempter = new SendAttempter(webhookDeliveryQueueDao, instantSource, mockWebhookMessageSender, mockEnvironment);
         var enqueuedItem = webhookDeliveryQueueDao.enqueueFrom(webhookMessage, WebhookDeliveryQueueEntity.DeliveryStatus.PENDING, instantSource.instant());
-        given(mockHttpResponse.statusCode()).willReturn(404);
+        given(mockStatusLine.getStatusCode()).willReturn(404);
        
         sendAttempter.attemptSend(enqueuedItem);
         assertThat(enqueuedItem.getDeliveryStatus(), is(WebhookDeliveryQueueEntity.DeliveryStatus.FAILED));

--- a/src/test/java/uk/gov/pay/webhooks/message/WebhookMessageSenderTest.java
+++ b/src/test/java/uk/gov/pay/webhooks/message/WebhookMessageSenderTest.java
@@ -3,6 +3,11 @@ package uk.gov.pay.webhooks.message;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.http.HttpResponse;
+import org.apache.http.client.HttpClient;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpUriRequest;
+import org.apache.http.impl.client.CloseableHttpClient;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -19,23 +24,16 @@ import uk.gov.pay.webhooks.webhook.dao.entity.WebhookStatus;
 
 import java.io.IOException;
 import java.net.URI;
-import java.net.http.HttpClient;
-import java.net.http.HttpRequest;
-import java.net.http.HttpResponse;
 import java.security.InvalidKeyException;
 import java.time.Instant;
-import java.util.Optional;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.when;
 import static uk.gov.pay.webhooks.message.WebhookMessageSender.SIGNATURE_HEADER_NAME;
-import static uk.gov.pay.webhooks.message.WebhookMessageSender.TIMEOUT;
 
 @ExtendWith(MockitoExtension.class)
 class WebhookMessageSenderTest {
@@ -60,7 +58,7 @@ class WebhookMessageSenderTest {
     private static final String SIGNATURE = "Signature";
 
     @Mock
-    private HttpClient mockHttpClient;
+    private CloseableHttpClient mockHttpClient;
 
     @Mock
     private WebhookMessageSignatureGenerator mockWebhookMessageSignatureGenerator;
@@ -69,7 +67,7 @@ class WebhookMessageSenderTest {
     private CallbackUrlService callbackUrlService;
 
     @Mock
-    private HttpResponse<String> mockHttpResponse;
+    private CloseableHttpResponse mockHttpResponse;
     
     private final ObjectMapper objectMapper = new ObjectMapper();
     private WebhookMessageSender webhookMessageSender;
@@ -102,33 +100,24 @@ class WebhookMessageSenderTest {
 
     @Test
     void constructsHttpRequestAndReturnsHttpResponse() throws IOException, InvalidKeyException, InterruptedException {
-        var httpRequestArgumentCaptor = ArgumentCaptor.forClass(HttpRequest.class);
+        var httpRequestArgumentCaptor = ArgumentCaptor.forClass(HttpUriRequest.class);
         given(mockWebhookMessageSignatureGenerator.generate(objectMapper.writeValueAsString(WebhookMessageBody.from(webhookMessageEntity)), SIGNING_KEY)).willReturn(SIGNATURE);
-        given(mockHttpClient.send(httpRequestArgumentCaptor.capture(), eq(HttpResponse.BodyHandlers.ofString()))).willReturn(mockHttpResponse);
+        given(mockHttpClient.execute(httpRequestArgumentCaptor.capture())).willReturn(mockHttpResponse);
 
-        HttpResponse<String> result = webhookMessageSender.sendWebhookMessage(webhookMessageEntity);
+        HttpResponse result = webhookMessageSender.sendWebhookMessage(webhookMessageEntity);
 
-        HttpRequest httpRequest = httpRequestArgumentCaptor.getValue();
-        assertThat(httpRequest.uri(), is(CALLBACK_URL));
-        assertThat(httpRequest.timeout(), is(Optional.of(TIMEOUT)));
-        assertThat(httpRequest.headers().firstValue("Content-Type"), is(Optional.of("application/json")));
-        assertThat(httpRequest.headers().firstValue(SIGNATURE_HEADER_NAME), is(Optional.of(SIGNATURE)));
-
+        HttpUriRequest httpRequest = httpRequestArgumentCaptor.getValue();
+        assertThat(httpRequest.getURI(), is(CALLBACK_URL));
+        assertThat(httpRequest.getFirstHeader("Content-Type").getValue(), is("application/json"));
+        assertThat(httpRequest.getFirstHeader(SIGNATURE_HEADER_NAME).getValue(), is(SIGNATURE));
         assertThat(result, is(mockHttpResponse));
     }
 
     @Test
     void propagatesIOException() throws IOException, InterruptedException, InvalidKeyException {
-        given(mockHttpClient.send(any(HttpRequest.class), eq(HttpResponse.BodyHandlers.ofString()))).willThrow(IOException.class);
+        given(mockHttpClient.execute(any(HttpUriRequest.class))).willThrow(IOException.class);
         given(mockWebhookMessageSignatureGenerator.generate(objectMapper.writeValueAsString(WebhookMessageBody.from(webhookMessageEntity)), SIGNING_KEY)).willReturn(SIGNATURE);
         assertThrows(IOException.class, () -> webhookMessageSender.sendWebhookMessage(webhookMessageEntity));
-    }
-
-    @Test
-    void propagatesInterruptedException() throws IOException, InterruptedException, InvalidKeyException {
-        given(mockHttpClient.send(any(HttpRequest.class), eq(HttpResponse.BodyHandlers.ofString()))).willThrow(InterruptedException.class);
-        given(mockWebhookMessageSignatureGenerator.generate(objectMapper.writeValueAsString(WebhookMessageBody.from(webhookMessageEntity)), SIGNING_KEY)).willReturn(SIGNATURE);
-        assertThrows(InterruptedException.class, () -> webhookMessageSender.sendWebhookMessage(webhookMessageEntity));
     }
 
     @Test

--- a/src/test/resources/config/test-config.yaml
+++ b/src/test/resources/config/test-config.yaml
@@ -59,5 +59,7 @@ queueMessageReceiverConfig:
   threadDelayInMilliseconds: ${QUEUE_MESSAGE_RECEIVER_THREAD_DELAY_IN_MILLISECONDS:-1}
   numberOfThreads: ${QUEUE_MESSAGE_RECEIVER_NUMBER_OF_THREADS:-1}
   messageRetryDelayInSeconds: ${QUEUE_MESSAGE_RETRY_DELAY_IN_SECONDS:-1}
+  connectionPoolTimeToLive: ${WEBHOOK_MESSAGE_SENDER_CONNECTION_POOL_TIME_TO_LIVE:-60s}
+  requestTimeout: ${WEBHOOK_MESSAGE_SENDER_REQUEST_TIMEOUT:-5s}
 
 liveDataAllowDomains: ["gov.uk"]


### PR DESCRIPTION
The apache client gives us more control over:
- connection pool behaviour, specifically around timeout behaviours for
  connection pools where we have no control over the receiving servers
  connection behaviour. We suspect these connection pools being
  terminated result in intermittent "Connection Reset" errors
- ease of specifying TLS and cipher requirements