### PR TITLE
PP-10543 Happy path integration test for sending a webhook message 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -243,6 +243,12 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>com.github.tomakehurst</groupId>
+            <artifactId>wiremock-jre8</artifactId>
+            <version>2.35.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
             <version>2.1.214</version>

--- a/src/test/java/uk/gov/pay/webhooks/deliveryqueue/WebhookDeliveryQueueIT.java
+++ b/src/test/java/uk/gov/pay/webhooks/deliveryqueue/WebhookDeliveryQueueIT.java
@@ -1,19 +1,49 @@
 package uk.gov.pay.webhooks.deliveryqueue;
 
+import com.github.tomakehurst.wiremock.client.ResponseDefinitionBuilder;
+import com.github.tomakehurst.wiremock.client.WireMock;
+import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
+import io.dropwizard.testing.ConfigOverride;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 import uk.gov.pay.extension.AppWithPostgresAndSqsExtension;
+import uk.gov.pay.rule.SqsTestDocker;
+import uk.gov.pay.webhooks.ledger.LedgerStub;
 import uk.gov.pay.webhooks.util.DatabaseTestHelper;
+import uk.gov.service.payments.commons.testing.port.PortFactory;
 
+import java.io.IOException;
+import java.util.Map;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.exactly;
+import static com.github.tomakehurst.wiremock.client.WireMock.matchingJsonPath;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static uk.gov.pay.webhooks.ledger.TransactionFromLedgerFixture.aTransactionFromLedgerFixture;
+import static uk.gov.pay.webhooks.util.SNSToSQSEventFixture.anSNSToSQSEventFixture;
 
 
 public class WebhookDeliveryQueueIT {
+    private static final int webhookCallbackEndpointStubPort = PortFactory.findFreePort();
     @RegisterExtension
-    public static AppWithPostgresAndSqsExtension app = new AppWithPostgresAndSqsExtension();
+    public static AppWithPostgresAndSqsExtension app = new AppWithPostgresAndSqsExtension(
+            ConfigOverride.config("queueMessageReceiverConfig.backgroundProcessingEnabled", "true"),
+            ConfigOverride.config("webhookMessageSendingQueueProcessorConfig.initialDelayInMilliseconds", "0"),
+            ConfigOverride.config("webhookMessageSendingQueueProcessorConfig.threadDelayInMilliseconds", "10")
+    );
+    @RegisterExtension
+    public static WireMockExtension wireMock = WireMockExtension.newInstance()
+            .options(wireMockConfig().port(app.getWireMockPort()).httpsPort(webhookCallbackEndpointStubPort))
+            .build();
     private DatabaseTestHelper dbHelper;
+    private final LedgerStub ledgerStub = new LedgerStub(wireMock);
 
     @BeforeEach
     public void setUp() {
@@ -27,5 +57,35 @@ public class WebhookDeliveryQueueIT {
         app.getJdbi().withHandle(h -> h.execute("INSERT INTO webhooks VALUES (1, '2022-01-01', 'webhook-external-id', 'signing-key', 'service-id', true, 'https://callback-url.test', 'description', 'ACTIVE')"));
         app.getJdbi().withHandle(h -> h.execute("INSERT INTO webhook_messages VALUES (1, 'message-external-id', '2022-01-01', 1, '2022-01-01', 1, '{}', 'transaction-external-id', 'payment')"));
         assertDoesNotThrow(() -> app.getJdbi().withHandle(h -> h.execute("INSERT INTO webhook_delivery_queue VALUES (1, '2022-01-01', '2022-01-01', '200', 200, 1, '%s', 1250)".formatted(status))));
+    }
+
+    @Test
+    public void webhookMessageIsEmittedForSubscribedWebhook() throws IOException, InterruptedException {
+        var serviceExternalId = "a-valid-service-id";
+        app.getJdbi().withHandle(h -> h.execute("INSERT INTO webhooks VALUES (1, '2022-01-01', 'webhook-external-id', 'signing-key', '%s', false, 'http://localhost:%d/a-test-endpoint', 'description', 'ACTIVE')".formatted(serviceExternalId, app.getWireMockPort())));
+        app.getJdbi().withHandle(h -> h.execute("INSERT INTO webhook_subscriptions VALUES (1, (SELECT id FROM event_types WHERE name = 'card_payment_succeeded'))"));
+        
+        var transaction = aTransactionFromLedgerFixture();
+        var sqsMessage = anSNSToSQSEventFixture()
+                .withBody(Map.of(
+                        "service_id", serviceExternalId,
+                        "live", false,
+                        "resource_external_id", transaction.getTransactionId(),
+                        "timestamp", "2023-03-14T09:00:00.000000Z",
+                        "resource_type", "payment",
+                        "event_type", "USER_APPROVED_FOR_CAPTURE",
+                        "sqs_message_id", "dc142884-1e4b-4e57-be93-111b692a4868"
+                ));
+
+        ledgerStub.returnLedgerTransaction(transaction);
+        wireMock.stubFor(post("/a-test-endpoint").willReturn(ResponseDefinitionBuilder.okForJson("{}")));
+
+        app.getSqsClient().sendMessage(SqsTestDocker.getQueueUrl("event-queue"), sqsMessage.build());
+        Thread.sleep(1000);
+
+        wireMock.verify(
+                exactly(1),
+                postRequestedFor(urlEqualTo("/a-test-endpoint")).withRequestBody(matchingJsonPath("$.resource_id", equalTo(transaction.getTransactionId())))
+        ); 
     }
 }

--- a/src/test/java/uk/gov/pay/webhooks/deliveryqueue/WebhookDeliveryQueueIT.java
+++ b/src/test/java/uk/gov/pay/webhooks/deliveryqueue/WebhookDeliveryQueueIT.java
@@ -62,8 +62,7 @@ public class WebhookDeliveryQueueIT {
     @Test
     public void webhookMessageIsEmittedForSubscribedWebhook() throws IOException, InterruptedException {
         var serviceExternalId = "a-valid-service-id";
-        app.getJdbi().withHandle(h -> h.execute("INSERT INTO webhooks VALUES (1, '2022-01-01', 'webhook-external-id', 'signing-key', '%s', false, 'http://localhost:%d/a-test-endpoint', 'description', 'ACTIVE')".formatted(serviceExternalId, app.getWireMockPort())));
-        app.getJdbi().withHandle(h -> h.execute("INSERT INTO webhook_subscriptions VALUES (1, (SELECT id FROM event_types WHERE name = 'card_payment_succeeded'))"));
+        dbHelper.addWebhookWithSubscription("a-valid-webhook-id", serviceExternalId, "http://localhost:%d/a-test-endpoint".formatted(app.getWireMockPort()));
         
         var transaction = aTransactionFromLedgerFixture();
         var sqsMessage = anSNSToSQSEventFixture()

--- a/src/test/java/uk/gov/pay/webhooks/ledger/LedgerStub.java
+++ b/src/test/java/uk/gov/pay/webhooks/ledger/LedgerStub.java
@@ -1,0 +1,21 @@
+package uk.gov.pay.webhooks.ledger;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.ResponseDefinitionBuilder.okForJson;
+
+public class LedgerStub {
+    private final WireMockExtension wireMock;
+
+    public LedgerStub(WireMockExtension wireMock) {
+        this.wireMock = wireMock;
+    }
+
+    public void returnLedgerTransaction(TransactionFromLedgerFixture transaction) {
+        var request = get("/v1/transaction/" + transaction.getTransactionId() + "?override_account_id_restriction=true");
+        var response = okForJson(transaction);
+        wireMock.stubFor(request.willReturn(response));
+    }
+}

--- a/src/test/java/uk/gov/pay/webhooks/ledger/TransactionFromLedgerFixture.java
+++ b/src/test/java/uk/gov/pay/webhooks/ledger/TransactionFromLedgerFixture.java
@@ -1,0 +1,39 @@
+package uk.gov.pay.webhooks.ledger;
+
+import com.amazonaws.util.json.Jackson;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import uk.gov.pay.webhooks.ledger.model.TransactionState;
+
+// src/test/resources/pacts/webhooks-ledger-get-payment-transaction.json
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class TransactionFromLedgerFixture {
+    private final int gatewayAccountId = 3;
+    private final int amount = 12000;
+    private final TransactionState transactionState = new TransactionState("success");
+    private final String description = "New passport application";
+    private final String reference = "1_86";
+    private final String language = "cy";
+    private final String returnUrl = "https://service-name.gov.uk/transactions/12345";
+    private final String email = "Joe.Bogs@example.org";
+    private final String paymentProvider = "sandbox";
+    private final String credentialExternalId = "credential-external-id";
+    private final String createdDate = "2020-02-13T16:26:04.204Z";
+    private final Boolean delayedCapture = false;
+    private final String transactionType = "PAYMENT";
+    private final Boolean moto = false;
+    private final Boolean live = false;
+    private final String transactionId = "e8eq11mi2ndmauvb51qsg8hccn";
+
+    public TransactionFromLedgerFixture() {
+    }
+
+    public static TransactionFromLedgerFixture aTransactionFromLedgerFixture() {
+        return new TransactionFromLedgerFixture();
+    }
+
+    public String build() throws JsonProcessingException {
+        return Jackson.getObjectMapper().writeValueAsString(this);
+    }
+}

--- a/src/test/java/uk/gov/pay/webhooks/ledger/TransactionFromLedgerFixture.java
+++ b/src/test/java/uk/gov/pay/webhooks/ledger/TransactionFromLedgerFixture.java
@@ -11,7 +11,7 @@ import uk.gov.pay.webhooks.ledger.model.TransactionState;
 public class TransactionFromLedgerFixture {
     private final int gatewayAccountId = 3;
     private final int amount = 12000;
-    private final TransactionState transactionState = new TransactionState("success");
+    private final TransactionState state = new TransactionState("success");
     private final String description = "New passport application";
     private final String reference = "1_86";
     private final String language = "cy";
@@ -21,7 +21,6 @@ public class TransactionFromLedgerFixture {
     private final String credentialExternalId = "credential-external-id";
     private final String createdDate = "2020-02-13T16:26:04.204Z";
     private final Boolean delayedCapture = false;
-    private final String transactionType = "PAYMENT";
     private final Boolean moto = false;
     private final Boolean live = false;
     private final String transactionId = "e8eq11mi2ndmauvb51qsg8hccn";
@@ -35,5 +34,65 @@ public class TransactionFromLedgerFixture {
 
     public String build() throws JsonProcessingException {
         return Jackson.getObjectMapper().writeValueAsString(this);
+    }
+
+    public String getTransactionId() {
+        return transactionId;
+    }
+
+    public int getGatewayAccountId() {
+        return gatewayAccountId;
+    }
+
+    public int getAmount() {
+        return amount;
+    }
+
+    public TransactionState getState() {
+        return state;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public String getReference() {
+        return reference;
+    }
+
+    public String getLanguage() {
+        return language;
+    }
+
+    public String getReturnUrl() {
+        return returnUrl;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public String getPaymentProvider() {
+        return paymentProvider;
+    }
+
+    public String getCredentialExternalId() {
+        return credentialExternalId;
+    }
+
+    public String getCreatedDate() {
+        return createdDate;
+    }
+
+    public Boolean getDelayedCapture() {
+        return delayedCapture;
+    }
+
+    public Boolean getMoto() {
+        return moto;
+    }
+
+    public Boolean getLive() {
+        return live;
     }
 }

--- a/src/test/java/uk/gov/pay/webhooks/util/DatabaseTestHelper.java
+++ b/src/test/java/uk/gov/pay/webhooks/util/DatabaseTestHelper.java
@@ -14,6 +14,10 @@ public class DatabaseTestHelper {
         return new DatabaseTestHelper(jdbi);
     }
     
+    public void addWebhookWithSubscription(String webhookExternalId, String serviceExternalId, String callbackUrl) {
+        jdbi.withHandle(h -> h.execute("INSERT INTO webhooks VALUES (1, '2022-01-01', '%s', 'signing-key', '%s', false, '%s', 'description', 'ACTIVE')".formatted(webhookExternalId, serviceExternalId, callbackUrl)));
+        jdbi.withHandle(h -> h.execute("INSERT INTO webhook_subscriptions VALUES (1, (SELECT id FROM event_types WHERE name = 'card_payment_succeeded'))"));
+    }
 
     public void truncateAllData() {
         jdbi.withHandle(h -> h.createScript(


### PR DESCRIPTION
Add happy path coverage for a webhook message being emitted given an
event polled from the event stream.

This PR adds wiremock for stubbing calls to external services (Ledger
and the dependant webhook callback URL).

This test covers the core components running on the webhooks service:
- an event is polled from SQS
- a webhook message is recorded for delivery
  - transaction details for the webhook body are fetched from ledger
- a delivery attempt is made to the webhooks callback url for the
  webhook message