### PR TITLE
PP-10543 Map last delivery status on webhook message

### DIFF
--- a/openapi/webhooks_spec.yaml
+++ b/openapi/webhooks_spec.yaml
@@ -403,6 +403,13 @@ components:
         external_id:
           type: string
           example: s0wjen129ejalk21nfjkdknf1jejklh
+        last_delivery_status:
+          type: string
+          enum:
+          - PENDING
+          - SUCCESSFUL
+          - FAILED
+          - WILL_NOT_SEND
         latest_attempt:
           $ref: '#/components/schemas/WebhookDeliveryQueueResponse'
         resource:

--- a/src/main/java/uk/gov/pay/webhooks/message/dao/entity/WebhookMessageEntity.java
+++ b/src/main/java/uk/gov/pay/webhooks/message/dao/entity/WebhookMessageEntity.java
@@ -6,12 +6,15 @@ import org.hibernate.annotations.JoinFormula;
 import org.hibernate.annotations.Type;
 import org.hibernate.annotations.TypeDef;
 import org.hibernate.annotations.TypeDefs;
+import uk.gov.pay.webhooks.deliveryqueue.DeliveryStatus;
 import uk.gov.pay.webhooks.deliveryqueue.dao.WebhookDeliveryQueueEntity;
 import uk.gov.pay.webhooks.eventtype.dao.EventTypeEntity;
 import uk.gov.pay.webhooks.webhook.dao.entity.WebhookEntity;
 
 import javax.persistence.Column;
 import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
 import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
@@ -126,6 +129,10 @@ public class WebhookMessageEntity {
             """)
     private WebhookDeliveryQueueEntity webhookDeliveryQueueEntity;
 
+    @Column(name = "last_delivery_status")
+    @Enumerated(EnumType.STRING)
+    private DeliveryStatus lastDeliveryStatus;
+
     public String getExternalId() {
         return externalId;
     }
@@ -176,5 +183,13 @@ public class WebhookMessageEntity {
 
     public WebhookDeliveryQueueEntity getWebhookDeliveryQueueEntity() {
         return webhookDeliveryQueueEntity;
+    }
+
+    public DeliveryStatus getLastDeliveryStatus() {
+        return lastDeliveryStatus;
+    }
+
+    public void setLastDeliveryStatus(DeliveryStatus lastDeliveryStatus) {
+        this.lastDeliveryStatus = lastDeliveryStatus;
     }
 }

--- a/src/main/java/uk/gov/pay/webhooks/message/resource/WebhookMessageResponse.java
+++ b/src/main/java/uk/gov/pay/webhooks/message/resource/WebhookMessageResponse.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import io.swagger.v3.oas.annotations.media.Schema;
+import uk.gov.pay.webhooks.deliveryqueue.DeliveryStatus;
 import uk.gov.pay.webhooks.eventtype.EventTypeName;
 import uk.gov.pay.webhooks.message.dao.entity.WebhookMessageEntity;
 import uk.gov.service.payments.commons.api.json.ApiResponseInstantSerializer;
@@ -24,7 +25,8 @@ public record WebhookMessageResponse(
         @Schema(example = "payment")
         @JsonProperty("resource_type") String resourceType,
         @JsonProperty("resource") JsonNode resource,
-        @JsonProperty("latest_attempt") WebhookDeliveryQueueResponse webhookDeliveryQueueEntity) {
+        @JsonProperty("latest_attempt") WebhookDeliveryQueueResponse webhookDeliveryQueueEntity,
+        @JsonProperty("last_delivery_status") DeliveryStatus lastDeliveryStatus) {
 
     public static WebhookMessageResponse from(WebhookMessageEntity webhookMessageEntity) {
         var latestAttempt = (webhookMessageEntity.getWebhookDeliveryQueueEntity() != null) ? WebhookDeliveryQueueResponse.from(webhookMessageEntity.getWebhookDeliveryQueueEntity()) : null;
@@ -36,7 +38,8 @@ public record WebhookMessageResponse(
                 webhookMessageEntity.getResourceExternalId(),
                 webhookMessageEntity.getResourceType(),
                 webhookMessageEntity.getResource(),
-                latestAttempt
+                latestAttempt,
+                webhookMessageEntity.getLastDeliveryStatus()
         );
     }
 }

--- a/src/test/java/uk/gov/pay/webhooks/message/dao/WebhookMessageDaoTest.java
+++ b/src/test/java/uk/gov/pay/webhooks/message/dao/WebhookMessageDaoTest.java
@@ -41,6 +41,15 @@ class WebhookMessageDaoTest {
     }
 
    @Test
+   public void shouldSerialiseAndDeserialiseWebhookMessage() {
+        setup(0);
+        var message = webhookMessageDao.get(webhookExternalId, "successful-message-external-id");
+        assertThat(message.getExternalId(), is("successful-message-external-id"));
+        assertThat(message.getWebhookEntity().getExternalId(), is(webhookExternalId));
+        assertThat(message.getLastDeliveryStatus(), is(DeliveryStatus.SUCCESSFUL));
+   }
+
+   @Test
    public void shouldListAndCountAllWithNoStatus() {
         setup(1);
         var messages = webhookMessageDao.list(webhookExternalId, null, 1);
@@ -78,6 +87,7 @@ class WebhookMessageDaoTest {
 
        var message = new WebhookMessageEntity();
        message.setWebhookEntity(webhook);
+       message.setLastDeliveryStatus(DeliveryStatus.SUCCESSFUL);
        message.setExternalId("successful-message-external-id");
 
        database.inTransaction(() -> {

--- a/src/test/java/uk/gov/pay/webhooks/webhook/resource/WebhookResourceIT.java
+++ b/src/test/java/uk/gov/pay/webhooks/webhook/resource/WebhookResourceIT.java
@@ -104,6 +104,7 @@ public class WebhookResourceIT {
                 .get("/v1/webhook/%s/message".formatted(externalId))
                 .then()
                 .statusCode(Response.Status.OK.getStatusCode())
+                .body("results.last_delivery_status[0]", is("FAILED"))
                 .body("results.latest_attempt[0].status", is("FAILED"));
 
         given().port(port)
@@ -156,6 +157,7 @@ public class WebhookResourceIT {
                 .body("external_id", is(messageExternalId))
                 .body("resource_id", is("transaction-external-id"))
                 .body("resource_type", is("payment"))
+                .body("last_delivery_status", is("FAILED"))
                 .body("latest_attempt.status", is("FAILED"))
                 .body("latest_attempt.response_time", is(25));
     }
@@ -187,18 +189,18 @@ public class WebhookResourceIT {
         ));
         app.getJdbi().withHandle(h -> h.execute("""
                             INSERT INTO webhook_messages VALUES
-                            (1, '%s', '2022-01-01', 1, '2022-01-01', 1, '{}', 'transaction-external-id', 'payment'),
-                            (2, 'second-message-external-id', '2022-01-01', 1, '2022-01-01', 1, '{}', null, null),
-                            (3, 'third-message-external-id', '2022-01-01', 1, '2022-01-01', 1, '{}', null, null),
-                            (4, 'fourth-message-external-id', '2022-01-01', 1, '2022-01-01', 1, '{}', null, null),
-                            (5, 'fifth-message-external-id', '2022-01-01', 1, '2022-01-01', 1, '{}', null, null),
-                            (6, 'sixth-message-external-id', '2022-01-01', 1, '2022-01-01', 1, '{}', null, null),
-                            (7, 'seventh-message-external-id', '2022-01-01', 1, '2022-01-01', 1, '{}', null, null),
-                            (8, 'eighth-message-external-id', '2022-01-01', 1, '2022-01-01', 1, '{}', null, null),
-                            (9, 'ninth-message-external-id', '2022-01-01', 1, '2022-01-01', 1, '{}', null, null),
-                            (10, 'tenth-message-external-id', '2022-01-01', 1, '2022-01-01', 1, '{}', null, null),
-                            (11, 'eleventh-message-external-id', '2022-01-01', 1, '2022-01-01', 1, '{}', null, null),
-                            (12, 'twelfth-message-external-id', '2022-01-01', 1, '2022-01-01', 1, '{}', null, null)
+                            (1, '%s', '2022-01-01', 1, '2022-01-01', 1, '{}', 'transaction-external-id', 'payment', 'FAILED'),
+                            (2, 'second-message-external-id', '2022-01-01', 1, '2022-01-01', 1, '{}', null, null, null),
+                            (3, 'third-message-external-id', '2022-01-01', 1, '2022-01-01', 1, '{}', null, null, null),
+                            (4, 'fourth-message-external-id', '2022-01-01', 1, '2022-01-01', 1, '{}', null, null, null),
+                            (5, 'fifth-message-external-id', '2022-01-01', 1, '2022-01-01', 1, '{}', null, null, null),
+                            (6, 'sixth-message-external-id', '2022-01-01', 1, '2022-01-01', 1, '{}', null, null, null),
+                            (7, 'seventh-message-external-id', '2022-01-01', 1, '2022-01-01', 1, '{}', null, null, null),
+                            (8, 'eighth-message-external-id', '2022-01-01', 1, '2022-01-01', 1, '{}', null, null, null),
+                            (9, 'ninth-message-external-id', '2022-01-01', 1, '2022-01-01', 1, '{}', null, null, null),
+                            (10, 'tenth-message-external-id', '2022-01-01', 1, '2022-01-01', 1, '{}', null, null, null),
+                            (11, 'eleventh-message-external-id', '2022-01-01', 1, '2022-01-01', 1, '{}', null, null, null),
+                            (12, 'twelfth-message-external-id', '2022-01-01', 1, '2022-01-01', 1, '{}', null, null, null)
                         """.formatted(messageExternalId)
         ));
         app.getJdbi().withHandle(h -> h.execute("""


### PR DESCRIPTION
Add entity mappings for `last_delivery_status` to serialise this from
the db.

Cover reading/ writing at the DAO level and jackson serialisation at the
resource level.

Update the open api spec to reflect the new resource attribute.