### PR TITLE
BAU: Add check to make sure pact files were generated

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -48,3 +48,9 @@ jobs:
           fi
       - name: Run tests
         run: mvn verify
+      - name: Check for generated pacts
+        run: |
+          if [ ! -d target/pacts ]; then
+            echo "The pact files were not generated, this means that no pact results will be published and this build will fail to deploy"
+            exit 1
+          fi


### PR DESCRIPTION
## WHAT YOU DID
Test if the pact files have been generated by the unit tests. If they haven't it means the pact doesn't get published and the version fails much later at the deploy-to-test phase of release.
