### PR TITLE
BAU Line webhook message body fields up with docs

### DIFF
--- a/src/main/java/uk/gov/pay/webhooks/message/WebhookMessageBody.java
+++ b/src/main/java/uk/gov/pay/webhooks/message/WebhookMessageBody.java
@@ -12,12 +12,12 @@ import java.time.Instant;
 
 
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
-public record WebhookMessageBody(String id,
+public record WebhookMessageBody(String webhookMessageId,
                                  @JsonSerialize(using = ApiResponseInstantSerializer.class) Instant createdDate,
                                  String resourceId,
                                  Integer apiVersion,
                                  String resourceType,
-                                 EventTypeName eventTypeName,
+                                 EventTypeName eventType,
                                  JsonNode resource) {
 
     public static final int API_VERSION = 1;

--- a/src/test/java/uk/gov/pay/webhooks/message/WebhookMessageBodyTest.java
+++ b/src/test/java/uk/gov/pay/webhooks/message/WebhookMessageBodyTest.java
@@ -48,12 +48,12 @@ class WebhookMessageBodyTest {
         var body = WebhookMessageBody.from(webhookMessageEntity);;
         var expectedJson = """
                 {
-                 	"id": "externalId",
+                 	"webhook_message_id": "externalId",
                  	"created_date": "2019-10-01T08:25:24.000Z",
                  	"resource_id": "resource-external-id",
                  	"api_version": 1,
                  	"resource_type": "payment",
-                 	"event_type_name": "card_payment_captured",
+                 	"event_type": "card_payment_captured",
                  	"resource": {
                  		"json": "and",
                  		"the": "argonauts"


### PR DESCRIPTION
Rename `resource_type_name` (internal) to `resource_type` (as specified in the docs).

Use `${entity_type}_id` identifier format as consistent with our Pay API resources. This could be changed in the future but should be done all at once with backwards compatability in mind.