### PR TITLE
PP-9850 Fix serialising child events

### DIFF
--- a/src/main/java/uk/gov/pay/webhooks/ledger/model/LedgerTransaction.java
+++ b/src/main/java/uk/gov/pay/webhooks/ledger/model/LedgerTransaction.java
@@ -49,6 +49,7 @@ public class LedgerTransaction {
     private String refundedByUserEmail;
     private String parentTransactionId;
     private String serviceId;
+    private String transactionType;
     private AuthorisationSummary authorisationSummary;
 
     public LedgerTransaction() {
@@ -299,6 +300,10 @@ public class LedgerTransaction {
 
     public AuthorisationSummary getAuthorisationSummary() {
         return authorisationSummary;
+    }
+
+    public String getTransactionType() {
+        return transactionType;
     }
 
     public void setAuthorisationSummary(AuthorisationSummary authorisationSummary) {

--- a/src/test/java/uk/gov/pay/webhooks/util/DatabaseTestHelper.java
+++ b/src/test/java/uk/gov/pay/webhooks/util/DatabaseTestHelper.java
@@ -17,6 +17,7 @@ public class DatabaseTestHelper {
     public void addWebhookWithSubscription(String webhookExternalId, String serviceExternalId, String callbackUrl, String gatewayAccountId) {
         jdbi.withHandle(h -> h.execute("INSERT INTO webhooks VALUES (1, '2022-01-01', '%s', 'signing-key', '%s', false, '%s', 'description', 'ACTIVE', '%s')".formatted(webhookExternalId, serviceExternalId, callbackUrl, gatewayAccountId)));
         jdbi.withHandle(h -> h.execute("INSERT INTO webhook_subscriptions VALUES (1, (SELECT id FROM event_types WHERE name = 'card_payment_succeeded'))"));
+        jdbi.withHandle(h -> h.execute("INSERT INTO webhook_subscriptions VALUES (1, (SELECT id FROM event_types WHERE name = 'card_payment_refunded'))"));
     }
 
     public void truncateAllData() {


### PR DESCRIPTION
Currently webhooks only supports sending events that relate to payments. Early thinking on how to populate the resource on a webhook message decided to format the resource according to the event type, however this won't always work (in this case we want to send the payment that has been refunded, rather than the refund).

This removes that early logic but leaves the tools in place in case we need to allow services to subscribe to different types of resources in the future (refunds, disputes, agreemenets, etc.)