### PR TITLE
PP-10543 Abstract SQS (SNS) events fixture

### DIFF
--- a/src/test/java/uk/gov/pay/webhooks/util/SNSToSQSEventFixture.java
+++ b/src/test/java/uk/gov/pay/webhooks/util/SNSToSQSEventFixture.java
@@ -1,0 +1,33 @@
+package uk.gov.pay.webhooks.util;
+
+import com.amazonaws.util.json.Jackson;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import java.io.IOException;
+import java.util.Optional;
+
+public class SNSToSQSEventFixture {
+    private JsonNode body;
+    private final ObjectNode fixture = (ObjectNode) Jackson.getObjectMapper().readTree(getClass().getResource("/sns-to-sqs-event.json"));
+    public SNSToSQSEventFixture() throws IOException {
+    }
+
+    public static SNSToSQSEventFixture anSNSToSQSEventFixture() throws IOException {
+        return new SNSToSQSEventFixture();
+    }
+
+    public String build() {
+        getBody().map(JsonNode::toString).map(body -> fixture.put("Message", body));
+        return fixture.toString();
+    }
+
+    public SNSToSQSEventFixture withBody(Object body) {
+        this.body = Jackson.getObjectMapper().valueToTree(body);
+        return this;
+    }
+
+    public Optional<JsonNode> getBody() {
+        return Optional.ofNullable(body);
+    }
+}

--- a/src/test/resources/sns-to-sqs-event.json
+++ b/src/test/resources/sns-to-sqs-event.json
@@ -1,0 +1,11 @@
+{
+  "Type" : "Notification",
+  "MessageId" : "04424f78-d540-5eb7-87e1-154d586b6b02",
+  "Message" : "",
+  "TopicArn" : "card-payment-events-topic",
+  "Timestamp" : "2021-12-16T18:52:27.068Z",
+  "SignatureVersion" : "1",
+  "Signature" : "a-valid-signature",
+  "SigningCertURL" : "https://sns.eu-west-1.amazonaws.com/SimpleNotificationService-signing-cert-uuid.pem",
+  "UnsubscribeURL" : "https://sns.eu-west-1.amazonaws.com/?Action=Unsubscribe&SubscriptionArn=arn:a-aws-arn"
+}


### PR DESCRIPTION
When an SQS message is processed by webhooks the message was initially fanned out from SNS. The shape and properties of this message are largely static (as we're currenlty only dealing with card events) with a variable `"Message"` parameter which includes the original event body.

Clean up existing tests by abstracting out the SNS schema details into a fixture that allows specifying a simple map for the event body (the fixture builder will deal with serialisation, JSON in JSON etc.).

This should let us use this fixture in other unit/ integration tests without duplicated schema.