### PR TITLE
PP-11027 Lookup relevant webhook subscriptions by gateway account ID

### DIFF
--- a/src/main/java/uk/gov/pay/webhooks/message/WebhookMessageService.java
+++ b/src/main/java/uk/gov/pay/webhooks/message/WebhookMessageService.java
@@ -63,8 +63,8 @@ public class WebhookMessageService {
     }
     
     public void handleInternalEvent(InternalEvent event) throws IOException, InterruptedException {
-        if (event.live() == null || event.serviceId() == null) {
-            LOGGER.info("Ignoring event without `service_id` or `live` properties");
+        if (event.live() == null || event.serviceId() == null || event.gatewayAccountId() == null) {
+            LOGGER.info("Ignoring event without `service_id`, `live` or `gateway_account_id` properties");
             return;
         }
 

--- a/src/main/java/uk/gov/pay/webhooks/queue/EventMessage.java
+++ b/src/main/java/uk/gov/pay/webhooks/queue/EventMessage.java
@@ -12,6 +12,7 @@ public record EventMessage(EventMessageDto eventMessageDto, QueueMessage queueMe
         return new InternalEvent(
                 eventMessageDto.eventType(),
                 eventMessageDto.serviceId(),
+                eventMessageDto.gatewayAccountId(),
                 eventMessageDto.live(),
                 eventMessageDto.resourceExternalId(),
                 eventMessageDto.parentResourceExternalId(),

--- a/src/main/java/uk/gov/pay/webhooks/queue/EventMessageDto.java
+++ b/src/main/java/uk/gov/pay/webhooks/queue/EventMessageDto.java
@@ -13,6 +13,7 @@ import java.time.Instant;
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public record EventMessageDto(@JsonProperty("service_id") String serviceId,
+                              @JsonProperty("gateway_account_id") String gatewayAccountId,
                               @JsonProperty("live") Boolean live,
                               @JsonProperty("timestamp") @JsonDeserialize(using = InstantDeserializer.class) Instant timestamp,
                               @JsonProperty("resource_external_id") String resourceExternalId,

--- a/src/main/java/uk/gov/pay/webhooks/queue/InternalEvent.java
+++ b/src/main/java/uk/gov/pay/webhooks/queue/InternalEvent.java
@@ -8,6 +8,7 @@ import java.time.Instant;
 public record InternalEvent(
         String eventType,
         String serviceId,
+        String gatewayAccountId,
         Boolean live,
         String resourceExternalId,
         String parentResourceExternalId,

--- a/src/main/java/uk/gov/pay/webhooks/webhook/WebhookService.java
+++ b/src/main/java/uk/gov/pay/webhooks/webhook/WebhookService.java
@@ -84,7 +84,7 @@ public class WebhookService {
 
     public List<WebhookEntity> list(boolean live, String serviceId) {
         return webhookDao.list(live, serviceId);
-    }      
+    }
 
     public List<WebhookEntity> list(boolean live) {
         return webhookDao.list(live);
@@ -142,7 +142,7 @@ public class WebhookService {
     }
 
     public List<WebhookEntity> getWebhooksSubscribedToEvent(InternalEvent event) {
-        return list(event.live(), event.serviceId())
+        return webhookDao.listByGatewayAccountId(event.gatewayAccountId())
                 .stream()
                 .filter(webhook -> webhookHasSubscriptionForEvent(webhook, event))
                 .toList();

--- a/src/main/java/uk/gov/pay/webhooks/webhook/dao/WebhookDao.java
+++ b/src/main/java/uk/gov/pay/webhooks/webhook/dao/WebhookDao.java
@@ -44,6 +44,12 @@ public class WebhookDao extends AbstractDAO<WebhookEntity> {
         .getResultList();
     }
 
+    public List<WebhookEntity> listByGatewayAccountId(String gatewayAccountId) {
+        return namedTypedQuery(WebhookEntity.LIST_BY_GATEWAY_ACCOUNT_ID)
+                .setParameter("gatewayAccountId", gatewayAccountId)
+                .getResultList();
+    }
+
     public List<WebhookEntity> list(boolean live) {
         return  namedTypedQuery(WebhookEntity.LIST_BY_LIVE)
                 .setParameter("live", live)

--- a/src/main/java/uk/gov/pay/webhooks/webhook/dao/entity/WebhookEntity.java
+++ b/src/main/java/uk/gov/pay/webhooks/webhook/dao/entity/WebhookEntity.java
@@ -41,6 +41,11 @@ import java.util.Set;
 )
 
 @NamedQuery(
+        name = WebhookEntity.LIST_BY_GATEWAY_ACCOUNT_ID,
+        query = "select p from WebhookEntity p where gatewayAccountId = :gatewayAccountId order by created_date DESC"
+)
+
+@NamedQuery(
     name = WebhookEntity.LIST_BY_LIVE,
     query = "select p from WebhookEntity p where live = :live order by created_date DESC"
 )
@@ -51,6 +56,7 @@ public class WebhookEntity {
     public static final String GET_BY_EXTERNAL_ID_AND_SERVICE_ID = "Webhook.get_webhook_by_external_id_and_service_id";
     public static final String GET_BY_EXTERNAL_ID = "Webhook.get_webhook_by_external_id";
     public static final String LIST_BY_LIVE_AND_SERVICE_ID = "Webhook.list_webhooks_by_live_and_service_id";
+    public static final String LIST_BY_GATEWAY_ACCOUNT_ID = "Webhook.list_webhooks_by_gateway_account_id";
     public static final String LIST_BY_LIVE = "Webhook.list_webhooks_by_live";
 
     @Id

--- a/src/test/java/uk/gov/pay/webhooks/message/WebhookMessageServiceTest.java
+++ b/src/test/java/uk/gov/pay/webhooks/message/WebhookMessageServiceTest.java
@@ -45,8 +45,8 @@ class WebhookMessageServiceTest {
 
     @Test
     public void shouldIgnoreEventsWithoutRequiredProperties() throws IOException, InterruptedException {
-        var eventWithProperties = new InternalEvent("PAYMENT_CREATED", "service-id", true, "resource-external-id", null, Instant.now(), "payment");
-        var eventMissingProperties = new InternalEvent("PAYMENT_CREATED", null, null, "resource-external-id", null, Instant.now(), "payment");
+        var eventWithProperties = new InternalEvent("PAYMENT_CREATED", "service-id", "100", true, "resource-external-id", null, Instant.now(), "payment");
+        var eventMissingProperties = new InternalEvent("PAYMENT_CREATED", null, null, null, "resource-external-id", null, Instant.now(), "payment");
         when(webhookService.getWebhooksSubscribedToEvent(eventWithProperties)).thenReturn(List.of());
 
         webhookMessageService.handleInternalEvent(eventWithProperties);

--- a/src/test/java/uk/gov/pay/webhooks/queue/EventQueueIT.java
+++ b/src/test/java/uk/gov/pay/webhooks/queue/EventQueueIT.java
@@ -58,6 +58,7 @@ class EventQueueIT {
         var eventMessage = Map.of(
                 "sqs_message_id", "dc142884-1e4b-4e57-be93-111b692a4868",
                 "service_id", "some-service-id",
+                "gateway_account_id", "100",
                 "live", "false",
                 "resource_type", "payment",
                 "resource_external_id", "t8cj9v1lci7da7pbp99qg9olv3",
@@ -85,5 +86,6 @@ class EventQueueIT {
         List<EventMessage> result = eventQueue.retrieveEvents();
         assertFalse(result.isEmpty());
         assertThat(result.get(0).eventMessageDto().resourceType(), is("payment"));
+        assertThat(result.get(0).eventMessageDto().gatewayAccountId(), is("100"));
     }
 }

--- a/src/test/java/uk/gov/pay/webhooks/util/DatabaseTestHelper.java
+++ b/src/test/java/uk/gov/pay/webhooks/util/DatabaseTestHelper.java
@@ -14,8 +14,8 @@ public class DatabaseTestHelper {
         return new DatabaseTestHelper(jdbi);
     }
     
-    public void addWebhookWithSubscription(String webhookExternalId, String serviceExternalId, String callbackUrl) {
-        jdbi.withHandle(h -> h.execute("INSERT INTO webhooks VALUES (1, '2022-01-01', '%s', 'signing-key', '%s', false, '%s', 'description', 'ACTIVE')".formatted(webhookExternalId, serviceExternalId, callbackUrl)));
+    public void addWebhookWithSubscription(String webhookExternalId, String serviceExternalId, String callbackUrl, String gatewayAccountId) {
+        jdbi.withHandle(h -> h.execute("INSERT INTO webhooks VALUES (1, '2022-01-01', '%s', 'signing-key', '%s', false, '%s', 'description', 'ACTIVE', '%s')".formatted(webhookExternalId, serviceExternalId, callbackUrl, gatewayAccountId)));
         jdbi.withHandle(h -> h.execute("INSERT INTO webhook_subscriptions VALUES (1, (SELECT id FROM event_types WHERE name = 'card_payment_succeeded'))"));
     }
 

--- a/src/test/java/uk/gov/pay/webhooks/webhook/WebhookServiceTest.java
+++ b/src/test/java/uk/gov/pay/webhooks/webhook/WebhookServiceTest.java
@@ -126,14 +126,14 @@ class WebhookServiceTest {
     }
     
     @Test
-    public void shouldReturnSubscribedWebhooksForGivenEventTypeServiceIdLivenessTuple() {
+    public void shouldReturnSubscribedWebhooksForGivenEventType() {
         var capturedEventType = new EventTypeEntity(EventTypeName.CARD_PAYMENT_CAPTURED);
         var webhookSubscribedToCaptureEvent = new WebhookEntity();
         webhookSubscribedToCaptureEvent.addSubscription(capturedEventType);
         var webhookNotSubscribedToAnyEvents = new WebhookEntity();
-        when(webhookDao.list(live, serviceId))
+        when(webhookDao.listByGatewayAccountId(gatewayAccountId))
                 .thenReturn(List.of(webhookSubscribedToCaptureEvent, webhookNotSubscribedToAnyEvents));
-        var event = new InternalEvent("CAPTURE_CONFIRMED", serviceId, live, "resource_id", null, instantSource.instant(), "PAYMENT");
+        var event = new InternalEvent("CAPTURE_CONFIRMED", serviceId, gatewayAccountId, live, "resource_id", null, instantSource.instant(), "PAYMENT");
         
         var subscribedWebhooks = webhookService.getWebhooksSubscribedToEvent(event);
         

--- a/src/test/java/uk/gov/pay/webhooks/webhook/dao/WebhookDaoTest.java
+++ b/src/test/java/uk/gov/pay/webhooks/webhook/dao/WebhookDaoTest.java
@@ -187,5 +187,32 @@ public class WebhookDaoTest {
         response.forEach(webhookEntity -> 
                 assertThat(webhookEntity.isLive(), equalTo(false)));
     }
+
+    @Test
+    void listWebhooksByGatewayAccountId() {
+        database.inTransaction(() -> {
+            var serviceOneFirst = new WebhookEntity();
+            serviceOneFirst.setLive(true);
+            serviceOneFirst.setServiceId("service-id-1");
+            serviceOneFirst.setGatewayAccountId("100");
+            webhookDao.create(serviceOneFirst);
+
+            var serviceOneSecond = new WebhookEntity();
+            serviceOneSecond.setLive(true);
+            serviceOneSecond.setServiceId("service-id-1");
+            serviceOneSecond.setGatewayAccountId("100");
+            webhookDao.create(serviceOneSecond);
+
+            WebhookEntity serviceTwoFirst = new WebhookEntity();
+            serviceTwoFirst.setLive(true);
+            serviceTwoFirst.setServiceId("service-id-2");
+            serviceTwoFirst.setGatewayAccountId("200");
+            webhookDao.create(serviceTwoFirst);
+        });
+        var response = webhookDao.listByGatewayAccountId("100");
+        assertThat(response, iterableWithSize(2));
+        response.forEach(webhookEntity ->
+                assertThat(webhookEntity.getGatewayAccountId(), equalTo("100")));
         
+    }
 }


### PR DESCRIPTION
Gateway account IDs were added in https://github.com/alphagov/pay-webhooks/pull/812 and https://github.com/alphagov/pay-webhooks/pull/813.

They should also [be available on the payment events schema](https://github.com/alphagov/pay-connector/pull/4525).

Until the data model across Pay shifts to being service-centric, use the gateway account ID to determine if there are any webhooks subscribed for a given event (this will allow multiple test card payment accounts to be associated with a single service without causing any issues in the webhooks mechanism or reporting on webhooks data, for the time being).