### PR TITLE
BAU Fix sequential SQS integration tests

### DIFF
--- a/src/test/resources/config/test-config.yaml
+++ b/src/test/resources/config/test-config.yaml
@@ -53,7 +53,7 @@ sqsConfig:
   secretKey: ${AWS_SECRET_KEY:-x}
   accessKey: ${AWS_ACCESS_KEY:-x}
   eventQueueUrl: ${AWS_SQS_PAYMENT_EVENT_QUEUE_URL}
-  messageMaximumWaitTimeInSeconds: ${AWS_SQS_MESSAGE_MAXIMUM_WAIT_TIME_IN_SECONDS:-20}
+  messageMaximumWaitTimeInSeconds: ${AWS_SQS_MESSAGE_MAXIMUM_WAIT_TIME_IN_SECONDS:-1}
   messageMaximumBatchSize: ${AWS_SQS_MESSAGE_MAXIMUM_BATCH_SIZE:-10}
 
 queueMessageReceiverConfig:


### PR DESCRIPTION
Integration tests that verify behaviour with SQS can [now fail](https://github.com/alphagov/pay-webhooks/actions/runs/4416797500). This especially happens where a test is [asserting that messages do or don't exist on a queue](https://github.com/alphagov/pay-webhooks/blob/2afe249fa1eff482466dd7d8f5f7e211783888fd/src/test/java/uk/gov/pay/webhooks/queue/EventQueueIT.java#L86).

Set the maximum timeout for fetching a batch of messages on tests to 1 second. 

The SQS client works by long polling the server and holding the HTTP connection open for a configured amount of time, if any messages become available within that timeframe the connection will be responded to and closed. By asking for a connection open for 20 seconds, the connection will continue to be fulfilled with valid messages that are added by other tests (even though the previous test has been appropriately shut down and the client is no longer asking for messages).

Set this configuration to 1 second, any tests that have background jobs enabled will poll more frequently but this should have a negligible impact on the test runtime.