### PR TITLE
BAU: Pin Java base image to v17

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,6 +15,10 @@ updates:
   schedule:
     interval: daily
     time: "03:00"
+  ignore:
+  - dependency-name: "eclipse-temurin"
+    versions:
+    - "> 17"
   open-pull-requests-limit: 10
   labels:
   - dependencies
@@ -25,6 +29,10 @@ updates:
   schedule:
     interval: daily
     time: "03:00"
+  ignore:
+  - dependency-name: "eclipse-temurin"
+    versions:
+    - "> 17"
   open-pull-requests-limit: 10
   labels:
   - dependencies


### PR DESCRIPTION
Dependabot wants to bump to v20, we want to stay on the LTS v17.