### PR TITLE
PP-10191 add connection pool manager

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -85,6 +85,13 @@
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
+            <dependency>
+                <groupId>org.hibernate</groupId>
+                <artifactId>hibernate-c3p0</artifactId>
+                <version>5.6.14.Final</version>
+                <scope>import</scope>
+                <type>pom</type>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 

--- a/src/main/resources/config/config.yaml
+++ b/src/main/resources/config/config.yaml
@@ -34,6 +34,11 @@ database:
     charSet: UTF-8
     hibernate.dialect: org.hibernate.dialect.PostgreSQLDialect
     hibernate.generate_statistics: false
+    hibernate.c3p0.min_size: 8
+    hibernate.c3p0.max_size: 32
+    hibernate.c3p0.acquire_increment: 8
+    hibernate.c3p0.idle_test_period: 300
+    hibernate.c3p0.timeout: 1800
 
   # the maximum amount of time to wait on an empty pool before throwing an exception
   maxWaitForConnection: 1s

--- a/src/test/resources/config/test-config.yaml
+++ b/src/test/resources/config/test-config.yaml
@@ -9,6 +9,11 @@ database:
   properties:
     charSet: UTF-8
     hibernate.dialect: org.hibernate.dialect.PostgreSQLDialect
+    hibernate.c3p0.min_size: 8
+    hibernate.c3p0.max_size: 32
+    hibernate.c3p0.acquire_increment: 8
+    hibernate.c3p0.idle_test_period: 300
+    hibernate.c3p0.timeout: 1800
 
   # the maximum amount of time to wait on an empty pool before throwing an exception
   maxWaitForConnection: 1s


### PR DESCRIPTION
When the webhooks database was updated the ECS app instances existing connection pools failed to connect and then did not recover, permanently erroring any time a database connection is attempted.

- add c3p0 connection pool manager
configure c3p0: 
- `hibernate.c3p0.min_size` - the minimum number of coccentions to keep open 
- `hibernate.c3p0.max_size` - the maximum number of connections to keep open 
- `hibernate.c3p0.acquire_increment` - number to increment connections when needed
- `hibernate.c3p0.idle_test_period` - idle time in seconds before a connection is automatically validated (ping)
- `hibernate.c3p0.timeout` - seconds, before an idle connection it is closed and removed from the pool