### PR TITLE
PP-10191 refactor healthcheck

### DIFF
--- a/openapi/webhooks_spec.yaml
+++ b/openapi/webhooks_spec.yaml
@@ -26,6 +26,9 @@ paths:
                   deadlocks:
                     healthy: true
                     message: Healthy
+                  sqsQueue:
+                    healthy: true
+                    message: Healthy
           description: OK
         "503":
           description: Service unavailable. If any healthchecks fail
@@ -344,85 +347,6 @@ components:
         path: description
         op: replace
         value: new description
-    Result:
-      type: object
-      properties:
-        details:
-          type: object
-          additionalProperties:
-            type: object
-        duration:
-          type: integer
-          format: int64
-        error:
-          type: object
-          properties:
-            localizedMessage:
-              type: string
-            message:
-              type: string
-            stackTrace:
-              type: array
-              items:
-                type: object
-                properties:
-                  classLoaderName:
-                    type: string
-                  className:
-                    type: string
-                  fileName:
-                    type: string
-                  lineNumber:
-                    type: integer
-                    format: int32
-                  methodName:
-                    type: string
-                  moduleName:
-                    type: string
-                  moduleVersion:
-                    type: string
-                  nativeMethod:
-                    type: boolean
-            suppressed:
-              type: array
-              items:
-                type: object
-                properties:
-                  localizedMessage:
-                    type: string
-                  message:
-                    type: string
-                  stackTrace:
-                    type: array
-                    items:
-                      type: object
-                      properties:
-                        classLoaderName:
-                          type: string
-                        className:
-                          type: string
-                        fileName:
-                          type: string
-                        lineNumber:
-                          type: integer
-                          format: int32
-                        methodName:
-                          type: string
-                        moduleName:
-                          type: string
-                        moduleVersion:
-                          type: string
-                        nativeMethod:
-                          type: boolean
-        healthy:
-          type: boolean
-        message:
-          type: string
-        time:
-          type: integer
-          format: int64
-        timestamp:
-          type: string
     SigningKeyResponse:
       type: object
       properties:

--- a/src/main/java/uk/gov/pay/webhooks/app/WebhooksApp.java
+++ b/src/main/java/uk/gov/pay/webhooks/app/WebhooksApp.java
@@ -20,6 +20,7 @@ import uk.gov.pay.webhooks.deliveryqueue.managed.WebhookMessageSendingQueueProce
 import uk.gov.pay.webhooks.eventtype.dao.EventTypeEntity;
 import uk.gov.pay.webhooks.healthcheck.HealthCheckResource;
 import uk.gov.pay.webhooks.healthcheck.Ping;
+import uk.gov.pay.webhooks.healthcheck.SQSHealthCheck;
 import uk.gov.pay.webhooks.message.dao.entity.WebhookMessageEntity;
 import uk.gov.pay.webhooks.queue.QueueMessageReceiver;
 import uk.gov.pay.webhooks.webhook.dao.entity.WebhookEntity;
@@ -69,6 +70,7 @@ public class WebhooksApp extends Application<WebhooksConfig> {
 
         environment.healthChecks().register("ping", new Ping());
         environment.healthChecks().register("database", new DatabaseHealthCheck(configuration.getDataSourceFactory()));
+        environment.healthChecks().register("sqsQueue", injector.getInstance(SQSHealthCheck.class));
         environment.jersey().register(injector.getInstance(HealthCheckResource.class));
         environment.jersey().register(injector.getInstance(WebhookResource.class));
 

--- a/src/main/java/uk/gov/pay/webhooks/healthcheck/HealthCheckResource.java
+++ b/src/main/java/uk/gov/pay/webhooks/healthcheck/HealthCheckResource.java
@@ -1,24 +1,33 @@
 package uk.gov.pay.webhooks.healthcheck;
 
 import com.codahale.metrics.health.HealthCheck;
+import com.google.common.collect.ImmutableMap;
 import io.dropwizard.setup.Environment;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.inject.Inject;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
-
+import javax.ws.rs.core.Response;
+import java.util.Collection;
 import java.util.Map;
-import java.util.Set;
+import java.util.SortedMap;
+import java.util.stream.Collectors;
 
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
+import static javax.ws.rs.core.Response.Status.OK;
+import static javax.ws.rs.core.Response.Status.SERVICE_UNAVAILABLE;
+import static org.apache.commons.lang3.StringUtils.defaultString;
 
 @Path("/")
 public class HealthCheckResource {
+    private static final Logger LOGGER = LoggerFactory.getLogger(HealthCheckResource.class);
     private final Environment environment;
     
     @Inject
@@ -49,12 +58,35 @@ public class HealthCheckResource {
                             "    \"deadlocks\": {" +
                             "        \"healthy\": true," +
                             "        \"message\": \"Healthy\"" +
+                            "    }," +
+                            "    \"sqsQueue\": {" +
+                            "        \"healthy\": true," +
+                            "        \"message\": \"Healthy\"" +
                             "    }" +
                             "}")), description = "OK"),
                     @ApiResponse(responseCode = "503", description = "Service unavailable. If any healthchecks fail")
             }
     )
-    public Set<Map.Entry<String, HealthCheck.Result>> healthCheck() {
-        return environment.healthChecks().runHealthChecks().entrySet();
+    public Response healthCheck() {
+        SortedMap<String, HealthCheck.Result> results = environment.healthChecks().runHealthChecks();
+
+        Map<String, Map<String, Object>> response = results.entrySet()
+                .stream()
+                .collect(Collectors.toMap(Map.Entry::getKey,
+                                healthCheck -> ImmutableMap.of(
+                                        "healthy", healthCheck.getValue().isHealthy(),
+                                        "message", defaultString(healthCheck.getValue().getMessage(), "Healthy"))
+                        )
+                );
+
+        if (allHealthy(results.values())) {
+            return Response.ok(response).build();
+        }
+        LOGGER.error("Healthcheck Failure: {}", response);
+        return Response.status(503).entity(response).build();
+    }
+
+    private boolean allHealthy(Collection<HealthCheck.Result> results) {
+        return results.stream().allMatch(HealthCheck.Result::isHealthy);
     }
 }

--- a/src/main/java/uk/gov/pay/webhooks/healthcheck/SQSHealthCheck.java
+++ b/src/main/java/uk/gov/pay/webhooks/healthcheck/SQSHealthCheck.java
@@ -1,0 +1,67 @@
+package uk.gov.pay.webhooks.healthcheck;
+
+import com.amazonaws.SdkClientException;
+import com.amazonaws.services.sqs.AmazonSQS;
+import com.amazonaws.services.sqs.model.AmazonSQSException;
+import com.amazonaws.services.sqs.model.GetQueueAttributesRequest;
+import com.codahale.metrics.health.HealthCheck;
+import org.apache.http.NameValuePair;
+import org.apache.http.message.BasicNameValuePair;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import uk.gov.pay.webhooks.app.WebhooksConfig;
+
+import javax.inject.Inject;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import static java.lang.String.format;
+
+public class SQSHealthCheck extends HealthCheck {
+
+    private final AmazonSQS sqsClient;
+    private final Logger logger = LoggerFactory.getLogger(SQSHealthCheck.class);
+    private List<NameValuePair> checkList = new ArrayList<>();
+
+    @Inject
+    public SQSHealthCheck(AmazonSQS sqsClient, WebhooksConfig webhooksConfig) {
+        this.sqsClient = sqsClient;
+        setUpCheckList(webhooksConfig);
+    }
+
+    @Override
+    protected Result check() {
+        List<String> queueChecks = checkList.stream()
+                .map(this::checkQueue)
+                .flatMap(Optional::stream)
+                .collect(Collectors.toUnmodifiableList());
+        if (!queueChecks.isEmpty()) {
+            return Result.unhealthy(format("Failed queue attribute check: %s", String.join(",", queueChecks)));
+        }
+        
+        return Result.healthy();
+    }
+    
+    private void setUpCheckList(WebhooksConfig webhooksConfig) {
+        checkList.add(new BasicNameValuePair("event", webhooksConfig.getSqsConfig().getEventQueueUrl()));
+    }
+    
+    private Optional<String> checkQueue(NameValuePair nameValuePair) {
+        GetQueueAttributesRequest queueAttributesRequest =
+                new GetQueueAttributesRequest(nameValuePair.getValue())
+                        .withAttributeNames("All");
+        try {
+            sqsClient.getQueueAttributes(queueAttributesRequest);
+        } catch (AmazonSQSException | UnsupportedOperationException e) {
+            logger.error("Failed to retrieve [{}] queue attributes - {}", nameValuePair.getName(), e.getMessage());
+            return Optional.of(e.getMessage());
+        } catch (SdkClientException e) {
+            logger.error("Failed to connect to sqs server - {}", e.getMessage());
+            return Optional.of("Failed to connect to sqs server - " + e.getMessage());
+        }
+        
+        return Optional.empty();
+    }
+}

--- a/src/test/java/uk/gov/pay/extension/AppWithPostgresAndSqsExtension.java
+++ b/src/test/java/uk/gov/pay/extension/AppWithPostgresAndSqsExtension.java
@@ -95,7 +95,4 @@ public class AppWithPostgresAndSqsExtension implements BeforeAllCallback, AfterA
     public AmazonSQS getSqsClient() {
         return sqsClient;
     }
-    
 }
-
-

--- a/src/test/java/uk/gov/pay/rule/PostgresTestDocker.java
+++ b/src/test/java/uk/gov/pay/rule/PostgresTestDocker.java
@@ -55,4 +55,9 @@ public class PostgresTestDocker {
     public static String getDbUsername() {
         return DB_USERNAME;
     }
+
+    public static void shutDown() {
+        POSTGRES_CONTAINER.stop();
+        POSTGRES_CONTAINER = null;
+    }
 }


### PR DESCRIPTION
AWS healtcheck does not take HealthCheck.Result into consideration when calling the endpoint.
- refactor resource to return `503` when at least one of the healthcheck result is is not healthy.
- implement sqs queue check (we don't check for it at the momemnt)