### PR TITLE
BAU Disable hibernate statistics logs

### DIFF
--- a/src/main/resources/config/config.yaml
+++ b/src/main/resources/config/config.yaml
@@ -33,6 +33,7 @@ database:
   properties:
     charSet: UTF-8
     hibernate.dialect: org.hibernate.dialect.PostgreSQLDialect
+    hibernate.generate_statistics: false
 
   # the maximum amount of time to wait on an empty pool before throwing an exception
   maxWaitForConnection: 1s


### PR DESCRIPTION
Hibernate seems to be generating and logging statistics for every single
database connection, by default.

How this behaviour was introduced or is on by default isn't clear at
this stage, however with production volumes the logs generated are
problematic.

Disable these logs by setting the hibernate property and investigate
why this behaviour is enabled in the first place.

Relates to https://github.com/alphagov/pay-webhooks/pull/373