### PR TITLE
ZD-5392584 Include default payment expired event

### DIFF
--- a/src/main/java/uk/gov/pay/webhooks/message/EventMapper.java
+++ b/src/main/java/uk/gov/pay/webhooks/message/EventMapper.java
@@ -22,6 +22,7 @@ public class EventMapper {
             entry("CANCELLED_BY_EXTERNAL_SERVICE", EventTypeName.CARD_PAYMENT_FAILED),
             entry("CANCELLED_BY_USER", EventTypeName.CARD_PAYMENT_FAILED),
             entry("CANCELLED_BY_EXPIRATION", EventTypeName.CARD_PAYMENT_EXPIRED),
+            entry("PAYMENT_EXPIRED", EventTypeName.CARD_PAYMENT_EXPIRED),
             entry("CAPTURE_CONFIRMED", EventTypeName.CARD_PAYMENT_CAPTURED),
             entry("REFUND_SUCCEEDED", EventTypeName.CARD_PAYMENT_REFUNDED)
     );


### PR DESCRIPTION
A user has observed that payments that expire without any interaction don't receive the webhook message for "Payment expired".

It looks like the event stream differentiates between payments that are expired and require cancelling (have already authorised the payment with the gateway) and payments that are able to be immediately expired without any action.

Include the default expired event as part of the "Payment expired" subscription to allow services to be updated when this default case occurs.