### PR TITLE
PP-11406: Log domain even if request timed out

### DIFF
--- a/src/main/java/uk/gov/pay/webhooks/deliveryqueue/managed/SendAttempter.java
+++ b/src/main/java/uk/gov/pay/webhooks/deliveryqueue/managed/SendAttempter.java
@@ -19,7 +19,7 @@ import javax.inject.Inject;
 import javax.ws.rs.core.Response;
 import java.io.IOException;
 import java.net.SocketTimeoutException;
-import java.net.URL;
+import java.net.URI;
 import java.net.http.HttpTimeoutException;
 import java.security.InvalidKeyException;
 import java.time.Duration;
@@ -70,8 +70,9 @@ public class SendAttempter {
         var retryCount = webhookDeliveryQueueDao.countFailed(queueItem.getWebhookMessageEntity());
         Instant start = instantSource.instant();
 
+        var url = URI.create(webhook.getCallbackUrl());
+        
         try {
-            var url = new URL(webhook.getCallbackUrl());
 
             LOGGER.info(
                     Markers.append(WEBHOOK_CALLBACK_URL, queueItem.getWebhookMessageEntity().getWebhookEntity().getCallbackUrl())
@@ -90,7 +91,7 @@ public class SendAttempter {
             }
         } catch (SocketTimeoutException | HttpTimeoutException | NoHttpResponseException | ConnectTimeoutException e) {
             LOGGER.info("Request timed out");
-            handleResponse(queueItem, DeliveryStatus.FAILED, null, "HTTP Timeout", retryCount, start);
+            handleResponse(queueItem, DeliveryStatus.FAILED, null, "HTTP Timeout", retryCount, start, Optional.of(url));
         } catch (IOException | InterruptedException | InvalidKeyException e) {
             LOGGER.info(
                     Markers.append(ERROR_MESSAGE, e.getMessage()),
@@ -107,7 +108,6 @@ public class SendAttempter {
             );
             handleResponse(queueItem, DeliveryStatus.WILL_NOT_SEND, null, "Violates security rules", retryCount, start);
         } catch (Exception e) {
-            var responseTime = Duration.between(start, instantSource.instant());
             // handle all exceptions at this level to make sure that the retry mechanism is allowed to work as designed
             // allowing errors passed this point (not guaranteeing an update) would allow perpetual failures 
             LOGGER.warn(
@@ -133,7 +133,7 @@ public class SendAttempter {
                                 String reason, 
                                 Long retryCount, 
                                 Instant startTime,
-                                Optional<URL> domain) {
+                                Optional<URI> domain) {
         var responseTime = Duration.between(startTime, instantSource.instant());
         
         LogstashMarker logstashMarker = Markers.append(HTTP_STATUS, statusCode)


### PR DESCRIPTION
If the request timed out, the request was still attempted. If the request was attempted, the domain is logged in the egress logs. Currently, if the reqest is timed out, the domain isn't logged in the application logs, which leads to a mismatch between the domains logged in the webhook application logs and egress logs. This causes the "Compare webhooks and webhooks-egress target domains" alert to fire unnecessarily. This commit logs the domain even if the request times out, and uses `URI.create` which does not throw a checked exception which makes the code a bit nicer.