### PR TITLE
PP-10004 M1 support for integration tests

### DIFF
--- a/src/test/java/uk/gov/pay/extension/AppWithPostgresAndSqsExtension.java
+++ b/src/test/java/uk/gov/pay/extension/AppWithPostgresAndSqsExtension.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.extension.BeforeAllCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import uk.gov.pay.rule.PostgresTestDocker;
 import uk.gov.pay.rule.SqsTestDocker;
 import uk.gov.pay.webhooks.app.WebhooksApp;
 import uk.gov.pay.webhooks.app.WebhooksConfig;
@@ -25,17 +26,17 @@ public class AppWithPostgresAndSqsExtension implements BeforeAllCallback, AfterA
 
     private static final Logger logger = LoggerFactory.getLogger(AppWithPostgresAndSqsExtension.class);
 
-    private static String CONFIG_PATH = resourceFilePath("config/test-config.yaml");
+    private static final String CONFIG_PATH = resourceFilePath("config/test-config.yaml");
     private final Jdbi jdbi;
-    private DropwizardAppExtension<WebhooksConfig> dropwizardAppExtension;
-    private AmazonSQS sqsClient;
+    private final DropwizardAppExtension<WebhooksConfig> dropwizardAppExtension;
+    private final AmazonSQS sqsClient;
 
     public AppWithPostgresAndSqsExtension() {
         this(new ConfigOverride[0]);
     }
 
     public AppWithPostgresAndSqsExtension(ConfigOverride... configOverrides) {
-        getOrCreate();
+        PostgresTestDocker.getOrCreate();
         sqsClient = SqsTestDocker.initialise("event-queue");
 
 

--- a/src/test/java/uk/gov/pay/rule/PostgresTestDocker.java
+++ b/src/test/java/uk/gov/pay/rule/PostgresTestDocker.java
@@ -2,7 +2,7 @@ package uk.gov.pay.rule;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.PostgreSQLContainer;
 
 import java.sql.Connection;
 import java.sql.SQLException;
@@ -12,27 +12,21 @@ import static java.sql.DriverManager.getConnection;
 public class PostgresTestDocker {
 
     private static final Logger logger = LoggerFactory.getLogger(PostgresTestDocker.class);
-
     private static final String DB_NAME = "webhooks_test";
     private static final String DB_USERNAME = "test";
     private static final String DB_PASSWORD = "test";
-    private static GenericContainer container;
+    private static PostgreSQLContainer<?> POSTGRES_CONTAINER;
 
     public static void getOrCreate() {
         try {
-            if (container == null) {
+            if (POSTGRES_CONTAINER == null) {
                 logger.info("Creating Postgres Container");
+                POSTGRES_CONTAINER = new PostgreSQLContainer<>("postgres:11.16")
+                        .withUsername(DB_USERNAME)
+                        .withPassword(DB_PASSWORD);
 
-                container = new GenericContainer("postgres:13.4");
-                container.addExposedPort(5432);
-
-                container.addEnv("POSTGRES_USER", DB_USERNAME);
-                container.addEnv("POSTGRES_PASSWORD", DB_PASSWORD);
-
-                container.start();
-
-                Thread.sleep(5000);
-                createDatabase(DB_NAME);
+                POSTGRES_CONTAINER.start();
+                createDatabase();
             }
         } catch (Exception e) {
             throw new RuntimeException(e);
@@ -40,28 +34,18 @@ public class PostgresTestDocker {
     }
 
     public static String getConnectionUrl() {
-        return "jdbc:postgresql://localhost:" + container.getMappedPort(5432) + "/";
+        return POSTGRES_CONTAINER.getJdbcUrl();
     }
 
-    public static void stopContainer() {
-        container.stop();
-        container = null;
-    }
+    private static void createDatabase() {
 
-    private static void createDatabase(final String dbName) {
-        final String dbUser = getDbUsername();
-
-        try (Connection connection = getConnection(getConnectionUrl(), dbUser, getDbPassword())) {
-            connection.createStatement().execute("CREATE DATABASE " + dbName + " WITH owner=" + dbUser + " TEMPLATE postgres");
-            connection.createStatement().execute("GRANT ALL PRIVILEGES ON DATABASE " + dbName + " TO " + dbUser);
+        try (Connection connection = getConnection(getConnectionUrl(), DB_USERNAME, DB_PASSWORD)) {
+            connection.createStatement().execute("CREATE DATABASE " + DB_NAME + " WITH owner=" + DB_USERNAME + " TEMPLATE postgres");
+            connection.createStatement().execute("GRANT ALL PRIVILEGES ON DATABASE " + DB_NAME + " TO " + DB_USERNAME);
             connection.createStatement().execute("CREATE EXTENSION IF NOT EXISTS pg_trgm");
         } catch (SQLException e) {
             throw new RuntimeException(e);
         }
-    }
-
-    static String getDbUri() {
-        return getConnectionUrl() + DB_NAME;
     }
 
     public static String getDbPassword() {

--- a/src/test/java/uk/gov/pay/webhooks/queue/EventQueueIT.java
+++ b/src/test/java/uk/gov/pay/webhooks/queue/EventQueueIT.java
@@ -1,7 +1,6 @@
 package uk.gov.pay.webhooks.queue;
 
 import com.amazonaws.services.sqs.AmazonSQS;
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -23,7 +22,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class EventQueueIT {
+class EventQueueIT {
 
     @RegisterExtension
     public static AppWithPostgresAndSqsExtension rule = new AppWithPostgresAndSqsExtension();
@@ -35,8 +34,8 @@ public class EventQueueIT {
     }
 
     @Test
-    public void shouldReceiveMessageFromTheQueue() throws QueueException {
-        client.sendMessage(SqsTestDocker.getQueueUrl("event-queue"), "");
+    void shouldReceiveMessageFromTheQueue() throws QueueException {
+        client.sendMessage(SqsTestDocker.getQueueUrl("event-queue"), "{ messageBody: \"example message\" }");
 
         SqsConfig sqsConfig = mock(SqsConfig.class);
         when(sqsConfig.getMessageMaximumBatchSize()).thenReturn(10);
@@ -52,7 +51,7 @@ public class EventQueueIT {
     }
     
     @Test
-    public void shouldConvertValidMessageFromQueueToEventMessage() throws QueueException, JsonProcessingException {
+    void shouldConvertValidMessageFromQueueToEventMessage() throws QueueException {
         var sqsMessage = """
                 {
                   "Type" : "Notification",
@@ -61,7 +60,7 @@ public class EventQueueIT {
                   "TopicArn" : "card-payment-events-topic",
                   "Timestamp" : "2021-12-16T18:52:27.068Z",
                   "SignatureVersion" : "1",
-                  "Signature" : "some-signature", 
+                  "Signature" : "some-signature",
                   "SigningCertURL" : "https://sns.eu-west-1.amazonaws.com/SimpleNotificationService-signing-cert-uuid.pem",
                   "UnsubscribeURL" : "https://sns.eu-west-1.amazonaws.com/?Action=Unsubscribe&SubscriptionArn=arn:a-aws-arn"
                 }


### PR DESCRIPTION
### WHAT

- baselining on architecture agnostic `postgres:11.16`
- replaced generic test container with postgres module
  - the module exposes the relevant port and can automatically determine when the database is healthy, removing the need to sleep the thread
- updated local sqs image to be consistent with other Pay applications
- removed some unused methods in test helpers
- added message body to example message in EventQueueIT receive test, fixes AmazonSQSException