### PR TITLE
Revert "Bump actions/checkout from 3.1.0 to 3.2.0"

### DIFF
--- a/.github/workflows/post-merge.yml
+++ b/.github/workflows/post-merge.yml
@@ -24,7 +24,7 @@ jobs:
     name: Publish and tag webhooks consumer pact
     steps:
       - name: Git checkout
-        uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b
+        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
       - name: Set up JDK 17
         uses: actions/setup-java@a18c333f3f14249953dab3e186e5e21bf3390f1d
         with:

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -12,14 +12,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Git checkout
-        uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b
+        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
       - name: Detect secrets
         uses: alphagov/pay-ci/actions/detect-secrets@master
   test:
     runs-on: ubuntu-latest
     steps:
       - name: Git checkout
-        uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b
+        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
         with:
           fetch-depth: '0'
       - name: Set up JDK 17


### PR DESCRIPTION
Reverts alphagov/pay-webhooks#565

There are two commits with different SHAs, both tagged as 3.2.0. For whatever reason Git chooses the SHA of the older commit. Reverting to 3.1.0 until issue is solved.