### PR TITLE
PP-10957: Use logging filter

### DIFF
--- a/src/main/java/uk/gov/pay/webhooks/app/InternalRestClientConfig.java
+++ b/src/main/java/uk/gov/pay/webhooks/app/InternalRestClientConfig.java
@@ -1,0 +1,12 @@
+package uk.gov.pay.webhooks.app;
+
+import javax.validation.Valid;
+
+public class InternalRestClientConfig {
+    @Valid
+    private boolean disabledSecureConnection;
+
+    public boolean isDisabledSecureConnection() {
+        return disabledSecureConnection;
+    }
+}

--- a/src/main/java/uk/gov/pay/webhooks/app/InternalRestClientFactory.java
+++ b/src/main/java/uk/gov/pay/webhooks/app/InternalRestClientFactory.java
@@ -1,0 +1,37 @@
+package uk.gov.pay.webhooks.app;
+
+import uk.gov.service.payments.logging.RestClientLoggingFilter;
+
+import javax.net.ssl.SSLContext;
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.ClientBuilder;
+import java.security.KeyManagementException;
+import java.security.NoSuchAlgorithmException;
+
+import static java.lang.String.format;
+
+public class InternalRestClientFactory {
+    private static final String TLSV1_2 = "TLSv1.2";
+
+    public static Client buildClient(InternalRestClientConfig clientConfig) {
+        ClientBuilder clientBuilder = ClientBuilder.newBuilder();
+
+        if (!clientConfig.isDisabledSecureConnection()) {
+            try {
+                SSLContext sslContext = SSLContext.getInstance(TLSV1_2);
+                sslContext.init(null, null, null);
+                clientBuilder = clientBuilder.sslContext(sslContext);
+            } catch (NoSuchAlgorithmException | KeyManagementException e) {
+                throw new RuntimeException(format("Unable to find an SSL context for %s", TLSV1_2), e);
+            }
+        }
+
+        Client client = clientBuilder.build();
+        client.register(RestClientLoggingFilter.class);
+
+        return client;
+    }
+
+    private InternalRestClientFactory() {
+    }
+}

--- a/src/main/java/uk/gov/pay/webhooks/app/WebhooksConfig.java
+++ b/src/main/java/uk/gov/pay/webhooks/app/WebhooksConfig.java
@@ -44,10 +44,17 @@ public class WebhooksConfig extends Configuration {
     @JsonProperty("queueMessageReceiverConfig")
     private QueueMessageReceiverConfig queueMessageReceiverConfig;
 
+    @NotNull
+    private InternalRestClientConfig internalRestClientConfig;
+
     public QueueMessageReceiverConfig getQueueMessageReceiverConfig() {
         return queueMessageReceiverConfig;
-    }    
-    
+    }
+
+    public InternalRestClientConfig getInternalRestClientConfig() {
+        return internalRestClientConfig;
+    }
+
     @NotNull
     @JsonProperty("webhookMessageDeletionConfig")
     private WebhookMessageDeletionConfig webhookMessageDeletionConfig;

--- a/src/main/java/uk/gov/pay/webhooks/app/WebhooksModule.java
+++ b/src/main/java/uk/gov/pay/webhooks/app/WebhooksModule.java
@@ -20,9 +20,11 @@ import org.apache.http.ssl.SSLContexts;
 import org.hibernate.SessionFactory;
 import uk.gov.pay.webhooks.message.WebhookMessageSignatureGenerator;
 import uk.gov.pay.webhooks.util.IdGenerator;
+import uk.gov.service.payments.logging.RestClientLoggingFilter;
 
 import javax.inject.Singleton;
-import java.time.Duration;
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.ClientBuilder;
 import java.time.InstantSource;
 import java.util.concurrent.TimeUnit;
 
@@ -58,8 +60,14 @@ public class WebhooksModule extends AbstractModule {
 
     @Provides
     @Singleton
-    public java.net.http.HttpClient netHttpClient() {
-        return java.net.http.HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(5)).build();
+    public Client netHttpClient() {
+        ClientBuilder clientBuilder = ClientBuilder.newBuilder();
+        Client client = clientBuilder.build();
+
+        clientBuilder.connectTimeout(5, TimeUnit.SECONDS);
+        client.register(RestClientLoggingFilter.class);
+
+        return client;
     }
     
     @Provides

--- a/src/main/java/uk/gov/pay/webhooks/app/WebhooksModule.java
+++ b/src/main/java/uk/gov/pay/webhooks/app/WebhooksModule.java
@@ -60,14 +60,8 @@ public class WebhooksModule extends AbstractModule {
 
     @Provides
     @Singleton
-    public Client netHttpClient() {
-        ClientBuilder clientBuilder = ClientBuilder.newBuilder();
-        Client client = clientBuilder.build();
-
-        clientBuilder.connectTimeout(5, TimeUnit.SECONDS);
-        client.register(RestClientLoggingFilter.class);
-
-        return client;
+    public Client internalRestClient() {
+        return InternalRestClientFactory.buildClient(configuration.getInternalRestClientConfig());
     }
     
     @Provides

--- a/src/main/java/uk/gov/pay/webhooks/ledger/LedgerService.java
+++ b/src/main/java/uk/gov/pay/webhooks/ledger/LedgerService.java
@@ -1,46 +1,39 @@
 package uk.gov.pay.webhooks.ledger;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import uk.gov.pay.webhooks.app.WebhooksConfig;
 import uk.gov.pay.webhooks.ledger.model.LedgerTransaction;
 
 import javax.inject.Inject;
-import java.io.IOException;
+import javax.ws.rs.client.Client;
+import javax.ws.rs.core.Response;
 import java.net.URI;
-import java.net.http.HttpClient;
-import java.net.http.HttpRequest;
-import java.net.http.HttpResponse;
 import java.util.Optional;
-
-import static java.nio.charset.StandardCharsets.UTF_8;
 
 public class LedgerService {
 
-    private final HttpClient httpClient;
+    private final Client client;
     private final String ledgerUrl;
 
     @Inject
-    public LedgerService(HttpClient httpClient, WebhooksConfig configuration) {
-        this.httpClient = httpClient;
+    public LedgerService(Client client, WebhooksConfig configuration) {
+        this.client = client;
         this.ledgerUrl = configuration.getLedgerBaseUrl();
     }
 
-    public Optional<LedgerTransaction> getTransaction(String id) throws IOException, InterruptedException {
+    public Optional<LedgerTransaction> getTransaction(String id) {
         var uri = URI.create(ledgerUrl + "/v1/transaction/" + id + "?override_account_id_restriction=true");
         return getTransactionFromLedger(uri);
     }
 
-    private Optional<LedgerTransaction> getTransactionFromLedger(URI uri) throws IOException, InterruptedException {
-        HttpResponse<String> response = getResponse(uri);
-        if (response.statusCode() == 200) {
-            var objectMapper = new ObjectMapper();
-            return Optional.of(objectMapper.readValue(response.body(), LedgerTransaction.class));
+    private Optional<LedgerTransaction> getTransactionFromLedger(URI uri) {
+        Response response = getResponse(uri);
+        if (response.getStatus() == 200) {
+            return Optional.of(response.readEntity(LedgerTransaction.class));
         }
         return Optional.empty();
     }
 
-    private HttpResponse<String> getResponse(URI uri) throws IOException, InterruptedException {
-        var httpRequest = HttpRequest.newBuilder().uri(uri).build();
-        return httpClient.send(httpRequest, HttpResponse.BodyHandlers.ofString(UTF_8));
+    private Response getResponse(URI uri) {
+        return client.target(uri).request().get();
     }
 }

--- a/src/main/resources/config/config.yaml
+++ b/src/main/resources/config/config.yaml
@@ -61,6 +61,9 @@ database:
 
 ledgerBaseURL: ${LEDGER_URL}
 
+internalRestClientConfig:
+  disabledSecureConnection: ${DISABLE_INTERNAL_HTTPS:-false}
+
 graphiteHost: ${METRICS_HOST:-localhost}
 graphitePort: ${METRICS_PORT:-8092}
 

--- a/src/test/java/uk/gov/pay/webhooks/app/InternalRestClientFactoryTest.java
+++ b/src/test/java/uk/gov/pay/webhooks/app/InternalRestClientFactoryTest.java
@@ -1,0 +1,29 @@
+package uk.gov.pay.webhooks.app;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class InternalRestClientFactoryTest {
+    @Mock
+    InternalRestClientConfig internalRestClientConfig;
+
+    @Test
+    void useSSLWhenSecureInternalFlagIsEnabled() {
+        when(internalRestClientConfig.isDisabledSecureConnection()).thenReturn(false);
+        assertThat(InternalRestClientFactory.buildClient(internalRestClientConfig).getSslContext().getProtocol(), is("TLSv1.2"));
+    }
+
+    @Test
+    void doesNotUseSSLWhenSecureInternalFlagIsDisabled() {
+        when(internalRestClientConfig.isDisabledSecureConnection()).thenReturn(true);
+        assertThat(InternalRestClientFactory.buildClient(internalRestClientConfig).getSslContext().getProtocol(), is(not("TLSv1.2")));
+    }
+}

--- a/src/test/java/uk/gov/pay/webhooks/deliveryqueue/WebhookDeliveryQueueIT.java
+++ b/src/test/java/uk/gov/pay/webhooks/deliveryqueue/WebhookDeliveryQueueIT.java
@@ -74,7 +74,7 @@ public class WebhookDeliveryQueueIT {
 
         wireMock.verify(
                 exactly(1),
-                postRequestedFor(urlEqualTo("/a-test-endpoint")).withRequestBody(matchingJsonPath("$.resource_id", equalTo(transaction.getTransactionId())))
+                postRequestedFor(urlEqualTo("/a-test-endpoint")).withRequestBody(matchingJsonPath("$.resource.payment_id", equalTo(transaction.getTransactionId())))
         );
 
         given().port(app.getAppRule().getLocalPort())

--- a/src/test/java/uk/gov/pay/webhooks/ledger/LedgerServiceTest.java
+++ b/src/test/java/uk/gov/pay/webhooks/ledger/LedgerServiceTest.java
@@ -1,109 +1,80 @@
 package uk.gov.pay.webhooks.ledger;
 
-import org.junit.Before;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.ArgumentMatchers;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.pay.webhooks.app.WebhooksConfig;
 import uk.gov.pay.webhooks.ledger.model.LedgerTransaction;
 
-import java.io.IOException;
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.Invocation;
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.Response;
 import java.net.URI;
-import java.net.http.HttpClient;
-import java.net.http.HttpRequest;
-import java.net.http.HttpResponse;
-import java.net.http.HttpResponse.BodyHandler;
 import java.util.Optional;
 
-import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.any;
 import static org.hamcrest.core.Is.is;
-import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class LedgerServiceTest {
     
     private static final String TRANSACTION_ID = "3rke415aam1pl1u3hvaljbcll3";
     
-    private static final String LEDGER_TRANSACTION_JSON = """
-            {
-              "amount": 1000,
-              "state": {
-                "finished": false,
-                "status": "created"
-              },
-              "description": "Test description",
-              "reference": "aReference",
-              "language": "en",
-              "transaction_id": "3rke415aam1pl1u3hvaljbcll3",
-              "return_url": "https://example.org",
-              "email": "someone@example.org",
-              "payment_provider": "sandbox",
-              "created_date": "2018-09-22T10:13:16.067Z",
-              "card_details": {
-                "cardholder_name": "j.doe@example.org",
-                "billing_address": {
-                  "line1": "line1",
-                  "line2": "line2",
-                  "postcode": "AB1 2CD",
-                  "city": "London",
-                  "country": "GB"
-                },
-                "card_brand": ""
-              },
-              "delayed_capture": false,
-              "moto": false,
-              "authorisation_summary": {
-                "three_d_secure": {
-                  "required": true,
-                  "version": "2.1.0"
-                }
-              }
-            }
-            """;
-    
     private LedgerService ledgerService;
     
     @Mock
-    private HttpClient mockHttpClient;
+    private Client mockClient;
+
+    @Mock
+    private WebTarget mockWebTarget;
+
+    @Mock
+    private Invocation.Builder mockClientRequestInvocationBuilder;
     
     @Mock
     private WebhooksConfig mockWebhooksConfig;
     
     @Mock
-    private HttpResponse<String> mockHttpResponse;
+    private Response mockResponse;
+
+    @Mock
+    private LedgerTransaction mockTransaction;
     
     @BeforeEach
     void setUp() {
         given(mockWebhooksConfig.getLedgerBaseUrl()).willReturn("https://ledger");
+
+        when(mockWebTarget.request()).thenReturn(mockClientRequestInvocationBuilder);
+        when(mockClientRequestInvocationBuilder.get()).thenReturn(mockResponse);
         
-        ledgerService = new LedgerService(mockHttpClient, mockWebhooksConfig);
+        ledgerService = new LedgerService(mockClient, mockWebhooksConfig);
     }
 
     @Test
-    void getTransactionReturnsTransactionWithId() throws IOException, InterruptedException {
+    void getTransactionReturnsTransactionWithId() {
         var uri = URI.create("https://ledger/v1/transaction/" + TRANSACTION_ID + "?override_account_id_restriction=true");
-        given(mockHttpClient.send(eq(HttpRequest.newBuilder().uri(uri).build()), ArgumentMatchers.<BodyHandler<String>>any())).willReturn(mockHttpResponse);
-        given(mockHttpResponse.statusCode()).willReturn(200);
-        given(mockHttpResponse.body()).willReturn(LEDGER_TRANSACTION_JSON);
+        when(mockClient.target(uri)).thenReturn(mockWebTarget);
+
+        given(mockResponse.getStatus()).willReturn(200);
+        given(mockResponse.readEntity(LedgerTransaction.class)).willReturn(mockTransaction);
 
         Optional<LedgerTransaction> ledgerTransaction = ledgerService.getTransaction(TRANSACTION_ID);
 
         assertThat(ledgerTransaction.isPresent(), is(true));
-        assertThat(ledgerTransaction.get().getTransactionId(), is(TRANSACTION_ID));
+        assertThat(ledgerTransaction.get(), is(mockTransaction));
     }
 
     @Test
-    void getTransactionReturnsEmptyOptionalWhenLedger404s() throws IOException, InterruptedException {
+    void getTransactionReturnsEmptyOptionalWhenLedger404s() {
         var uri = URI.create("https://ledger/v1/transaction/" + TRANSACTION_ID + "?override_account_id_restriction=true");
-        given(mockHttpClient.send(eq(HttpRequest.newBuilder().uri(uri).build()), ArgumentMatchers.<BodyHandler<String>>any())).willReturn(mockHttpResponse);
-        given(mockHttpResponse.statusCode()).willReturn(404);
+        when(mockClient.target(uri)).thenReturn(mockWebTarget);
+
+        given(mockResponse.getStatus()).willReturn(404);
 
         Optional<LedgerTransaction> ledgerTransaction = ledgerService.getTransaction(TRANSACTION_ID);
 

--- a/src/test/java/uk/gov/pay/webhooks/ledger/pact/LedgerServiceConsumerTest.java
+++ b/src/test/java/uk/gov/pay/webhooks/ledger/pact/LedgerServiceConsumerTest.java
@@ -12,11 +12,12 @@ import uk.gov.pay.webhooks.ledger.LedgerService;
 import uk.gov.pay.webhooks.ledger.model.LedgerTransaction;
 import uk.gov.service.payments.commons.testing.pact.consumers.PactProviderRule;
 import uk.gov.service.payments.commons.testing.pact.consumers.Pacts;
+import uk.gov.service.payments.logging.RestClientLoggingFilter;
 
-import java.io.IOException;
-import java.net.http.HttpClient;
-import java.time.Duration;
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.ClientBuilder;
 import java.util.Optional;
+import java.util.concurrent.TimeUnit;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -30,19 +31,26 @@ public class LedgerServiceConsumerTest {
 
     @Mock
     WebhooksConfig configuration;
-    
+
     private LedgerService ledgerService;
-    
+
     @Before
     public void setUp() {
         when(configuration.getLedgerBaseUrl()).thenReturn(ledgerRule.getUrl());
-        ledgerService = new LedgerService(HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(5)).build(), configuration);
+
+        ClientBuilder clientBuilder = ClientBuilder.newBuilder();
+        Client client = clientBuilder.build();
+
+        clientBuilder.connectTimeout(5, TimeUnit.SECONDS);
+        client.register(RestClientLoggingFilter.class);
+
+        ledgerService = new LedgerService(client, configuration);
     }
 
     @Test
     @PactVerification("ledger")
     @Pacts(pacts = {"webhooks-ledger-get-payment-transaction"})
-    public void getTransaction_shouldSerialiseLedgerPaymentTransactionCorrectly() throws IOException, InterruptedException {
+    public void getTransaction_shouldSerialiseLedgerPaymentTransactionCorrectly() {
         String externalId = "e8eq11mi2ndmauvb51qsg8hccn";
         Optional<LedgerTransaction> mayBeTransaction = ledgerService.getTransaction(externalId);
 

--- a/src/test/java/uk/gov/pay/webhooks/ledger/pact/LedgerServiceConsumerTest.java
+++ b/src/test/java/uk/gov/pay/webhooks/ledger/pact/LedgerServiceConsumerTest.java
@@ -7,6 +7,8 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.pay.webhooks.app.InternalRestClientConfig;
+import uk.gov.pay.webhooks.app.InternalRestClientFactory;
 import uk.gov.pay.webhooks.app.WebhooksConfig;
 import uk.gov.pay.webhooks.ledger.LedgerService;
 import uk.gov.pay.webhooks.ledger.model.LedgerTransaction;
@@ -31,20 +33,17 @@ public class LedgerServiceConsumerTest {
 
     @Mock
     WebhooksConfig configuration;
+    @Mock
+    InternalRestClientConfig internalRestClientConfig;
 
     private LedgerService ledgerService;
 
     @Before
     public void setUp() {
+        when(internalRestClientConfig.isDisabledSecureConnection()).thenReturn(true);
         when(configuration.getLedgerBaseUrl()).thenReturn(ledgerRule.getUrl());
 
-        ClientBuilder clientBuilder = ClientBuilder.newBuilder();
-        Client client = clientBuilder.build();
-
-        clientBuilder.connectTimeout(5, TimeUnit.SECONDS);
-        client.register(RestClientLoggingFilter.class);
-
-        ledgerService = new LedgerService(client, configuration);
+        ledgerService = new LedgerService(InternalRestClientFactory.buildClient(internalRestClientConfig), configuration);
     }
 
     @Test

--- a/src/test/resources/config/test-config.yaml
+++ b/src/test/resources/config/test-config.yaml
@@ -36,6 +36,9 @@ database:
 
 ledgerBaseURL: ${LEDGER_URL}
 
+internalRestClientConfig:
+  disabledSecureConnection: ${DISABLE_INTERNAL_HTTPS:-true}
+
 graphiteHost: ${METRICS_HOST:-localhost}
 graphitePort: ${METRICS_PORT:-8092}
 


### PR DESCRIPTION
* Switch from using `java.net.http.HttpClient` to using `javax.ws.rs.client.Client`
  * This lets us add a logging filter to the client - this could not be done when we were using `HttpClient`
  * It also brings the project into line with how other Pay projects perform http requests
* Update tests - the new `Client` deals with deserialising body content automatically, so our implementation code is now doing less and the scope of some unit tests is thus diminished

I'm afraid I didn't get time actually test this, beyond running the automated tests.  It needs to be tested running locally (to verify that requests do get logged), and will also need testing after being merged to production, to verify that X-Request-Ids are correctly written to the logs (which can't be reproduced when testing locally).