### PR TITLE
PP-10835: Add "ON DELETE CASCADE" to webhook_messages

### DIFF
--- a/src/main/resources/migrations/0014_alter_table_webhook_delivery_queue_add_on_delete_cascade.sql
+++ b/src/main/resources/migrations/0014_alter_table_webhook_delivery_queue_add_on_delete_cascade.sql
@@ -1,0 +1,3 @@
+ALTER TABLE webhook_delivery_queue
+DROP CONSTRAINT fk_webhook_message_id,
+ADD CONSTRAINT fk_webhook_message_id FOREIGN KEY (webhook_message_id) REFERENCES webhook_messages (id) ON DELETE CASCADE;


### PR DESCRIPTION
In order to delete from webhook_messages, corresponding entries in webhook_delivery_queue need to be deleted. It would be more expedient to delete from webhook_delivery_queue by setting "ON DELETE CASCADE" to webhook_messages rather than deleting from both tables separately.