### PR TITLE
ZD-5451010 Temporarily allow custom HSE Azure domain

### DIFF
--- a/src/main/resources/config/config.yaml
+++ b/src/main/resources/config/config.yaml
@@ -102,6 +102,8 @@ webhookMessageSendingQueueProcessorConfig:
   idleConnectionMonitorInitialDelayInMilliseconds: ${WEBHOOK_MESSAGE_SENDING_QUEUE_IDLE_CONNECTION_MONITOR_INITIAL_DELAY_IN_MILLISECONDS:-1000}
   idleConnectionMonitorThreadDelayInMilliseconds: ${WEBHOOK_MESSAGE_SENDING_QUEUE_IDLE_CONNECTION_MONITOR_THREAD_DELAY_IN_MILLISECONDS:-1000}
 
-liveDataAllowDomains: ["gov.uk"]
+# The azurewebsites.net domain was added due to Zendesk ticket #5451010 — it is
+# intended to be temporary and should be gone by the end of August 2023
+liveDataAllowDomains: ["gov.uk", "s118-prod-bsr-acs-common-fa.azurewebsites.net"]
 
 ecsContainerMetadataUriV4: ${ECS_CONTAINER_METADATA_URI_V4:-}


### PR DESCRIPTION
Temporarily allow webhook callback URLs hosted on the domain s118-prod-bsr-acs-common-fa.azurewebsites.net (or its subdomains) to be configured. This domain will be used temporarily by the HSE Building Safety Regulator before they switch to a .gov.uk domain, which will be in about two weeks.