### PR TITLE
Revert "Bump mockito-bom from 4.9.0 to 4.10.0"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -81,7 +81,7 @@
             <dependency>
                 <groupId>org.mockito</groupId>
                 <artifactId>mockito-bom</artifactId>
-                <version>4.10.0</version>
+                <version>4.9.0</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>


### PR DESCRIPTION
Reverts alphagov/pay-webhooks#570

There are two commits tagged as 3.2