### PR TITLE
PP-10834 Remove total from webhook messages pagination

### DIFF
--- a/openapi/webhooks_spec.yaml
+++ b/openapi/webhooks_spec.yaml
@@ -435,10 +435,6 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/WebhookMessageResponse'
-        total:
-          type: integer
-          format: int32
-          example: 120
     WebhookResponse:
       type: object
       properties:

--- a/src/main/java/uk/gov/pay/webhooks/message/resource/WebhookMessageSearchResponse.java
+++ b/src/main/java/uk/gov/pay/webhooks/message/resource/WebhookMessageSearchResponse.java
@@ -4,8 +4,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.util.List;
 
-public record WebhookMessageSearchResponse(@Schema(example = "120") int total,
-                                           @Schema(example = "100") int count,
+public record WebhookMessageSearchResponse(@Schema(example = "100") int count,
                                            @Schema(example = "1") int page,
                                            List<WebhookMessageResponse> results) {
 }

--- a/src/main/java/uk/gov/pay/webhooks/webhook/WebhookService.java
+++ b/src/main/java/uk/gov/pay/webhooks/webhook/WebhookService.java
@@ -82,8 +82,7 @@ public class WebhookService {
                 .stream()
                 .map(WebhookMessageResponse::from)
                 .toList();
-        var total = webhookMessageDao.count(webhook, status);
-        return new WebhookMessageSearchResponse(total.intValue(), messages.size(), page, messages);
+        return new WebhookMessageSearchResponse(messages.size(), page, messages);
     }
 
     public Optional<WebhookMessageResponse> getMessage(String webhookId, String messageId) {

--- a/src/test/java/uk/gov/pay/webhooks/webhook/resource/WebhookResourceIT.java
+++ b/src/test/java/uk/gov/pay/webhooks/webhook/resource/WebhookResourceIT.java
@@ -113,7 +113,6 @@ public class WebhookResourceIT {
                 .then()
                 .statusCode(Response.Status.OK.getStatusCode())
                 .body("count", is(10))
-                .body("total", is(12))
                 .body("page", is(1))
                 .body("results.size()", is(10));
 
@@ -124,7 +123,6 @@ public class WebhookResourceIT {
                 .then()
                 .statusCode(Response.Status.OK.getStatusCode())
                 .body("count", is(2))
-                .body("total", is(12))
                 .body("page", is(2))
                 .body("results.size()", is(2));
     }
@@ -149,7 +147,6 @@ public class WebhookResourceIT {
                 .then()
                 .statusCode(Response.Status.OK.getStatusCode())
                 .body("count", is(0))
-                .body("total", is(0))
                 .body("page", is(1))
                 .body("results.size()", is(0));
     }


### PR DESCRIPTION
The admin tool should no longer provide a "Last" link when showing webhook messags pagination. The last link is calculated by taking the total number of webhook messages and dividing by the current page size.

Remove the total calculation when webhook messages are listed, this should avoid any costly lookups if there is any significant scale on webhook messages in the given webhook message TTL.

Depends on https://github.com/alphagov/pay-selfservice/pull/3849