### PR TITLE
PP-11019 Serealise gateway account id on webhooks

### DIFF
--- a/openapi/webhooks_spec.yaml
+++ b/openapi/webhooks_spec.yaml
@@ -344,6 +344,9 @@ components:
         description:
           type: string
           example: Webhook description
+        gateway_account_id:
+          type: string
+          example: "100"
         live:
           type: boolean
         service_id:
@@ -365,6 +368,7 @@ components:
             example: card_payment_started
       required:
       - callback_url
+      - gateway_account_id
       - live
       - service_id
     JsonNode:
@@ -479,6 +483,9 @@ components:
         external_id:
           type: string
           example: gh0d0923jpsjdf0923jojlsfgkw3seg
+        gateway_account_id:
+          type: string
+          example: "100"
         live:
           type: boolean
         service_id:

--- a/src/main/java/uk/gov/pay/webhooks/webhook/dao/entity/WebhookEntity.java
+++ b/src/main/java/uk/gov/pay/webhooks/webhook/dao/entity/WebhookEntity.java
@@ -94,6 +94,7 @@ public class WebhookEntity {
         entity.setDescription(createWebhookRequest.description());
         entity.setCallbackUrl(createWebhookRequest.callbackUrl());
         entity.setServiceId(createWebhookRequest.serviceId());
+        entity.setGatewayAccountId(createWebhookRequest.gatewayAccountId());
         entity.setLive(createWebhookRequest.live());
         entity.setCreatedDate(createdDate);
         entity.setStatus(WebhookStatus.ACTIVE);

--- a/src/main/java/uk/gov/pay/webhooks/webhook/dao/entity/WebhookEntity.java
+++ b/src/main/java/uk/gov/pay/webhooks/webhook/dao/entity/WebhookEntity.java
@@ -56,33 +56,36 @@ public class WebhookEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "webhooks_id_seq")
     private Long id;
-    
+
     @Column(name = "created_date")
     private OffsetDateTime createdDate;
-    
+
     @Column(name = "external_id")
     private String externalId;
-    
+
     @Column(name = "service_id")
     private String serviceId;
-    
+
+    @Column(name = "gateway_account_id")
+    private String gatewayAccountId;
+
     private boolean live;
-    
+
     @Column(name = "callback_url")
     private String callbackUrl;
-    
+
     private String description;
-    
+
     @OneToMany(cascade = CascadeType.ALL)
     @JoinTable(name="webhook_subscriptions",
             joinColumns=@JoinColumn(name="webhook_id", referencedColumnName="id"),
             inverseJoinColumns=@JoinColumn(name="event_type_id", referencedColumnName="id"))
     Set<EventTypeEntity> subscriptions = new HashSet<>();
 
-    
+
     @Enumerated(EnumType.STRING)
     private WebhookStatus status;
-    
+
     @Column(name = "signing_key")
     private String signingKey;
 
@@ -109,6 +112,10 @@ public class WebhookEntity {
 
     public String getServiceId() {
         return serviceId;
+    }
+
+    public String getGatewayAccountId() {
+        return gatewayAccountId;
     }
 
     public boolean isLive() {
@@ -145,6 +152,10 @@ public class WebhookEntity {
 
     public void setServiceId(String serviceId) {
         this.serviceId = serviceId;
+    }
+
+    public void setGatewayAccountId(String gatewayAccountId) {
+        this.gatewayAccountId = gatewayAccountId;
     }
 
     public void setLive(boolean live) {

--- a/src/main/java/uk/gov/pay/webhooks/webhook/resource/CreateWebhookRequest.java
+++ b/src/main/java/uk/gov/pay/webhooks/webhook/resource/CreateWebhookRequest.java
@@ -13,6 +13,8 @@ import java.util.List;
 public record CreateWebhookRequest(
         @Schema(example = "eo29upsdkjlk3jpwjj2dfn12")
         @JsonProperty("service_id") @NotEmpty @Size(max = 32) String serviceId,
+        @Schema(example = "100")
+        @JsonProperty("gateway_account_id") @NotEmpty String gatewayAccountId,
         @JsonProperty("live") @NotNull Boolean live,
         @Schema(example = "https://example.com")
         @JsonProperty("callback_url") @NotEmpty @Size(max = 2048) String callbackUrl,

--- a/src/main/java/uk/gov/pay/webhooks/webhook/resource/WebhookResponse.java
+++ b/src/main/java/uk/gov/pay/webhooks/webhook/resource/WebhookResponse.java
@@ -16,6 +16,8 @@ import java.util.List;
 public record WebhookResponse(
         @Schema(example = "eo29upsdkjlk3jpwjj2dfn12")
         @JsonProperty("service_id") String serviceId,
+        @Schema(example = "100")
+        @JsonProperty("gateway_account_id") String gatewayAccountId,
         @JsonProperty("live") Boolean live,
         @Schema(example = "https://example.com")
         @JsonProperty(FIELD_CALLBACK_URL) String callbackUrl,
@@ -39,6 +41,7 @@ public record WebhookResponse(
     public static WebhookResponse from(WebhookEntity webhookEntity) {
         return new WebhookResponse(
                 webhookEntity.getServiceId(),
+                webhookEntity.getGatewayAccountId(),
                 webhookEntity.isLive(),
                 webhookEntity.getCallbackUrl(),
                 webhookEntity.getDescription(),

--- a/src/test/java/uk/gov/pay/webhooks/webhook/WebhookServiceTest.java
+++ b/src/test/java/uk/gov/pay/webhooks/webhook/WebhookServiceTest.java
@@ -41,6 +41,7 @@ class WebhookServiceTest {
     private final WebhookMessageDeletionConfig webhookMessageDeletionConfig = mock(WebhookMessageDeletionConfig.class);
     private WebhookService webhookService;
     private final String serviceId = "test_service_id";
+    private final String gatewayAccountId = "100";
     private final String callbackUrl = "test_callback_url";
     private final boolean live = true;
     private final String description = "test_description";
@@ -77,6 +78,7 @@ class WebhookServiceTest {
         
         var createWebhookRequest = new CreateWebhookRequest(
                 serviceId,
+                gatewayAccountId,
                 live,
                 callbackUrl,
                 description,
@@ -95,6 +97,7 @@ class WebhookServiceTest {
                 is("card_payment_captured")
         );
         assertThat(captured.getServiceId(), is(serviceId));
+        assertThat(captured.getGatewayAccountId(), is(gatewayAccountId));
         assertThat(captured.getCallbackUrl(), is(callbackUrl));
         assertThat(captured.getDescription(), is(description));
         assertThat(captured.isLive(), is(live));
@@ -104,6 +107,7 @@ class WebhookServiceTest {
     public void shouldCallWebhookDaoWithOnlyRequiredAttributes() {
         var createWebhookRequest = new CreateWebhookRequest(
                 serviceId,
+                gatewayAccountId,
                 live,
                 callbackUrl,
                 null,
@@ -145,6 +149,7 @@ class WebhookServiceTest {
         
         var createWebhookRequest = new CreateWebhookRequest(
                 serviceId,
+                gatewayAccountId,
                 live,
                 callbackUrl,
                 null,

--- a/src/test/java/uk/gov/pay/webhooks/webhook/resource/WebhookListIT.java
+++ b/src/test/java/uk/gov/pay/webhooks/webhook/resource/WebhookListIT.java
@@ -36,6 +36,7 @@ public class WebhookListIT {
         var json = """
                 {
                   "service_id": "test_service_id",
+                  "gateway_account_id": "100",
                   "live": false,
                   "callback_url": "https://example.com",
                   "description": "description",
@@ -62,6 +63,7 @@ public class WebhookListIT {
             assertThat(listResponse.size(),is(equalTo(1)));
             var firstItem = (LinkedHashMap) listResponse.get(0);
             assertThat(firstItem.get("service_id"), is("test_service_id"));
+            assertThat(firstItem.get("gateway_account_id"), is("100"));
     }
 
     @Test
@@ -69,6 +71,7 @@ public class WebhookListIT {
         var serviceOne = """
                 {
                   "service_id": "service_one",
+                  "gateway_account_id": "100",
                   "live": false,
                   "callback_url": "https://example.com",
                   "description": "description",
@@ -79,6 +82,7 @@ public class WebhookListIT {
         var serviceTwo = """
                 {
                   "service_id": "service_two",
+                  "gateway_account_id": "200",
                   "live": false,
                   "callback_url": "https://example.com",
                   "description": "description",

--- a/src/test/java/uk/gov/pay/webhooks/webhook/resource/WebhookResourceIT.java
+++ b/src/test/java/uk/gov/pay/webhooks/webhook/resource/WebhookResourceIT.java
@@ -50,6 +50,7 @@ public class WebhookResourceIT {
                 .then()
                 .statusCode(Response.Status.OK.getStatusCode())
                 .body("service_id", is("test_service_id"))
+                .body("gateway_account_id", is("100"))
                 .body("live", is(false))
                 .body("callback_url", is("https://example.com"))
                 .body("description", is("description"))
@@ -67,6 +68,7 @@ public class WebhookResourceIT {
                 .then()
                 .statusCode(Response.Status.OK.getStatusCode())
                 .body("service_id", is("test_service_id"))
+                .body("gateway_account_id", is("100"))
                 .body("live", is(false))
                 .body("callback_url", is("https://example.com"))
                 .body("description", is("description"))
@@ -343,6 +345,7 @@ public class WebhookResourceIT {
        return """
                 {
                   "service_id": "test_service_id",
+                  "gateway_account_id": "100",
                   "live": %s,
                   "callback_url": "%s",
                   "description": "description",
@@ -353,7 +356,7 @@ public class WebhookResourceIT {
 
     private void setupWebhookWithMessages(String externalId, String messageExternalId) {
         app.getJdbi().withHandle(h -> h.execute(
-                "INSERT INTO webhooks VALUES (1, '2022-01-01', '%s', 'signing-key', 'service-id', true, 'http://callback-url.com', 'description', 'ACTIVE')".formatted(externalId)
+                "INSERT INTO webhooks VALUES (1, '2022-01-01', '%s', 'signing-key', 'service-id', true, 'http://callback-url.com', 'description', 'ACTIVE', '100')".formatted(externalId)
         ));
         app.getJdbi().withHandle(h -> h.execute("""
                             INSERT INTO webhook_messages VALUES

--- a/src/test/java/uk/gov/pay/webhooks/webhook/resource/WebhookResourceTest.java
+++ b/src/test/java/uk/gov/pay/webhooks/webhook/resource/WebhookResourceTest.java
@@ -60,6 +60,7 @@ public class WebhookResourceTest {
         var json = """
                 {
                     "service_id": "some-service-id",
+                    "gateway_account_id": "100",
                     "callback_url": "https://some-callback-url.com",
                     "live": false
                 }
@@ -90,6 +91,7 @@ public class WebhookResourceTest {
         var json = """
                 {
                     "service_id": "some-service-id-that-is-way-toooooo-loooooooong",
+                    "gateway_account_id": "100",
                     "callback_url": "https://some-callback-url.com",
                     "live": false
                 }
@@ -108,6 +110,7 @@ public class WebhookResourceTest {
         var json = """
                 {
                     "service_id": "some-service-id",
+                    "gateway_account_id": "100",
                     "callback_url": "https://some-callback-url.com",
                     "live": false,
                     "subscriptions": ["nonexistent_event_type_name"]
@@ -188,6 +191,7 @@ public class WebhookResourceTest {
     @Test
     public void getWebhooksReturnsListOfWebhooks() throws JsonProcessingException {
         webhook.setServiceId("some-service-id");
+        webhook.setGatewayAccountId("100");
         webhook.setLive(true);
         webhook.setDescription("fooBar");
         webhook.addSubscription(new EventTypeEntity(EventTypeName.CARD_PAYMENT_CAPTURED));
@@ -205,6 +209,7 @@ public class WebhookResourceTest {
         JsonNode expected = objectMapper.readTree("""
                 [{
                 	"service_id": "some-service-id",
+                	"gateway_account_id": "100",
                 	"live": true,
                 	"callback_url": null,
                 	"description": "fooBar",
@@ -214,6 +219,7 @@ public class WebhookResourceTest {
                 	"subscriptions": ["card_payment_captured"]
                 }, {
                 	"service_id": "some-service-id",
+                	"gateway_account_id": "100",
                 	"live": true,
                 	"callback_url": null,
                 	"description": "fooBar",

--- a/src/test/java/uk/gov/pay/webhooks/webhook/resource/WebhookSigningKeyIT.java
+++ b/src/test/java/uk/gov/pay/webhooks/webhook/resource/WebhookSigningKeyIT.java
@@ -36,6 +36,7 @@ public class WebhookSigningKeyIT {
         var json = """
                 {
                   "service_id": "test_service_id",
+                  "gateway_account_id": "100",
                   "live": false,
                   "callback_url": "https://example.com",
                   "description": "description",

--- a/src/test/java/uk/gov/pay/webhooks/webhook/resource/WebhookUpdateIT.java
+++ b/src/test/java/uk/gov/pay/webhooks/webhook/resource/WebhookUpdateIT.java
@@ -35,6 +35,7 @@ public class WebhookUpdateIT {
         var json = """
                 {
                   "service_id": "test_service_id",
+                  "gateway_account_id": "100",
                   "live": false,
                   "callback_url": "https://example.com",
                   "description": "original description",
@@ -89,6 +90,7 @@ public class WebhookUpdateIT {
         var json = """
                 {
                   "service_id": "test_service_id",
+                  "gateway_account_id": "100",
                   "live": false,
                   "callback_url": "https://example.com",
                   "description": "original description",
@@ -128,6 +130,7 @@ public class WebhookUpdateIT {
         var json = """
                 {
                   "service_id": "test_service_id",
+                  "gateway_account_id": "100",
                   "live": false,
                   "callback_url": "https://example.com",
                   "description": "original description",
@@ -168,6 +171,7 @@ public class WebhookUpdateIT {
         var json = """
                 {
                   "service_id": "test_service_id",
+                  "gateway_account_id": "100",
                   "live": true,
                   "callback_url": "https://gov.uk",
                   "description": "original description",


### PR DESCRIPTION
Depends on https://github.com/alphagov/pay-webhooks/pull/812

Add gateway account id to the webhooks entity to reflect the column
added to the database table.

Include on the resource model and require when creating a new webhook.

This field will be used to lookup webhooks and webhook data (message,
attempts, etc.) as a separate PR to allow the data to be appropriately
backfilled in environments before being relied on.