### PR TITLE
PP-11228: Remove graphite metrics sending and config

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -146,10 +146,6 @@
             <artifactId>metrics-core</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.dropwizard.metrics</groupId>
-            <artifactId>metrics-graphite</artifactId>
-        </dependency>
-        <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
         </dependency>

--- a/src/main/java/uk/gov/pay/webhooks/app/WebhooksApp.java
+++ b/src/main/java/uk/gov/pay/webhooks/app/WebhooksApp.java
@@ -51,7 +51,7 @@ public class WebhooksApp extends Application<WebhooksConfig> {
     }
     
     private static final String SERVICE_METRICS_NODE = "webhooks";
-    private static final int METRICS_COLLECTION_PERIOD_SECONDS = 10;
+    private static final int METRICS_COLLECTION_PERIOD_SECONDS = 30;
 
     private final HibernateBundle<WebhooksConfig> hibernate = new HibernateBundle<>(
             WebhookEntity.class,

--- a/src/main/java/uk/gov/pay/webhooks/app/WebhooksApp.java
+++ b/src/main/java/uk/gov/pay/webhooks/app/WebhooksApp.java
@@ -1,8 +1,5 @@
 package uk.gov.pay.webhooks.app;
 
-import com.codahale.metrics.graphite.GraphiteReporter;
-import com.codahale.metrics.graphite.GraphiteSender;
-import com.codahale.metrics.graphite.GraphiteUDP;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
 import io.dropwizard.Application;
@@ -54,7 +51,7 @@ public class WebhooksApp extends Application<WebhooksConfig> {
     }
     
     private static final String SERVICE_METRICS_NODE = "webhooks";
-    private static final int GRAPHITE_SENDING_PERIOD_SECONDS = 10;
+    private static final int METRICS_COLLECTION_PERIOD_SECONDS = 10;
 
     private final HibernateBundle<WebhooksConfig> hibernate = new HibernateBundle<>(
             WebhookEntity.class,
@@ -122,9 +119,8 @@ public class WebhooksApp extends Application<WebhooksConfig> {
                 .scheduledExecutorService("metricscollector")
                 .threads(1)
                 .build()
-                .scheduleAtFixedRate(metricsService::updateMetricData, 0, GRAPHITE_SENDING_PERIOD_SECONDS / 2, TimeUnit.SECONDS);
+                .scheduleAtFixedRate(metricsService::updateMetricData, 0, METRICS_COLLECTION_PERIOD_SECONDS / 2, TimeUnit.SECONDS);
 
-        initialiseGraphiteMetrics(configuration, environment);
         configuration.getEcsContainerMetadataUriV4().ifPresent(uri -> initialisePrometheusMetrics(environment, uri));
     }
 
@@ -133,15 +129,5 @@ public class WebhooksApp extends Application<WebhooksConfig> {
         CollectorRegistry collectorRegistry = new CollectorRegistry();
         collectorRegistry.register(new DropwizardExports(environment.metrics(), new PrometheusDefaultLabelSampleBuilder(ecsContainerMetadataUri)));
         environment.admin().addServlet("prometheusMetrics", new MetricsServlet(collectorRegistry)).addMapping("/metrics");
-    }
-
-    private void initialiseGraphiteMetrics(WebhooksConfig configuration, Environment environment) {
-        GraphiteSender graphiteUDP = new GraphiteUDP(configuration.getGraphiteHost(), Integer.parseInt(configuration.getGraphitePort()));
-        GraphiteReporter.forRegistry(environment.metrics())
-                .prefixedWith(SERVICE_METRICS_NODE)
-                .convertRatesTo(TimeUnit.MINUTES)
-                .convertDurationsTo(TimeUnit.MILLISECONDS)
-                .build(graphiteUDP)
-                .start(GRAPHITE_SENDING_PERIOD_SECONDS, TimeUnit.SECONDS);
     }
 }

--- a/src/main/java/uk/gov/pay/webhooks/app/WebhooksConfig.java
+++ b/src/main/java/uk/gov/pay/webhooks/app/WebhooksConfig.java
@@ -77,22 +77,6 @@ public class WebhooksConfig extends Configuration {
     }
     
     @NotNull
-    @JsonProperty("graphiteHost")
-    private String graphiteHost;
-    
-    public String getGraphiteHost() {
-        return graphiteHost;
-    }
-
-    @NotNull
-    @JsonProperty("graphitePort")
-    private String graphitePort;
-    
-    public String getGraphitePort() {
-        return graphitePort;
-    }
-
-    @NotNull
     @JsonProperty("liveDataAllowDomains")
     private Set<String> liveDataAllowDomains;
 

--- a/src/main/resources/config/config.yaml
+++ b/src/main/resources/config/config.yaml
@@ -67,9 +67,6 @@ ledgerBaseURL: ${LEDGER_URL}
 internalRestClientConfig:
   disabledSecureConnection: ${DISABLE_INTERNAL_HTTPS:-false}
 
-graphiteHost: ${METRICS_HOST:-localhost}
-graphitePort: ${METRICS_PORT:-8092}
-
 sqsConfig:
   nonStandardServiceEndpoint: ${AWS_SQS_NON_STANDARD_SERVICE_ENDPOINT:-false}
   endpoint: ${AWS_SQS_ENDPOINT:-}

--- a/src/test/resources/config/test-config.yaml
+++ b/src/test/resources/config/test-config.yaml
@@ -39,9 +39,6 @@ ledgerBaseURL: ${LEDGER_URL}
 internalRestClientConfig:
   disabledSecureConnection: ${DISABLE_INTERNAL_HTTPS:-true}
 
-graphiteHost: ${METRICS_HOST:-localhost}
-graphitePort: ${METRICS_PORT:-8092}
-
 webhookMessageDeletionConfig:
   maxAgeOfMessages: ${MAXIMUM_AGE_OF_MESSAGE:-7}
   maxNumOfMessagesToExpire: ${MAXIMUM_NUMBER_OF_MESSAGES_TO_EXPIRE_PER_JOB:-6}


### PR DESCRIPTION
## WHAT YOU DID
1. Remove graphite metrics configuration and sending
2. Rename GRAPHITE_SENDING_PERIOD_SECONDS to METRICS_COLLECTION_PERIOD_SECONDS, and set it to the appropriate value.

## How to test

Check build passes and explicitly wait for the e2e tests to pass

## Code review checklist

### Logging

- [X] only emit log lines at ERROR level which require immediate attention from a support engineer. These will trigger a zendesk alert.
