### PR TITLE
PP-10537 Add override flag to get one webhook endpoint

### DIFF
--- a/openapi/webhooks_spec.yaml
+++ b/openapi/webhooks_spec.yaml
@@ -110,9 +110,14 @@ paths:
       - example: eo29upsdkjlk3jpwjj2dfn12
         in: query
         name: service_id
-        required: true
         schema:
           type: string
+      - description: "If false, the service_id must be specified"
+        example: false
+        in: query
+        name: override_account_or_service_id_restriction
+        schema:
+          type: boolean
       responses:
         "200":
           content:
@@ -224,7 +229,7 @@ paths:
       - Webhooks
   /v1/webhook/{webhookExternalId}/message/{webhookMessageExternalId}/attempt:
     get:
-      operationId: getWebhookMessageAttemps
+      operationId: getWebhookMessageAttempts
       parameters:
       - in: path
         name: webhookExternalId

--- a/src/main/java/uk/gov/pay/webhooks/webhook/WebhookService.java
+++ b/src/main/java/uk/gov/pay/webhooks/webhook/WebhookService.java
@@ -66,7 +66,11 @@ public class WebhookService {
 
     public Optional<WebhookEntity> findByExternalIdAndServiceId(String externalId, String serviceId) {
         return webhookDao.findByExternalIdAndServiceId(externalId, serviceId);
-    }    
+    }
+
+    public Optional<WebhookEntity> findByExternalId(String externalId) {
+        return webhookDao.findByExternalId(externalId);
+    }
 
     public List<WebhookEntity> list(boolean live, String serviceId) {
         return webhookDao.list(live, serviceId);

--- a/src/main/java/uk/gov/pay/webhooks/webhook/resource/WebhookResource.java
+++ b/src/main/java/uk/gov/pay/webhooks/webhook/resource/WebhookResource.java
@@ -82,9 +82,14 @@ public class WebhookResource {
     public WebhookResponse getWebhookByExternalId(@Parameter(example = "gh0d0923jpsjdf0923jojlsfgkw3seg")
                                                   @PathParam("webhookExternalId") @NotNull String externalId,
                                                   @Parameter(example = "eo29upsdkjlk3jpwjj2dfn12")
-                                                  @QueryParam("service_id") @NotNull String serviceId) {
-        return webhookService
-                .findByExternalIdAndServiceId(externalId, serviceId)
+                                                  @QueryParam("service_id") String serviceId,
+                                                  @Parameter(description = "If false, the service_id must be specified", example = "false")
+                                                  @QueryParam("override_account_or_service_id_restriction") Boolean overrideFilterRestrictions) {
+        if (!Boolean.TRUE.equals(overrideFilterRestrictions) && serviceId == null) {
+            throw new BadRequestException("[service_id] is required");
+        }
+        var webhook = Boolean.TRUE.equals(overrideFilterRestrictions) ? webhookService.findByExternalId(externalId) : webhookService.findByExternalIdAndServiceId(externalId, serviceId);
+        return webhook
                 .map(WebhookResponse::from)
                 .orElseThrow(NotFoundException::new);
     }
@@ -207,7 +212,7 @@ public class WebhookResource {
                     @ApiResponse(responseCode = "200", description = "OK", content = @Content(array = @ArraySchema(schema = @Schema(implementation = WebhookDeliveryQueueResponse.class))))
             }
     )
-    public List<WebhookDeliveryQueueResponse> getWebhookMessageAttemps(
+    public List<WebhookDeliveryQueueResponse> getWebhookMessageAttempts(
             @Schema(example = "gh0d0923jpsjdf0923jojlsfgkw3seg") @PathParam("webhookExternalId") String externalId,
             @Schema(example = "s0wjen129ejalk21nfjkdknf1jejklh") @PathParam("webhookMessageExternalId") String messageId
     ) {

--- a/src/test/java/uk/gov/pay/webhooks/webhook/resource/WebhookResourceTest.java
+++ b/src/test/java/uk/gov/pay/webhooks/webhook/resource/WebhookResourceTest.java
@@ -172,6 +172,19 @@ public class WebhookResourceTest {
     }
 
     @Test
+    public void getWebhookByIdWithoutServiceIdWithOverrideFlagWhenWebhookExists() {
+        when(webhookService.findByExternalId(eq(existingWebhookId))).thenReturn(Optional.of(webhook));
+
+        var response = resources
+                .target("/v1/webhook/%s".formatted(existingWebhookId))
+                .queryParam("override_account_or_service_id_restriction", "true")
+                .request()
+                .get();
+
+        assertThat(response.getStatus(), is(200)); 
+    }
+
+    @Test
     public void getWebhooksReturnsListOfWebhooks() throws JsonProcessingException {
         webhook.setServiceId("some-service-id");
         webhook.setLive(true);


### PR DESCRIPTION
Internal tools like Toolbox internally consume this resource and might be trying to access a webhook outside of an account/ service context. The standard pattern for this on other endpoints is to require the identifier to be provided (to avoid internal code loading data by mistake) but to allow internal tools to provice the `override_account_or_service_id_restriction` flag.

Check existing resource tests pass and add a scenario for providing the flag without providing a service identifier.