### PR TITLE
PP-9016 Fix webhook sender timeout config

### DIFF
--- a/src/main/java/uk/gov/pay/webhooks/app/QueueMessageReceiverConfig.java
+++ b/src/main/java/uk/gov/pay/webhooks/app/QueueMessageReceiverConfig.java
@@ -1,7 +1,6 @@
 package uk.gov.pay.webhooks.app;
 
 import io.dropwizard.Configuration;
-import io.dropwizard.util.Duration;
 
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
@@ -22,10 +21,6 @@ public class QueueMessageReceiverConfig extends Configuration {
     @Valid
     @NotNull
     private int messageRetryDelayInSeconds;
-    @NotNull
-    private Duration connectionPoolTimeToLive;
-    @NotNull
-    private Duration requestTimeout;
 
     public int getThreadDelayInMilliseconds() {
         return threadDelayInMilliseconds;
@@ -40,12 +35,4 @@ public class QueueMessageReceiverConfig extends Configuration {
     }
 
     public boolean isBackgroundProcessingEnabled() { return backgroundProcessingEnabled; }
-
-    public Duration getConnectionPoolTimeToLive() {
-        return connectionPoolTimeToLive;
-    }
-
-    public Duration getRequestTimeout() {
-        return requestTimeout;
-    }
 }

--- a/src/main/java/uk/gov/pay/webhooks/app/WebhookMessageSendingQueueProcessorConfig.java
+++ b/src/main/java/uk/gov/pay/webhooks/app/WebhookMessageSendingQueueProcessorConfig.java
@@ -1,6 +1,7 @@
 package uk.gov.pay.webhooks.app;
 
 import io.dropwizard.Configuration;
+import io.dropwizard.util.Duration;
 
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
@@ -19,6 +20,11 @@ public class WebhookMessageSendingQueueProcessorConfig extends Configuration {
     @NotNull
     private int initialDelayInMilliseconds;
 
+    @NotNull
+    private Duration connectionPoolTimeToLive;
+    @NotNull
+    private Duration requestTimeout;
+
     public int getThreadDelayInMilliseconds() {
         return threadDelayInMilliseconds;
     }
@@ -29,5 +35,13 @@ public class WebhookMessageSendingQueueProcessorConfig extends Configuration {
 
     public int getInitialDelayInMilliseconds() {
         return initialDelayInMilliseconds;
+    }
+
+    public Duration getConnectionPoolTimeToLive() {
+        return connectionPoolTimeToLive;
+    }
+
+    public Duration getRequestTimeout() {
+        return requestTimeout;
     }
 }

--- a/src/main/java/uk/gov/pay/webhooks/app/WebhooksModule.java
+++ b/src/main/java/uk/gov/pay/webhooks/app/WebhooksModule.java
@@ -63,7 +63,7 @@ public class WebhooksModule extends AbstractModule {
     @Provides
     @Singleton
     public CloseableHttpClient httpClient() {
-        var timeoutInMillis = Math.toIntExact(configuration.getQueueMessageReceiverConfig().getRequestTimeout().toMilliseconds());
+        var timeoutInMillis = Math.toIntExact(configuration.getWebhookMessageSendingQueueProcessorConfig().getRequestTimeout().toMilliseconds());
         var config = RequestConfig.custom()
                 .setConnectTimeout(timeoutInMillis)
                 .setConnectionRequestTimeout(timeoutInMillis)
@@ -79,7 +79,7 @@ public class WebhooksModule extends AbstractModule {
 
         return HttpClientBuilder.create()
                 .useSystemProperties()
-                .setConnectionTimeToLive(configuration.getQueueMessageReceiverConfig().getConnectionPoolTimeToLive().toSeconds(), TimeUnit.SECONDS)
+                .setConnectionTimeToLive(configuration.getWebhookMessageSendingQueueProcessorConfig().getConnectionPoolTimeToLive().toSeconds(), TimeUnit.SECONDS)
                 .setSSLSocketFactory(sslsf)
                 .setDefaultRequestConfig(config)
                 .build();

--- a/src/test/resources/config/test-config.yaml
+++ b/src/test/resources/config/test-config.yaml
@@ -43,6 +43,8 @@ webhookMessageSendingQueueProcessorConfig:
   numberOfThreads: ${WEBHOOK_MESSAGE_SENDING_QUEUE_NUMBER_OF_THREADS:-1}
   initialDelayInMilliseconds: ${WEBHOOK_MESSAGE_SENDING_QUEUE_INITIAL_DELAY_IN_MILLISECONDS:-30000}
   threadDelayInMilliseconds: ${WEBHOOK_MESSAGE_SENDING_QUEUE_THREAD_DELAY_IN_MILLISECONDS:-1000}
+  connectionPoolTimeToLive: ${WEBHOOK_MESSAGE_SENDER_CONNECTION_POOL_TIME_TO_LIVE:-60s}
+  requestTimeout: ${WEBHOOK_MESSAGE_SENDER_REQUEST_TIMEOUT:-5s}
 
 sqsConfig:
   nonStandardServiceEndpoint: ${AWS_SQS_NON_STANDARD_SERVICE_ENDPOINT:-true}
@@ -59,7 +61,5 @@ queueMessageReceiverConfig:
   threadDelayInMilliseconds: ${QUEUE_MESSAGE_RECEIVER_THREAD_DELAY_IN_MILLISECONDS:-1}
   numberOfThreads: ${QUEUE_MESSAGE_RECEIVER_NUMBER_OF_THREADS:-1}
   messageRetryDelayInSeconds: ${QUEUE_MESSAGE_RETRY_DELAY_IN_SECONDS:-1}
-  connectionPoolTimeToLive: ${WEBHOOK_MESSAGE_SENDER_CONNECTION_POOL_TIME_TO_LIVE:-60s}
-  requestTimeout: ${WEBHOOK_MESSAGE_SENDER_REQUEST_TIMEOUT:-5s}
 
 liveDataAllowDomains: ["gov.uk"]


### PR DESCRIPTION
The configuration properties for message sending client timeouts were
applied to the wrong configuration file.

This passed tests because the `test-config.yaml` correctly (incorrectly)
set the configuration on the incorrect property.

The real configuration file `config.yaml` incorrectly (correctly) set
the configuration on the right property however this couldn't be parsed
by the app causing it not to start.