### PR TITLE
BAU Favour enums and javax persistence (delivery queue)

### DIFF
--- a/src/main/java/uk/gov/pay/webhooks/deliveryqueue/dao/WebhookDeliveryQueueEntity.java
+++ b/src/main/java/uk/gov/pay/webhooks/deliveryqueue/dao/WebhookDeliveryQueueEntity.java
@@ -6,6 +6,8 @@ import uk.gov.pay.webhooks.message.dao.entity.WebhookMessageEntity;
 
 import javax.persistence.Column;
 import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
 import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
@@ -73,18 +75,17 @@ public class WebhookDeliveryQueueEntity {
         return createdDate.toInstant();
     }
 
-
-    public void setDeliveryStatus(DeliveryStatus deliveryStatusEnum) {
-        this.deliveryStatus = deliveryStatusEnum.name();
+    public void setDeliveryStatus(DeliveryStatus deliveryStatus) {
+        this.deliveryStatus = deliveryStatus;
     }
 
-
     public DeliveryStatus getDeliveryStatus() {
-        return DeliveryStatus.valueOf(deliveryStatus);
+        return deliveryStatus;
     }
 
     @Column(name = "delivery_status")
-    private String deliveryStatus;
+    @Enumerated(EnumType.STRING)
+    private DeliveryStatus deliveryStatus;
 
     @Column(name = "delivery_response_time_in_millis")
     private Long deliveryResponseTime;

--- a/src/main/java/uk/gov/pay/webhooks/message/dao/WebhookMessageDao.java
+++ b/src/main/java/uk/gov/pay/webhooks/message/dao/WebhookMessageDao.java
@@ -2,6 +2,7 @@ package uk.gov.pay.webhooks.message.dao;
 
 import io.dropwizard.hibernate.AbstractDAO;
 import org.hibernate.SessionFactory;
+import uk.gov.pay.webhooks.deliveryqueue.DeliveryStatus;
 import uk.gov.pay.webhooks.message.dao.entity.WebhookMessageEntity;
 
 import javax.inject.Inject;
@@ -28,7 +29,7 @@ public class WebhookMessageDao extends AbstractDAO<WebhookMessageEntity> {
                .getSingleResult();
     }
 
-    public List<WebhookMessageEntity> list(String webhookId, String deliveryStatus, int page) {
+    public List<WebhookMessageEntity> list(String webhookId, DeliveryStatus deliveryStatus, int page) {
         var query = deliveryStatus != null ?
                 namedTypedQuery(WebhookMessageEntity.MESSAGES_BY_WEBHOOK_ID_AND_STATUS).setParameter("webhookId", webhookId).setParameter("deliveryStatus", deliveryStatus) :
                 namedTypedQuery(WebhookMessageEntity.MESSAGES_BY_WEBHOOK_ID).setParameter("webhookId", webhookId);
@@ -37,7 +38,7 @@ public class WebhookMessageDao extends AbstractDAO<WebhookMessageEntity> {
                 .getResultList();
     }
 
-    public Long count(String webhookId, String deliveryStatus) {
+    public Long count(String webhookId, DeliveryStatus deliveryStatus) {
         var query = deliveryStatus != null ?
                 namedQuery(WebhookMessageEntity.COUNT_MESSAGES_BY_WEBHOOK_ID_AND_STATUS).setParameter("webhookId", webhookId).setParameter("deliveryStatus", deliveryStatus) :
                 namedQuery(WebhookMessageEntity.COUNT_MESSAGES_BY_WEBHOOK_ID).setParameter("webhookId", webhookId);

--- a/src/main/java/uk/gov/pay/webhooks/webhook/WebhookService.java
+++ b/src/main/java/uk/gov/pay/webhooks/webhook/WebhookService.java
@@ -1,5 +1,6 @@
 package uk.gov.pay.webhooks.webhook;
 
+import uk.gov.pay.webhooks.deliveryqueue.DeliveryStatus;
 import uk.gov.pay.webhooks.deliveryqueue.dao.WebhookDeliveryQueueDao;
 import uk.gov.pay.webhooks.eventtype.EventTypeName;
 import uk.gov.pay.webhooks.eventtype.dao.EventTypeDao;
@@ -75,7 +76,7 @@ public class WebhookService {
         return webhookDao.list(live);
     }
 
-    public WebhookMessageSearchResponse listMessages(String webhookId, String status, int page) {
+    public WebhookMessageSearchResponse listMessages(String webhookId, DeliveryStatus status, int page) {
         var messages = webhookMessageDao.list(webhookId, status, page)
                 .stream()
                 .map(WebhookMessageResponse::from)

--- a/src/main/java/uk/gov/pay/webhooks/webhook/resource/WebhookResource.java
+++ b/src/main/java/uk/gov/pay/webhooks/webhook/resource/WebhookResource.java
@@ -174,13 +174,10 @@ public class WebhookResource {
     public WebhookMessageSearchResponse getWebhookMessages(
             @Parameter(example = "gh0d0923jpsjdf0923jojlsfgkw3seg") @PathParam("webhookExternalId") String externalId,
             @Parameter(example = "1") @QueryParam("page") Integer page,
-            @Parameter(example = "SUCCESSFUL") @Valid @QueryParam("status") DeliveryStatus status
+            @Parameter(example = "SUCCESSFUL") @Valid @QueryParam("status") DeliveryStatus deliveryStatus
     ) {
         var currentPage = Optional.ofNullable(page)
                 .orElse(1);
-        var deliveryStatus = Optional.ofNullable(status)
-                .map(String::valueOf)
-                .orElse(null);
         return webhookService.listMessages(externalId, deliveryStatus, currentPage);
     }
 

--- a/src/test/java/uk/gov/pay/webhooks/message/dao/WebhookMessageDaoTest.java
+++ b/src/test/java/uk/gov/pay/webhooks/message/dao/WebhookMessageDaoTest.java
@@ -52,8 +52,8 @@ class WebhookMessageDaoTest {
     @Test
     public void shouldListAndCountFilteredByStatus() {
         setup(1);
-        var messages = webhookMessageDao.list(webhookExternalId, "SUCCESSFUL", 1);
-        var total = webhookMessageDao.count(webhookExternalId, "SUCCESSFUL");
+        var messages = webhookMessageDao.list(webhookExternalId, DeliveryStatus.SUCCESSFUL, 1);
+        var total = webhookMessageDao.count(webhookExternalId, DeliveryStatus.SUCCESSFUL);
         assertThat(messages.size(), is(1));
         assertThat(total, is(1L));
         assertThat(messages.get(0).getExternalId(), is("successful-message-external-id"));


### PR DESCRIPTION
Instead of manually mapping between a string taken from the database, use the enumerated javax annotation to do this for us.