### PR TITLE
PP-11027 Require and use gateway account ID to fetch webhooks data

### DIFF
--- a/openapi/webhooks_spec.yaml
+++ b/openapi/webhooks_spec.yaml
@@ -54,6 +54,13 @@ paths:
         name: service_id
         schema:
           type: string
+      - description: Gateway account ID. Required when override_service_id_restriction
+          is not `true`
+        example: 100
+        in: query
+        name: gateway_account_id
+        schema:
+          type: string
       - description: "Set to true to list all webhooks. if 'true', service_id is not\
           \ permitted"
         example: true
@@ -125,7 +132,12 @@ paths:
         name: service_id
         schema:
           type: string
-      - description: "If false, the service_id must be specified"
+      - example: 100
+        in: query
+        name: gateway_account_id
+        schema:
+          type: string
+      - description: "If false, the service_id and gateway_account_id must be specified"
         example: false
         in: query
         name: override_account_or_service_id_restriction
@@ -140,7 +152,8 @@ paths:
           description: OK
         "404":
           description: Not found
-      summary: Get webhook by external ID and service ID (query param)
+      summary: "Get webhook by external ID, service ID and gateway account ID (query\
+        \ param)"
       tags:
       - Webhooks
     patch:
@@ -156,6 +169,12 @@ paths:
       - example: eo29upsdkjlk3jpwjj2dfn12
         in: query
         name: service_id
+        required: true
+        schema:
+          type: string
+      - example: 100
+        in: query
+        name: gateway_account_id
         required: true
         schema:
           type: string
@@ -286,6 +305,12 @@ paths:
         required: true
         schema:
           type: string
+      - example: 100
+        in: query
+        name: gateway_account_id
+        required: true
+        schema:
+          type: string
       - example: eo29upsdkjlk3jpwjj2dfn12
         in: query
         name: service_id
@@ -310,6 +335,12 @@ paths:
       - example: gh0d0923jpsjdf0923jojlsfgkw3seg
         in: path
         name: webhookExternalId
+        required: true
+        schema:
+          type: string
+      - example: 100
+        in: query
+        name: gateway_account_id
         required: true
         schema:
           type: string

--- a/src/main/java/uk/gov/pay/webhooks/webhook/WebhookService.java
+++ b/src/main/java/uk/gov/pay/webhooks/webhook/WebhookService.java
@@ -77,6 +77,10 @@ public class WebhookService {
     public Optional<WebhookEntity> findByExternalIdAndServiceId(String externalId, String serviceId) {
         return webhookDao.findByExternalIdAndServiceId(externalId, serviceId);
     }
+    
+    public Optional<WebhookEntity> findByExternalIdAndGatewayAccountId(String externalId, String gatewayAccountId) {
+        return webhookDao.findByExternalIdAndGatewayAccountId(externalId, gatewayAccountId);
+    }
 
     public Optional<WebhookEntity> findByExternalId(String externalId) {
         return webhookDao.findByExternalId(externalId);
@@ -88,6 +92,10 @@ public class WebhookService {
 
     public List<WebhookEntity> list(boolean live) {
         return webhookDao.list(live);
+    }
+    
+    public List<WebhookEntity> listByGatewayAccountId(String gatewayAccountId) {
+        return webhookDao.listByGatewayAccountId(gatewayAccountId);
     }
 
     public WebhookMessageSearchResponse listMessages(String webhookId, WebhookMessageSearchParams queryParams) {
@@ -112,8 +120,8 @@ public class WebhookService {
                 .toList();
     }
 
-    public Optional<WebhookEntity> regenerateSigningKey(String externalId, String serviceId) {
-         return webhookDao.findByExternalIdAndServiceId(externalId, serviceId).map(webhookEntity -> { 
+    public Optional<WebhookEntity> regenerateSigningKey(String externalId, String gatewayAccountId) {
+         return webhookDao.findByExternalIdAndGatewayAccountId(externalId, gatewayAccountId).map(webhookEntity -> { 
           webhookEntity.setSigningKey(idGenerator.newWebhookSigningKey(webhookEntity.isLive()));
              return webhookEntity;
          });

--- a/src/main/java/uk/gov/pay/webhooks/webhook/dao/WebhookDao.java
+++ b/src/main/java/uk/gov/pay/webhooks/webhook/dao/WebhookDao.java
@@ -29,6 +29,15 @@ public class WebhookDao extends AbstractDAO<WebhookEntity> {
                     .findFirst();
     }
 
+    public Optional<WebhookEntity> findByExternalIdAndGatewayAccountId(String webhookExternalId, String gatewayAccountId) {
+        return namedTypedQuery(WebhookEntity.GET_BY_EXTERNAL_ID_AND_GATEWAY_ACCOUNT_ID)
+                .setParameter("externalId", webhookExternalId)
+                .setParameter("gatewayAccountId", gatewayAccountId)
+                .getResultList()
+                .stream()
+                .findFirst();
+    }
+
     public Optional<WebhookEntity> findByExternalId(String webhookExternalId) {
         return namedTypedQuery(WebhookEntity.GET_BY_EXTERNAL_ID)
                 .setParameter("externalId", webhookExternalId)

--- a/src/main/java/uk/gov/pay/webhooks/webhook/dao/entity/WebhookEntity.java
+++ b/src/main/java/uk/gov/pay/webhooks/webhook/dao/entity/WebhookEntity.java
@@ -31,6 +31,11 @@ import java.util.Set;
 )
 
 @NamedQuery(
+        name = WebhookEntity.GET_BY_EXTERNAL_ID_AND_GATEWAY_ACCOUNT_ID,
+        query = "select p from WebhookEntity p where externalId = :externalId and gatewayAccountId = :gatewayAccountId"
+)
+
+@NamedQuery(
         name = WebhookEntity.GET_BY_EXTERNAL_ID,
         query = "select p from WebhookEntity p where externalId = :externalId"
 )
@@ -54,6 +59,7 @@ import java.util.Set;
 @Table(name = "webhooks")
 public class WebhookEntity {
     public static final String GET_BY_EXTERNAL_ID_AND_SERVICE_ID = "Webhook.get_webhook_by_external_id_and_service_id";
+    public static final String GET_BY_EXTERNAL_ID_AND_GATEWAY_ACCOUNT_ID = "Webhook.get_webhook_by_external_id_and_gateway_account_id";
     public static final String GET_BY_EXTERNAL_ID = "Webhook.get_webhook_by_external_id";
     public static final String LIST_BY_LIVE_AND_SERVICE_ID = "Webhook.list_webhooks_by_live_and_service_id";
     public static final String LIST_BY_GATEWAY_ACCOUNT_ID = "Webhook.list_webhooks_by_gateway_account_id";

--- a/src/main/java/uk/gov/pay/webhooks/webhook/resource/WebhookResource.java
+++ b/src/main/java/uk/gov/pay/webhooks/webhook/resource/WebhookResource.java
@@ -100,6 +100,7 @@ public class WebhookResource {
                                                   @PathParam("webhookExternalId") @NotNull String externalId,
                                                   @Parameter(example = "eo29upsdkjlk3jpwjj2dfn12")
                                                   @QueryParam("service_id") String serviceId,
+                                                  @Parameter(example = "100")
                                                   @QueryParam("gateway_account_id") String gatewayAccountId,
                                                   @Parameter(description = "If false, the service_id and gateway_account_id must be specified", example = "false")
                                                   @QueryParam("override_account_or_service_id_restriction") Boolean overrideFilterRestrictions) {

--- a/src/main/java/uk/gov/pay/webhooks/webhook/resource/WebhookResource.java
+++ b/src/main/java/uk/gov/pay/webhooks/webhook/resource/WebhookResource.java
@@ -90,7 +90,7 @@ public class WebhookResource {
     @GET
     @Path("/{webhookExternalId}")
     @Operation(
-            summary = "Get webhook by external ID and service ID (query param)",
+            summary = "Get webhook by external ID, service ID and gateway account ID (query param)",
             responses = {
                     @ApiResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(implementation = WebhookResponse.class))),
                     @ApiResponse(responseCode = "404", description = "Not found")
@@ -100,12 +100,13 @@ public class WebhookResource {
                                                   @PathParam("webhookExternalId") @NotNull String externalId,
                                                   @Parameter(example = "eo29upsdkjlk3jpwjj2dfn12")
                                                   @QueryParam("service_id") String serviceId,
-                                                  @Parameter(description = "If false, the service_id must be specified", example = "false")
+                                                  @QueryParam("gateway_account_id") String gatewayAccountId,
+                                                  @Parameter(description = "If false, the service_id and gateway_account_id must be specified", example = "false")
                                                   @QueryParam("override_account_or_service_id_restriction") Boolean overrideFilterRestrictions) {
-        if (!Boolean.TRUE.equals(overrideFilterRestrictions) && serviceId == null) {
-            throw new BadRequestException("[service_id] is required");
+        if (!Boolean.TRUE.equals(overrideFilterRestrictions) && (serviceId == null || gatewayAccountId == null)) {
+            throw new BadRequestException("[service_id, gateway_account_id] is required");
         }
-        var webhook = Boolean.TRUE.equals(overrideFilterRestrictions) ? webhookService.findByExternalId(externalId) : webhookService.findByExternalIdAndServiceId(externalId, serviceId);
+        var webhook = Boolean.TRUE.equals(overrideFilterRestrictions) ? webhookService.findByExternalId(externalId) : webhookService.findByExternalIdAndGatewayAccountId(externalId, gatewayAccountId);
         return webhook
                 .map(WebhookResponse::from)
                 .orElseThrow(NotFoundException::new);
@@ -124,10 +125,12 @@ public class WebhookResource {
     )
     public SigningKeyResponse getSigningKeyByExternalId(@Parameter(example = "gh0d0923jpsjdf0923jojlsfgkw3seg")
                                                         @PathParam("webhookExternalId") @NotNull String externalId,
+                                                        @Parameter(example = "100")
+                                                        @QueryParam("gateway_account_id") @NotNull String gatewayAccountId,
                                                         @Parameter(example = "eo29upsdkjlk3jpwjj2dfn12")
                                                         @QueryParam("service_id") @NotNull String serviceId) {
         return webhookService
-                .findByExternalIdAndServiceId(externalId, serviceId)
+                .findByExternalIdAndGatewayAccountId(externalId, gatewayAccountId)
                 .map(WebhookEntity::getSigningKey)
                 .map(SigningKeyResponse::new)
                 .orElseThrow(NotFoundException::new);
@@ -145,9 +148,11 @@ public class WebhookResource {
     )
     public SigningKeyResponse regenerateSigningKey(@Parameter(example = "gh0d0923jpsjdf0923jojlsfgkw3seg")
                                                    @PathParam("webhookExternalId") @NotNull String externalId,
+                                                   @Parameter(example = "100")
+                                                   @QueryParam("gateway_account_id") @NotNull String gatewayAccountId,
                                                    @Parameter(example = "eo29upsdkjlk3jpwjj2dfn12")
                                                    @QueryParam("service_id") @NotNull String serviceId) {
-        return webhookService.regenerateSigningKey(externalId, serviceId)
+        return webhookService.regenerateSigningKey(externalId, gatewayAccountId)
                 .map(WebhookEntity::getSigningKey)
                 .map(SigningKeyResponse::new)
                 .orElseThrow(NotFoundException::new);
@@ -166,17 +171,19 @@ public class WebhookResource {
                                              @NotNull @QueryParam("live") Boolean live,
                                              @Parameter(example = "eo29upsdkjlk3jpwjj2dfn12", description = "Service external ID. Required when override_service_id_restriction is not `true`")
                                              @QueryParam("service_id") String service_id,
+                                             @Parameter(example = "100", description = "Gateway account ID. Required when override_service_id_restriction is not `true`")
+                                             @QueryParam("gateway_account_id") String gatewayAccountId,
                                              @Parameter(example = "true", description = "Set to true to list all webhooks. if 'true', service_id is not permitted")
                                              @QueryParam("override_service_id_restriction") boolean overrideServiceIdRestriction) {
-        if (service_id != null && overrideServiceIdRestriction) {
-            throw new BadRequestException("service_id not permitted when using override_service_id_restriction");
+        if ((service_id != null || gatewayAccountId != null) && overrideServiceIdRestriction) {
+            throw new BadRequestException("[service_id, gateway_account_id] not permitted when using override_service_id_restriction");
         }
 
-        if (service_id == null && !overrideServiceIdRestriction) {
-            throw new BadRequestException("either service_id or override_service_id_restriction query parameter must be provided");
+        if ((service_id == null || gatewayAccountId == null) && !overrideServiceIdRestriction) {
+            throw new BadRequestException("[service_id, gateway_account_id] or override_service_id_restriction query parameter must be provided");
         }
 
-        List<WebhookEntity> results = overrideServiceIdRestriction ? webhookService.list(live) : webhookService.list(live, service_id);
+        List<WebhookEntity> results = overrideServiceIdRestriction ? webhookService.list(live) : webhookService.listByGatewayAccountId(gatewayAccountId);
 
         return results
                 .stream()
@@ -246,13 +253,14 @@ public class WebhookResource {
     )
     public WebhookResponse updateWebhook(@Parameter(example = "gh0d0923jpsjdf0923jojlsfgkw3seg") @PathParam("webhookExternalId") @NotNull String externalId,
                                          @Parameter(example = "eo29upsdkjlk3jpwjj2dfn12") @QueryParam("service_id") @NotNull String serviceId,
+                                         @Parameter(example = "100") @QueryParam("gateway_account_id") @NotNull String gatewayAccountId,
                                          @ArraySchema(schema = @Schema(example = "{" +
                                                  "                            \"path\": \"description\"," +
                                                  "                            \"op\": \"replace\"," +
                                                  "                            \"value\": \"new description\"" +
                                                  "                        }"))
                                                  JsonNode payload) {
-        var webhook = webhookService.findByExternalIdAndServiceId(externalId, serviceId).orElseThrow(NotFoundException::new);
+        var webhook = webhookService.findByExternalIdAndGatewayAccountId(externalId, gatewayAccountId).orElseThrow(NotFoundException::new);
         webhookRequestValidator.validate(payload, webhook.isLive());
         List<JsonPatchRequest> patchRequests = StreamSupport.stream(payload.spliterator(), false)
                 .map(JsonPatchRequest::from)

--- a/src/test/java/uk/gov/pay/webhooks/webhook/dao/WebhookDaoTest.java
+++ b/src/test/java/uk/gov/pay/webhooks/webhook/dao/WebhookDaoTest.java
@@ -10,6 +10,7 @@ import uk.gov.pay.webhooks.eventtype.dao.EventTypeEntity;
 import uk.gov.pay.webhooks.webhook.dao.entity.WebhookEntity;
 
 import java.time.Instant;
+import java.util.Optional;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.any;
@@ -52,6 +53,21 @@ public class WebhookDaoTest {
     @Test
     public void returnsEmptyListIfNoWebhooksFound() {
         assertThat(webhookDao.list(true, "not-real-service-id"), iterableWithSize(0));
+    }
+
+    @Test
+    void getsWebhookByExternalIDAndGatewayAccountID() {
+        var webhookEntity = new WebhookEntity();
+        webhookEntity.setExternalId("external-id");
+        webhookEntity.setLive(true);
+        webhookEntity.setServiceId("real-service-id");
+        webhookEntity.setGatewayAccountId("100");
+        database.inTransaction(() -> {
+            webhookDao.create(webhookEntity);
+        });
+
+        assertThat(webhookDao.findByExternalIdAndGatewayAccountId("external-id", "100"), is(Optional.of(webhookEntity)));
+        assertThat(webhookDao.findByExternalIdAndGatewayAccountId("external-id", "200"), is(Optional.empty()));
     }
     
     @Test

--- a/src/test/java/uk/gov/pay/webhooks/webhook/resource/WebhookListIT.java
+++ b/src/test/java/uk/gov/pay/webhooks/webhook/resource/WebhookListIT.java
@@ -52,12 +52,9 @@ public class WebhookListIT {
                 .extract()
                 .as(Map.class);
 
-        var externalId = response.get("external_id");
-        var serviceId = response.get("service_id");
-
         var listResponse = given().port(port)
                 .contentType(JSON)
-                .get("/v1/webhook?service_id=test_service_id&live=false".formatted(externalId, serviceId))
+                .get("/v1/webhook?service_id=test_service_id&live=false&gateway_account_id=100")
                 .then()
                 .extract().as(List.class);
             assertThat(listResponse.size(),is(equalTo(1)));

--- a/src/test/java/uk/gov/pay/webhooks/webhook/resource/WebhookResourceIT.java
+++ b/src/test/java/uk/gov/pay/webhooks/webhook/resource/WebhookResourceIT.java
@@ -61,10 +61,11 @@ public class WebhookResourceIT {
 
         var externalId = response.get("external_id");
         var serviceId = response.get("service_id");
+        var gatewayAccountId = response.get("gateway_account_id");
 
         given().port(port)
                 .contentType(JSON)
-                .get("/v1/webhook/%s?service_id=%s".formatted(externalId, serviceId))
+                .get("/v1/webhook/%s?service_id=%s&gateway_account_id=%s".formatted(externalId, serviceId, gatewayAccountId))
                 .then()
                 .statusCode(Response.Status.OK.getStatusCode())
                 .body("service_id", is("test_service_id"))
@@ -231,7 +232,7 @@ public class WebhookResourceIT {
     public void notFoundShouldReturn404() {
         given().port(port)
                 .contentType(JSON)
-                .get("/v1/webhook/not-real-external-id?service_id=not-real-service-id")
+                .get("/v1/webhook/not-real-external-id?service_id=not-real-service-id&gateway_account_id=100")
                 .then()
                 .statusCode(Response.Status.NOT_FOUND.getStatusCode());
     }

--- a/src/test/java/uk/gov/pay/webhooks/webhook/resource/WebhookResourceTest.java
+++ b/src/test/java/uk/gov/pay/webhooks/webhook/resource/WebhookResourceTest.java
@@ -145,7 +145,7 @@ public class WebhookResourceTest {
 
         var response = resources
                 .target("/v1/webhook/%s".formatted(existingWebhookId))
-                .queryParam("service_id", "aint-no-serviceid")
+                .queryParam("service_id", "some-service-id")
                 .queryParam("gateway_account_id", "200")
                 .request()
                 .get();
@@ -154,7 +154,7 @@ public class WebhookResourceTest {
     }
 
     @Test
-    public void getWebhookByIdWhenDoesNotExist404() {
+    public void getWebhookByIdWhenDoesNotExistForServiceOrGatewayAccountID404() {
         when(webhookService.findByExternalIdAndGatewayAccountId(any(String.class), any(String.class))).thenReturn(Optional.empty());
 
         var response = resources
@@ -291,6 +291,33 @@ public class WebhookResourceTest {
         });
         assertThat(response.getStatus(), is(400));
         assertThat(responseBody.get("message"), is("[service_id, gateway_account_id] or override_service_id_restriction query parameter must be provided"));
+    }
+
+    @Test
+    public void getWebhooksRequestWithLiveAndServiceWithoutGatewayAccountIdShould400() throws JsonProcessingException {
+        var response = resources
+                .target("/v1/webhook")
+                .queryParam("live", true)
+                .queryParam("service_id", existingServiceId)
+                .request()
+                .get();
+        Map<String, String> responseBody = objectMapper.readValue(response.readEntity(String.class), new TypeReference<>() {
+        });
+        assertThat(response.getStatus(), is(400));
+        assertThat(responseBody.get("message"), is("[service_id, gateway_account_id] or override_service_id_restriction query parameter must be provided"));
+    }
+
+    @Test
+    public void getWebhookRequestWithServiceWithoutGatewayAccountIdShould400() throws JsonProcessingException {
+        var response = resources
+                .target("/v1/webhook/a-webhook-id")
+                .queryParam("service_id", existingServiceId)
+                .request()
+                .get();
+        Map<String, String> responseBody = objectMapper.readValue(response.readEntity(String.class), new TypeReference<>() {
+        });
+        assertThat(response.getStatus(), is(400));
+        assertThat(responseBody.get("message"), is("[service_id, gateway_account_id] is required"));
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/webhooks/webhook/resource/WebhookSigningKeyIT.java
+++ b/src/test/java/uk/gov/pay/webhooks/webhook/resource/WebhookSigningKeyIT.java
@@ -54,10 +54,11 @@ public class WebhookSigningKeyIT {
 
         var externalId = response.get("external_id");
         var serviceId = response.get("service_id");
+        var gatewayAccountId = response.get("gateway_account_id");
         
         var signingKeyResponse = given().port(port)
                 .contentType(JSON)
-                .get("/v1/webhook/%s/signing-key?service_id=%s".formatted(externalId, serviceId))
+                .get("/v1/webhook/%s/signing-key?service_id=%s&gateway_account_id=%s".formatted(externalId, serviceId, gatewayAccountId))
                 .then()
                 .statusCode(200)
                 .body("signing_key", startsWith("webhook_test_"))
@@ -69,7 +70,7 @@ public class WebhookSigningKeyIT {
 
         var regeneratePostResponse = given().port(port)
                 .contentType(JSON)
-                .post("/v1/webhook/%s/signing-key?service_id=%s".formatted(externalId, serviceId))
+                .post("/v1/webhook/%s/signing-key?service_id=%s&gateway_account_id=%s".formatted(externalId, serviceId, gatewayAccountId))
                 .then()
                 .statusCode(200)
                 .body("signing_key", not(originalSigningKey))
@@ -82,7 +83,7 @@ public class WebhookSigningKeyIT {
 
         given().port(port)
                 .contentType(JSON)
-                .get("/v1/webhook/%s/signing-key?service_id=%s".formatted(externalId, serviceId))
+                .get("/v1/webhook/%s/signing-key?service_id=%s&gateway_account_id=%s".formatted(externalId, serviceId, gatewayAccountId))
                 .then()
                 .statusCode(200)
                 .body("signing_key", equalTo(regeneratedSigningKey));

--- a/src/test/java/uk/gov/pay/webhooks/webhook/resource/WebhookUpdateIT.java
+++ b/src/test/java/uk/gov/pay/webhooks/webhook/resource/WebhookUpdateIT.java
@@ -113,13 +113,13 @@ public class WebhookUpdateIT {
 
         var externalId = response.get("external_id");
         var serviceId = response.get("service_id");
-
+        var gatewayAccountId = response.get("gateway_account_id");
 
         var mapper = new ObjectMapper();
         given().port(port)
                 .contentType(JSON)
                 .body(mapper.writeValueAsString(payload))
-                .patch(format("/v1/webhook/%s?service_id=%s", externalId, serviceId))
+                .patch(format("/v1/webhook/%s?service_id=%s&gateway_account_id=%s", externalId, serviceId, gatewayAccountId))
                 .then()
                 .statusCode(200)
                 .body("status", is("INACTIVE"));
@@ -156,11 +156,12 @@ public class WebhookUpdateIT {
 
         var externalId = response.get("external_id");
         var serviceId = response.get("service_id");
+        var gatewayAccountId = response.get("gateway_account_id");
 
         given().port(port)
                 .contentType(JSON)
                 .body(payload)
-                .patch(format("/v1/webhook/%s?service_id=%s", externalId, serviceId))
+                .patch(format("/v1/webhook/%s?service_id=%s&gateway_account_id=%s", externalId, serviceId, gatewayAccountId))
                 .then()
                 .statusCode(200)
                 .body("subscriptions", containsInAnyOrder("card_payment_captured"));
@@ -194,12 +195,13 @@ public class WebhookUpdateIT {
 
         var externalId = response.get("external_id");
         var serviceId = response.get("service_id");
+        var gatewayAccountId = response.get("gateway_account_id");
 
         var mapper = new ObjectMapper();
         given().port(port)
                 .contentType(JSON)
                 .body(mapper.writeValueAsString(payload))
-                .patch(format("/v1/webhook/%s?service_id=%s", externalId, serviceId))
+                .patch(format("/v1/webhook/%s?service_id=%s&gateway_account_id=%s", externalId, serviceId, gatewayAccountId))
                 .then()
                 .statusCode(400)
                 .body("error_identifier", is("CALLBACK_URL_NOT_ON_ALLOW_LIST"));

--- a/src/test/java/uk/gov/pay/webhooks/webhook/resource/WebhookUpdateIT.java
+++ b/src/test/java/uk/gov/pay/webhooks/webhook/resource/WebhookUpdateIT.java
@@ -66,11 +66,12 @@ public class WebhookUpdateIT {
                 """;
         var externalId = response.get("external_id");
         var serviceId = response.get("service_id");
+        var gatewayAccountId = response.get("gateway_account_id");
         
         given().port(port)
                 .contentType(JSON)
                 .body(payload)
-                .patch(format("/v1/webhook/%s?service_id=%s", externalId, serviceId))
+                .patch(format("/v1/webhook/%s?service_id=%s&gateway_account_id=%s", externalId, serviceId, gatewayAccountId))
                 .then()
                 .statusCode(200)
                 .body("description", is("new description"))
@@ -78,7 +79,7 @@ public class WebhookUpdateIT {
 
         given().port(port)
                 .contentType(JSON)
-                .get(format("/v1/webhook/%s?service_id=%s", externalId, serviceId))
+                .get(format("/v1/webhook/%s?service_id=%s&gateway_account_id=%s", externalId, serviceId, gatewayAccountId))
                 .then()
                 .statusCode(200)
                 .body("description", is("new description"))


### PR DESCRIPTION
Depends on https://github.com/alphagov/pay-webhooks/pull/820.

Until the data model across Pay shifts to being service-centric, use the
gateway account ID to allow consumers to fetch webhooks data
(this will allow multiple test card payment accounts to be
associated with a single service without causing any issues in the
webhooks mechanism or reporting on webhooks data, for the time being).