### PR TITLE
bau: Unblock failed GHA

### DIFF
--- a/.github/workflows/post-merge.yml
+++ b/.github/workflows/post-merge.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Git checkout
         uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b
       - name: Set up JDK 17
-        uses: actions/setup-java@a18c333f3f14249953dab3e186e5e21bf3390f1d
+        uses: actions/setup-java@c3ac5dd0ed8db40fedb61c32fbe677e6b355e94c
         with:
           java-version: '17'
           distribution: 'adopt'


### PR DESCRIPTION
Apparently GH workflows don't run with
actions/setup-java@1df8dbefe2a8cbc99770194893dd902763bee34b. Version c3ac5dd0ed8db40fedb61c32fbe677e6b355e94c is in our [whitelist](https://github.com/alphagov/pay-webhooks/settings/actions) so should be ok.