### PR TITLE
PP-10539: Use single connection

### DIFF
--- a/src/main/java/uk/gov/pay/webhooks/app/WebhooksModule.java
+++ b/src/main/java/uk/gov/pay/webhooks/app/WebhooksModule.java
@@ -15,6 +15,7 @@ import org.apache.http.client.config.RequestConfig;
 import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.impl.conn.BasicHttpClientConnectionManager;
 import org.apache.http.ssl.SSLContexts;
 import org.hibernate.SessionFactory;
 import uk.gov.pay.webhooks.message.WebhookMessageSignatureGenerator;
@@ -81,6 +82,7 @@ public class WebhooksModule extends AbstractModule {
 
         return HttpClientBuilder.create()
                 .useSystemProperties()
+                .setConnectionManager(new BasicHttpClientConnectionManager())
                 .setConnectionTimeToLive(configuration.getWebhookMessageSendingQueueProcessorConfig().getConnectionPoolTimeToLive().toSeconds(), TimeUnit.SECONDS)
                 .setSSLSocketFactory(sslsf)
                 .setDefaultRequestConfig(config)

--- a/src/main/resources/config/config.yaml
+++ b/src/main/resources/config/config.yaml
@@ -12,6 +12,9 @@ server:
             environment: ${ENVIRONMENT}
 logging:
   level: INFO
+  loggers:
+    "org.apache.http.impl.conn":
+      level: DEBUG
   appenders:
     - type: logstash-console
       threshold: ALL


### PR DESCRIPTION
Using BasicHttpClientConnectionManager. From the javadoc:

A connection manager for a single connection. This connection manager maintains only one active connection. Even though this class is fully thread-safe it ought to be used by one execution thread only, as only one thread a time can lease the connection at a time. This connection manager will make an effort to reuse the connection for subsequent requests with the same route. It will, however, close the existing connection and open it for the given route, if the route of the persistent connection does not match that of the connection request. If the connection has been already been allocated IllegalStateException is thrown.