### PR TITLE
PP-10836 Add index on resource_external_id

### DIFF
--- a/src/main/resources/migrations/0013_alter_table_webhook_messages_add_index_on_resource_external_id.sql
+++ b/src/main/resources/migrations/0013_alter_table_webhook_messages_add_index_on_resource_external_id.sql
@@ -1,0 +1,6 @@
+--liquibase formatted sql
+
+--changeset uk.gov.pay:alter-table-webhook-messages-add-index-on-resource-external-id
+CREATE INDEX IF NOT EXISTS webhook_messages_resource_external_id_idx on webhook_messages(resource_external_id)
+
+--rollback DROP INDEX IF EXISTS webhook_messages_resource_external_id_idx


### PR DESCRIPTION
Add a btree index to the webhook_messages table on the resource_external_id column, so it is possible to search for messages by the resource (payment/refund etc) id.