### PR TITLE
PP-10543 Add last delivery status to webhook messages

### DIFF
--- a/src/main/resources/migrations/0012_alter_table_webhook_messages_add_last_delivery_status.sql
+++ b/src/main/resources/migrations/0012_alter_table_webhook_messages_add_last_delivery_status.sql
@@ -1,4 +1,8 @@
+--liquibase formatted sql
+
+--changeset uk.gov.pay:alter-table-webhook-messages-add-last-delivery-status
 ALTER TABLE webhook_messages
 ADD COLUMN last_delivery_status VARCHAR(64) check (last_delivery_status in ('SUCCESSFUL', 'FAILED', 'PENDING', 'WILL_NOT_SEND'));
 
-CREATE INDEX IF NOT EXISTS last_delivery_status_idx on webhook_messages(last_delivery_status)
+--changeset uk.gov.pay:alter-table-webhook-messages-index-last-delivery-status runInTransaction:false
+CREATE INDEX CONCURRENTLY IF NOT EXISTS last_delivery_status_idx on webhook_messages(last_delivery_status)

--- a/src/main/resources/migrations/0012_alter_table_webhook_messages_add_last_delivery_status.sql
+++ b/src/main/resources/migrations/0012_alter_table_webhook_messages_add_last_delivery_status.sql
@@ -1,0 +1,4 @@
+ALTER TABLE webhook_messages
+ADD COLUMN last_delivery_status VARCHAR(64) check (last_delivery_status in ('SUCCESSFUL', 'FAILED', 'PENDING', 'WILL_NOT_SEND'));
+
+CREATE INDEX IF NOT EXISTS last_delivery_status_idx on webhook_messages(last_delivery_status)


### PR DESCRIPTION
Add a column to webhook messages to allow for simple filtering of messages by status in the admin tool. This column will line up with the existing status represented on delivery queue entries and should eventually be used to filter and display the delivery status for a given message.