### PR TITLE
PP-10466 Fix webhook delivery queue next to send query

### DIFF
--- a/src/main/java/uk/gov/pay/webhooks/deliveryqueue/dao/WebhookDeliveryQueueEntity.java
+++ b/src/main/java/uk/gov/pay/webhooks/deliveryqueue/dao/WebhookDeliveryQueueEntity.java
@@ -22,7 +22,7 @@ import java.util.Optional;
 
 @NamedQuery(
         name = WebhookDeliveryQueueEntity.NEXT_TO_SEND,
-        query = "select m from WebhookDeliveryQueueEntity m where :send_at > send_at and delivery_status = 'PENDING' order by send_at asc"
+        query = "select m from WebhookDeliveryQueueEntity m where :send_at > send_at and delivery_status = 'PENDING'"
 )
 
 @NamedQuery(


### PR DESCRIPTION
The webhook delivery queue DAO exposes a method to search for webhook messages which are in a pending state and are now scheduled to be sent.

There are a number of individual indexes on the delivery queue table:
- `send_at`
- `created_at`
- `delivery_status`

Both `send_at` and `delivery_status` are used in the query, which should correctly use index scans to immediately return the value.

An order (through the named query) and a limit (through a hibernate setter) are also applied to the query, by order by `send_at` and limiting to 1 we are asking postgres to use both the `send_at` and `delivery_status` index at the same time which results in no index being used -- if we wanted to include this ordering we would need to have a composite index between these two columns.

However it doesn't look like the ordering for which message to send should be too important in this case, all messages that meet these criteria will need to be immediately attempted and for a healthy emitter system this should never see a significant backlog. The order will now come from the default read order which will likely favour newly created messages which feels appropriate.

By removing the order, the indexes are individually used and the query should immediately execute as expected.