### PR TITLE
BAU: Pin to elasticmq v1.4.2

### DIFF
--- a/src/test/java/uk/gov/pay/rule/SqsTestDocker.java
+++ b/src/test/java/uk/gov/pay/rule/SqsTestDocker.java
@@ -31,7 +31,7 @@ public class SqsTestDocker {
         if (sqsContainer == null) {
             logger.info("Creating SQS Container");
 
-            sqsContainer = new GenericContainer<>("softwaremill/elasticmq-native")
+            sqsContainer = new GenericContainer<>("softwaremill/elasticmq-native:1.4.2")
                     .withExposedPorts(PORT)
                     .waitingFor(Wait.forLogMessage(".*ElasticMQ server.*.*started.*", 1));
 


### PR DESCRIPTION
v1.4.3 ([released today](https://github.com/softwaremill/elasticmq/releases)) has been failing to start during the integration tests (on this app and on connector).