### PR TITLE
PP-10957 Log service ID

### DIFF
--- a/src/main/java/uk/gov/pay/webhooks/app/WebhooksKeys.java
+++ b/src/main/java/uk/gov/pay/webhooks/app/WebhooksKeys.java
@@ -7,7 +7,6 @@ public final class WebhooksKeys {
     public static final String WEBHOOK_EXTERNAL_ID = "webhook_external_id";
     public static final String WEBHOOK_CALLBACK_URL = "webhook_callback_url";
     public static final String WEBHOOK_MESSAGE_EXTERNAL_ID = "webhook_message_external_id";
-    public static final String WEBHOOK_MESSAGE_RESOURCE_EXTERNAL_ID = "resource_external_id";
     public static final String RESOURCE_IS_LIVE = "is_live";
     public static final String JOB_BATCH_ID = "job_id";
     public static final String ERROR = "error";


### PR DESCRIPTION
- Log the service_external_id as a structured argument for lines logged as part of the background job to send webhook messages.
- Use the shared RESOURCE_EXTERNAL_ID logging key from pay-java-commons
- Initialise the MDC in a single place for processing events from the SQS event subscriber queue.