### PR TITLE
PP-10543 Validate delivery status enumerations against database schema

### DIFF
--- a/src/main/java/uk/gov/pay/webhooks/deliveryqueue/DeliveryStatus.java
+++ b/src/main/java/uk/gov/pay/webhooks/deliveryqueue/DeliveryStatus.java
@@ -1,0 +1,8 @@
+package uk.gov.pay.webhooks.deliveryqueue;
+
+public enum DeliveryStatus {
+    PENDING,
+    SUCCESSFUL,
+    FAILED,
+    WILL_NOT_SEND
+}

--- a/src/main/java/uk/gov/pay/webhooks/deliveryqueue/dao/WebhookDeliveryQueueDao.java
+++ b/src/main/java/uk/gov/pay/webhooks/deliveryqueue/dao/WebhookDeliveryQueueDao.java
@@ -4,6 +4,7 @@ import com.codahale.metrics.MetricRegistry;
 import io.dropwizard.hibernate.AbstractDAO;
 import org.hibernate.LockOptions;
 import org.hibernate.SessionFactory;
+import uk.gov.pay.webhooks.deliveryqueue.DeliveryStatus;
 import uk.gov.pay.webhooks.message.dao.entity.WebhookMessageEntity;
 
 import javax.inject.Inject;
@@ -42,7 +43,7 @@ public class WebhookDeliveryQueueDao extends AbstractDAO<WebhookDeliveryQueueEnt
                 .findAny();
     }
 
-    public WebhookDeliveryQueueEntity enqueueFrom(WebhookMessageEntity webhookMessageEntity, WebhookDeliveryQueueEntity.DeliveryStatus deliveryStatus, Instant sendAt) {
+    public WebhookDeliveryQueueEntity enqueueFrom(WebhookMessageEntity webhookMessageEntity, DeliveryStatus deliveryStatus, Instant sendAt) {
        return persist(WebhookDeliveryQueueEntity.enqueueFrom(
                 webhookMessageEntity,
                 instantSource.instant(),
@@ -56,7 +57,7 @@ public class WebhookDeliveryQueueDao extends AbstractDAO<WebhookDeliveryQueueEnt
                 .getSingleResult();
     }
 
-    public WebhookDeliveryQueueEntity recordResult(WebhookDeliveryQueueEntity webhookDeliveryQueueEntity, String deliveryResult, Duration deliveryResponseTime, Integer statusCode, WebhookDeliveryQueueEntity.DeliveryStatus deliveryStatus, MetricRegistry metricRegistry) {
+    public WebhookDeliveryQueueEntity recordResult(WebhookDeliveryQueueEntity webhookDeliveryQueueEntity, String deliveryResult, Duration deliveryResponseTime, Integer statusCode, DeliveryStatus deliveryStatus, MetricRegistry metricRegistry) {
         metricRegistry.counter("delivery-status.%s".formatted(deliveryStatus.name()));
         return persist(WebhookDeliveryQueueEntity.recordResult(webhookDeliveryQueueEntity, deliveryResult, deliveryResponseTime, statusCode, deliveryStatus));
     }

--- a/src/main/java/uk/gov/pay/webhooks/deliveryqueue/dao/WebhookDeliveryQueueEntity.java
+++ b/src/main/java/uk/gov/pay/webhooks/deliveryqueue/dao/WebhookDeliveryQueueEntity.java
@@ -1,6 +1,7 @@
 package uk.gov.pay.webhooks.deliveryqueue.dao;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import uk.gov.pay.webhooks.deliveryqueue.DeliveryStatus;
 import uk.gov.pay.webhooks.message.dao.entity.WebhookMessageEntity;
 
 import javax.persistence.Column;
@@ -70,13 +71,6 @@ public class WebhookDeliveryQueueEntity {
 
     public Instant getCreatedDate() {
         return createdDate.toInstant();
-    }
-
-    public enum DeliveryStatus {
-        PENDING,
-        SUCCESSFUL,
-        FAILED,
-        WILL_NOT_SEND
     }
 
 

--- a/src/main/java/uk/gov/pay/webhooks/deliveryqueue/managed/SendAttempter.java
+++ b/src/main/java/uk/gov/pay/webhooks/deliveryqueue/managed/SendAttempter.java
@@ -8,6 +8,7 @@ import org.apache.http.NoHttpResponseException;
 import org.apache.http.conn.ConnectTimeoutException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import uk.gov.pay.webhooks.deliveryqueue.DeliveryStatus;
 import uk.gov.pay.webhooks.deliveryqueue.WebhookNotActiveException;
 import uk.gov.pay.webhooks.deliveryqueue.dao.WebhookDeliveryQueueDao;
 import uk.gov.pay.webhooks.deliveryqueue.dao.WebhookDeliveryQueueEntity;
@@ -48,9 +49,9 @@ public class SendAttempter {
     private final InstantSource instantSource;
     private final WebhookMessageSender webhookMessageSender;
 
-    private final List<WebhookDeliveryQueueEntity.DeliveryStatus> terminalStatuses = List.of(
-            WebhookDeliveryQueueEntity.DeliveryStatus.SUCCESSFUL,
-            WebhookDeliveryQueueEntity.DeliveryStatus.WILL_NOT_SEND
+    private final List<DeliveryStatus> terminalStatuses = List.of(
+            DeliveryStatus.SUCCESSFUL,
+            DeliveryStatus.WILL_NOT_SEND
     );
 
     @Inject
@@ -83,28 +84,28 @@ public class SendAttempter {
 
             var statusCode = response.getStatusLine().getStatusCode();
             if (statusCode >= 200 && statusCode <= 299) {
-                handleResponse(queueItem, WebhookDeliveryQueueEntity.DeliveryStatus.SUCCESSFUL, statusCode, getReasonFromStatusCode(statusCode), retryCount, start, Optional.of(url));
+                handleResponse(queueItem, DeliveryStatus.SUCCESSFUL, statusCode, getReasonFromStatusCode(statusCode), retryCount, start, Optional.of(url));
             } else {
-                handleResponse(queueItem, WebhookDeliveryQueueEntity.DeliveryStatus.FAILED, statusCode, getReasonFromStatusCode(statusCode), retryCount, start, Optional.of(url));
+                handleResponse(queueItem, DeliveryStatus.FAILED, statusCode, getReasonFromStatusCode(statusCode), retryCount, start, Optional.of(url));
             }
         } catch (SocketTimeoutException | HttpTimeoutException | NoHttpResponseException | ConnectTimeoutException e) {
             LOGGER.info("Request timed out");
-            handleResponse(queueItem, WebhookDeliveryQueueEntity.DeliveryStatus.FAILED, null, "HTTP Timeout", retryCount, start);
+            handleResponse(queueItem, DeliveryStatus.FAILED, null, "HTTP Timeout", retryCount, start);
         } catch (IOException | InterruptedException | InvalidKeyException e) {
             LOGGER.info(
                     Markers.append(ERROR_MESSAGE, e.getMessage()),
                     "Exception caught by request"
             );
-            handleResponse(queueItem, WebhookDeliveryQueueEntity.DeliveryStatus.FAILED, null, e.getMessage(), retryCount, start);
+            handleResponse(queueItem, DeliveryStatus.FAILED, null, e.getMessage(), retryCount, start);
         } catch (WebhookNotActiveException e) {
             LOGGER.info("Not sending webhook message for non-active webhook");
-            handleResponse(queueItem, WebhookDeliveryQueueEntity.DeliveryStatus.WILL_NOT_SEND, null, "Webhook not active", retryCount, start);
+            handleResponse(queueItem, DeliveryStatus.WILL_NOT_SEND, null, "Webhook not active", retryCount, start);
         } catch (CallbackUrlDomainNotOnAllowListException e) {
             LOGGER.error(
                     Markers.append(WEBHOOK_CALLBACK_URL_DOMAIN, e.getUrl()),
                     "Attempt to send to a domain not on the allow list has been blocked"
             );
-            handleResponse(queueItem, WebhookDeliveryQueueEntity.DeliveryStatus.WILL_NOT_SEND, null, "Violates security rules", retryCount, start);
+            handleResponse(queueItem, DeliveryStatus.WILL_NOT_SEND, null, "Violates security rules", retryCount, start);
         } catch (Exception e) {
             var responseTime = Duration.between(start, instantSource.instant());
             // handle all exceptions at this level to make sure that the retry mechanism is allowed to work as designed
@@ -113,12 +114,12 @@ public class SendAttempter {
                     Markers.append(ERROR_MESSAGE, e.getMessage()),
                     "Unexpected exception thrown by request"
             );
-            handleResponse(queueItem, WebhookDeliveryQueueEntity.DeliveryStatus.FAILED, null, "Unknown error", retryCount, start);
+            handleResponse(queueItem, DeliveryStatus.FAILED, null, "Unknown error", retryCount, start);
         }
     }
 
     private void handleResponse(WebhookDeliveryQueueEntity webhookDeliveryQueueEntity,
-                                WebhookDeliveryQueueEntity.DeliveryStatus status,
+                                DeliveryStatus status,
                                 Integer statusCode,
                                 String reason,
                                 Long retryCount,
@@ -127,7 +128,7 @@ public class SendAttempter {
     }
 
     private void handleResponse(WebhookDeliveryQueueEntity webhookDeliveryQueueEntity, 
-                                WebhookDeliveryQueueEntity.DeliveryStatus status, 
+                                DeliveryStatus status, 
                                 Integer statusCode, 
                                 String reason, 
                                 Long retryCount, 
@@ -155,7 +156,7 @@ public class SendAttempter {
     private void enqueueRetry(WebhookDeliveryQueueEntity queueItem, Duration nextRetryIn) {
         Optional.ofNullable(nextRetryIn).ifPresentOrElse(retryDelay -> {
             LOGGER.info("Scheduling webhook message for retry");
-            webhookDeliveryQueueDao.enqueueFrom(queueItem.getWebhookMessageEntity(), WebhookDeliveryQueueEntity.DeliveryStatus.PENDING, instantSource.instant().plus(retryDelay));
+            webhookDeliveryQueueDao.enqueueFrom(queueItem.getWebhookMessageEntity(), DeliveryStatus.PENDING, instantSource.instant().plus(retryDelay));
         }, () -> {
             LOGGER.warn("Webhook message terminally failed to deliver");
         });

--- a/src/main/java/uk/gov/pay/webhooks/message/WebhookMessageService.java
+++ b/src/main/java/uk/gov/pay/webhooks/message/WebhookMessageService.java
@@ -5,9 +5,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import net.logstash.logback.marker.Markers;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.slf4j.MDC;
+import uk.gov.pay.webhooks.deliveryqueue.DeliveryStatus;
 import uk.gov.pay.webhooks.deliveryqueue.dao.WebhookDeliveryQueueDao;
-import uk.gov.pay.webhooks.deliveryqueue.dao.WebhookDeliveryQueueEntity;
 import uk.gov.pay.webhooks.eventtype.dao.EventTypeDao;
 import uk.gov.pay.webhooks.ledger.LedgerService;
 import uk.gov.pay.webhooks.ledger.model.LedgerTransaction;
@@ -83,11 +82,11 @@ public class WebhookMessageService {
                buildWebhookMessage(webhook, event, ledgerTransaction)
                        .ifPresent(message -> {
                            var entity = webhookMessageDao.create(message);
-                           webhookDeliveryQueueDao.enqueueFrom(entity, WebhookDeliveryQueueEntity.DeliveryStatus.PENDING, instantSource.instant());
+                           webhookDeliveryQueueDao.enqueueFrom(entity, DeliveryStatus.PENDING, instantSource.instant());
                            LOGGER.info(
                                    Markers.append(WEBHOOK_MESSAGE_EXTERNAL_ID, entity.getExternalId())
                                            .and(Markers.append(WEBHOOK_EXTERNAL_ID, entity.getWebhookEntity().getExternalId()))
-                                           .and(Markers.append(STATE_TRANSITION_TO_STATE, WebhookDeliveryQueueEntity.DeliveryStatus.PENDING))
+                                           .and(Markers.append(STATE_TRANSITION_TO_STATE, DeliveryStatus.PENDING))
                                            .and(Markers.append(WEBHOOK_MESSAGE_EVENT_TYPE, entity.getEventType().getName().getName())),
                                    "Persisted and queued webhook message to send"
                            );

--- a/src/main/java/uk/gov/pay/webhooks/message/resource/WebhookDeliveryQueueResponse.java
+++ b/src/main/java/uk/gov/pay/webhooks/message/resource/WebhookDeliveryQueueResponse.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import io.swagger.v3.oas.annotations.media.Schema;
+import uk.gov.pay.webhooks.deliveryqueue.DeliveryStatus;
 import uk.gov.pay.webhooks.deliveryqueue.dao.WebhookDeliveryQueueEntity;
 import uk.gov.service.payments.commons.api.json.ApiResponseInstantSerializer;
 
@@ -13,7 +14,7 @@ import java.time.Instant;
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public record WebhookDeliveryQueueResponse(@Schema(example = "\"2022-04-05T21:37:32.366Z\"") @JsonSerialize(using = ApiResponseInstantSerializer.class) Instant createdDate,
                                            @Schema(example = "\"2022-04-05T21:37:34.366Z\"") @JsonSerialize(using = ApiResponseInstantSerializer.class) Instant sendAt,
-                                           @Schema(example = "SUCCESSFUL") WebhookDeliveryQueueEntity.DeliveryStatus status,
+                                           @Schema(example = "SUCCESSFUL") DeliveryStatus status,
                                            @Schema(example = "23") Long responseTime,
                                            @Schema(example = "200") Integer statusCode,
                                            @Schema(example = "200 OK") String result) {

--- a/src/main/java/uk/gov/pay/webhooks/webhook/resource/WebhookResource.java
+++ b/src/main/java/uk/gov/pay/webhooks/webhook/resource/WebhookResource.java
@@ -9,14 +9,13 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import uk.gov.pay.webhooks.deliveryqueue.dao.WebhookDeliveryQueueEntity;
+import uk.gov.pay.webhooks.deliveryqueue.DeliveryStatus;
 import uk.gov.pay.webhooks.message.resource.WebhookDeliveryQueueResponse;
 import uk.gov.pay.webhooks.message.resource.WebhookMessageResponse;
 import uk.gov.pay.webhooks.message.resource.WebhookMessageSearchResponse;
 import uk.gov.pay.webhooks.validations.WebhookRequestValidator;
 import uk.gov.pay.webhooks.webhook.WebhookService;
 import uk.gov.pay.webhooks.webhook.dao.entity.WebhookEntity;
-import uk.gov.service.payments.commons.api.exception.ValidationException;
 import uk.gov.service.payments.commons.model.jsonpatch.JsonPatchRequest;
 
 import javax.inject.Inject;
@@ -175,7 +174,7 @@ public class WebhookResource {
     public WebhookMessageSearchResponse getWebhookMessages(
             @Parameter(example = "gh0d0923jpsjdf0923jojlsfgkw3seg") @PathParam("webhookExternalId") String externalId,
             @Parameter(example = "1") @QueryParam("page") Integer page,
-            @Parameter(example = "SUCCESSFUL") @Valid @QueryParam("status") WebhookDeliveryQueueEntity.DeliveryStatus status
+            @Parameter(example = "SUCCESSFUL") @Valid @QueryParam("status") DeliveryStatus status
     ) {
         var currentPage = Optional.ofNullable(page)
                 .orElse(1);

--- a/src/test/java/uk/gov/pay/webhooks/deliveryqueue/WebhookDeliveryQueueIT.java
+++ b/src/test/java/uk/gov/pay/webhooks/deliveryqueue/WebhookDeliveryQueueIT.java
@@ -5,7 +5,6 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 import uk.gov.pay.extension.AppWithPostgresAndSqsExtension;
-import uk.gov.pay.webhooks.deliveryqueue.dao.WebhookDeliveryQueueEntity;
 import uk.gov.pay.webhooks.util.DatabaseTestHelper;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
@@ -23,8 +22,8 @@ public class WebhookDeliveryQueueIT {
     }
 
     @ParameterizedTest
-    @EnumSource(value = WebhookDeliveryQueueEntity.DeliveryStatus.class)
-    public void deliveryStatusEnumIsConsistentWithDatabase(WebhookDeliveryQueueEntity.DeliveryStatus status) {
+    @EnumSource(value = DeliveryStatus.class)
+    public void deliveryStatusEnumIsConsistentWithDatabase(DeliveryStatus status) {
         app.getJdbi().withHandle(h -> h.execute("INSERT INTO webhooks VALUES (1, '2022-01-01', 'webhook-external-id', 'signing-key', 'service-id', true, 'https://callback-url.test', 'description', 'ACTIVE')"));
         app.getJdbi().withHandle(h -> h.execute("INSERT INTO webhook_messages VALUES (1, 'message-external-id', '2022-01-01', 1, '2022-01-01', 1, '{}', 'transaction-external-id', 'payment')"));
         assertDoesNotThrow(() -> app.getJdbi().withHandle(h -> h.execute("INSERT INTO webhook_delivery_queue VALUES (1, '2022-01-01', '2022-01-01', '200', 200, 1, '%s', 1250)".formatted(status))));

--- a/src/test/java/uk/gov/pay/webhooks/deliveryqueue/dao/WebhookDeliveryQueueDaoTest.java
+++ b/src/test/java/uk/gov/pay/webhooks/deliveryqueue/dao/WebhookDeliveryQueueDaoTest.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.pay.webhooks.deliveryqueue.DeliveryStatus;
 import uk.gov.pay.webhooks.eventtype.dao.EventTypeEntity;
 import uk.gov.pay.webhooks.message.dao.WebhookMessageDao;
 import uk.gov.pay.webhooks.message.dao.entity.WebhookMessageEntity;
@@ -55,7 +56,7 @@ class WebhookDeliveryQueueDaoTest {
             return webhookMessageDao.create(webhookMessageEntity);
         });
         database.inTransaction(() -> {
-            webhookDeliveryQueueDao.enqueueFrom(persisted, WebhookDeliveryQueueEntity.DeliveryStatus.PENDING, instantSource.instant().minusMillis(1));
+            webhookDeliveryQueueDao.enqueueFrom(persisted, DeliveryStatus.PENDING, instantSource.instant().minusMillis(1));
             assertThat(webhookDeliveryQueueDao.nextToSend(instantSource.instant()).get().getWebhookMessageEntity(), is(persisted));
         });
     }
@@ -68,9 +69,9 @@ class WebhookDeliveryQueueDaoTest {
             return webhookMessageDao.create(webhookMessageEntity);
         });
         database.inTransaction(() -> {
-            var enqueued = webhookDeliveryQueueDao.enqueueFrom(persisted, WebhookDeliveryQueueEntity.DeliveryStatus.PENDING, instantSource.instant().minusMillis(1));
-            var updated = webhookDeliveryQueueDao.recordResult(enqueued, "200 OK", Duration.ofMillis(50L), 200, WebhookDeliveryQueueEntity.DeliveryStatus.SUCCESSFUL, mockMetricRegistry);
-            assertThat(updated.getDeliveryStatus(), is(WebhookDeliveryQueueEntity.DeliveryStatus.SUCCESSFUL));
+            var enqueued = webhookDeliveryQueueDao.enqueueFrom(persisted, DeliveryStatus.PENDING, instantSource.instant().minusMillis(1));
+            var updated = webhookDeliveryQueueDao.recordResult(enqueued, "200 OK", Duration.ofMillis(50L), 200, DeliveryStatus.SUCCESSFUL, mockMetricRegistry);
+            assertThat(updated.getDeliveryStatus(), is(DeliveryStatus.SUCCESSFUL));
             assertThat(updated.getDeliveryResult(), is("200 OK"));
             assertThat(updated.getStatusCode(), is(200));
         });
@@ -84,8 +85,8 @@ class WebhookDeliveryQueueDaoTest {
             return webhookMessageDao.create(webhookMessageEntity);
         });
         database.inTransaction(() -> {
-            webhookDeliveryQueueDao.enqueueFrom(persisted, WebhookDeliveryQueueEntity.DeliveryStatus.FAILED, instantSource.instant());
-            webhookDeliveryQueueDao.enqueueFrom(persisted, WebhookDeliveryQueueEntity.DeliveryStatus.FAILED, instantSource.instant());
+            webhookDeliveryQueueDao.enqueueFrom(persisted, DeliveryStatus.FAILED, instantSource.instant());
+            webhookDeliveryQueueDao.enqueueFrom(persisted, DeliveryStatus.FAILED, instantSource.instant());
             assertThat(webhookDeliveryQueueDao.countFailed(persisted), is(2L));
         });
     }

--- a/src/test/java/uk/gov/pay/webhooks/deliveryqueue/managed/WebhookMessagePollingServiceTest.java
+++ b/src/test/java/uk/gov/pay/webhooks/deliveryqueue/managed/WebhookMessagePollingServiceTest.java
@@ -5,7 +5,6 @@ import io.dropwizard.hibernate.UnitOfWorkAwareProxyFactory;
 import io.dropwizard.setup.Environment;
 import io.dropwizard.testing.junit5.DAOTestExtension;
 import io.dropwizard.testing.junit5.DropwizardExtensionsSupport;
-import org.apache.http.HttpResponse;
 import org.apache.http.StatusLine;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.junit.jupiter.api.BeforeEach;
@@ -16,6 +15,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
+import uk.gov.pay.webhooks.deliveryqueue.DeliveryStatus;
 import uk.gov.pay.webhooks.deliveryqueue.dao.WebhookDeliveryQueueDao;
 import uk.gov.pay.webhooks.deliveryqueue.dao.WebhookDeliveryQueueEntity;
 import uk.gov.pay.webhooks.eventtype.EventTypeName;
@@ -163,7 +163,7 @@ class WebhookMessagePollingServiceTest {
                 return webhookMessageDao.create(webhookMessageEntity);
             });
             database.inTransaction(() -> {
-                webhookDeliveryQueueDao.enqueueFrom(message, WebhookDeliveryQueueEntity.DeliveryStatus.PENDING, instantSource.instant().minusMillis((messageIds.size() - i) * 10L));
+                webhookDeliveryQueueDao.enqueueFrom(message, DeliveryStatus.PENDING, instantSource.instant().minusMillis((messageIds.size() - i) * 10L));
             });
         });
     }

--- a/src/test/java/uk/gov/pay/webhooks/message/WebhookMessageIT.java
+++ b/src/test/java/uk/gov/pay/webhooks/message/WebhookMessageIT.java
@@ -1,0 +1,31 @@
+package uk.gov.pay.webhooks.message;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import uk.gov.pay.extension.AppWithPostgresAndSqsExtension;
+import uk.gov.pay.webhooks.deliveryqueue.DeliveryStatus;
+import uk.gov.pay.webhooks.util.DatabaseTestHelper;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+
+public class WebhookMessageIT {
+    @RegisterExtension
+    public static AppWithPostgresAndSqsExtension app = new AppWithPostgresAndSqsExtension();
+    private DatabaseTestHelper dbHelper;
+
+    @BeforeEach
+    public void setUp() {
+        dbHelper = DatabaseTestHelper.aDatabaseTestHelper(app.getJdbi());
+        dbHelper.truncateAllData();
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = DeliveryStatus.class)
+    public void deliveryStatusEnumIsConsistentWithWebhookMessageLastDeliveryStatus(DeliveryStatus status) {
+        app.getJdbi().withHandle(h -> h.execute("INSERT INTO webhooks VALUES (1, '2022-01-01', 'webhook-external-id', 'signing-key', 'service-id', true, 'https://callback-url.test', 'description', 'ACTIVE')"));
+        assertDoesNotThrow(() -> app.getJdbi().withHandle(h -> h.execute("INSERT INTO webhook_messages VALUES (1, 'message-external-id', '2022-01-01', 1, '2022-01-01', 1, '{}', 'transaction-external-id', 'payment', '%s')".formatted(status))));
+    }
+}

--- a/src/test/java/uk/gov/pay/webhooks/message/dao/WebhookMessageDaoTest.java
+++ b/src/test/java/uk/gov/pay/webhooks/message/dao/WebhookMessageDaoTest.java
@@ -5,6 +5,7 @@ import io.dropwizard.testing.junit5.DropwizardExtensionsSupport;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import uk.gov.pay.webhooks.deliveryqueue.DeliveryStatus;
 import uk.gov.pay.webhooks.deliveryqueue.dao.WebhookDeliveryQueueDao;
 import uk.gov.pay.webhooks.deliveryqueue.dao.WebhookDeliveryQueueEntity;
 import uk.gov.pay.webhooks.eventtype.dao.EventTypeEntity;
@@ -82,14 +83,14 @@ class WebhookMessageDaoTest {
        database.inTransaction(() -> {
            webhookDao.create(webhook);
            webhookMessageDao.create(message);
-           webhookDeliveryQueueDao.enqueueFrom(message, WebhookDeliveryQueueEntity.DeliveryStatus.SUCCESSFUL, Instant.now());
+           webhookDeliveryQueueDao.enqueueFrom(message, DeliveryStatus.SUCCESSFUL, Instant.now());
 
            for (var i = 0; i < numberOfPendingMessagesToPad; i++) {
                var padMessage = new WebhookMessageEntity();
                padMessage.setWebhookEntity(webhook);
                padMessage.setExternalId("padded-message-%s".formatted(i));
                webhookMessageDao.create(padMessage);
-               webhookDeliveryQueueDao.enqueueFrom(padMessage, WebhookDeliveryQueueEntity.DeliveryStatus.PENDING, Instant.now());
+               webhookDeliveryQueueDao.enqueueFrom(padMessage, DeliveryStatus.PENDING, Instant.now());
            }
        });
    }


### PR DESCRIPTION
Depends on https://github.com/alphagov/pay-webhooks/pull/677

Extract delivery status to be shared outside of the delivery queue class.

Ensure that any changes that are made to the enum representing possible
message delivery statuses are valid according to database constraints.
Do this by spinning up the database and running all of the enum values
against webhook message entries.