### PR TITLE
PP-10717: Upgrade Docker Java image to 17.0.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:17-jre-alpine@sha256:02c04793fa49ad5cd193c961403223755f9209a67894622e05438598b32f210e
+FROM eclipse-temurin:17-jre-alpine@sha256:2b33ef284e6dc43a61903cef6d36dbce13414a9e5444e2c96cdd5e35123f9903
 
 RUN ["apk", "--no-cache", "upgrade"]
 

--- a/m1/arm64.Dockerfile
+++ b/m1/arm64.Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:17-jre@sha256:787e1e19c56b8c4f1f0dfa23f4cd7e2b33e670b41ab529c071abb7fe4eef3cfd
+FROM eclipse-temurin:17-jre@sha256:0563afe1aa8e2bfbf68c8ef633d67839321b8bd0a8d163f0dff2dfedef04af29
 
 ARG DNS_TTL=15
 


### PR DESCRIPTION
Upgrade image to jdk 17.0.6 for the [amd](https://hub.docker.com/layers/library/eclipse-temurin/17-jre-alpine/images/sha256-2b33ef284e6dc43a61903cef6d36dbce13414a9e5444e2c96cdd5e35123f9903?context=explore) and [arm](https://hub.docker.com/layers/library/eclipse-temurin/17-jre/images/sha256-0563afe1aa8e2bfbf68c8ef633d67839321b8bd0a8d163f0dff2dfedef04af29?context=explore) architectures

See this [adr](https://github.com/alphagov/pay-architecture/blob/main/adr/024-java-base-image-pinning-strategy.md) on why we only specify the major version.