### PR TITLE
PP-11652 upgrade dropwizard to version 3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,16 +31,9 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
-                <groupId>com.google.guava</groupId>
-                <artifactId>guava-bom</artifactId>
-                <version>32.1.2-jre</version>
-                <scope>import</scope>
-                <type>pom</type>
-            </dependency>
-            <dependency>
                 <groupId>io.dropwizard</groupId>
-                <artifactId>dropwizard-bom</artifactId>
-                <version>2.1.4</version>
+                <artifactId>dropwizard-dependencies</artifactId>
+                <version>3.0.2</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -59,38 +52,18 @@
                 <type>pom</type>
             </dependency>
             <dependency>
-                <groupId>com.fasterxml.jackson</groupId>
-                <artifactId>jackson-bom</artifactId>
-                <version>2.15.2</version>
-                <scope>import</scope>
-                <type>pom</type>
-            </dependency>
-            <dependency>
                 <groupId>com.amazonaws</groupId>
                 <artifactId>aws-java-sdk-bom</artifactId>
                 <version>1.12.566</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
-            <dependency>
-                <groupId>org.junit</groupId>
-                <artifactId>junit-bom</artifactId>
-                <version>5.10.0</version>
-                <scope>import</scope>
-                <type>pom</type>
-            </dependency>
-            <dependency>
-                <groupId>org.mockito</groupId>
-                <artifactId>mockito-bom</artifactId>
-                <version>5.6.0</version>
-                <scope>import</scope>
-                <type>pom</type>
-            </dependency>
         </dependencies>
     </dependencyManagement>
 
     <dependencies>
-        <!-- Main dependencies that use a BOM so no explicit versions needed -->
+        <!-- Main dependencies that are imported from one of the BOMs specified
+             in <dependencyManagement> so no explicit versions needed -->
         <dependency>
             <groupId>io.dropwizard</groupId>
             <artifactId>dropwizard-core</artifactId>
@@ -106,12 +79,6 @@
         <dependency>
             <groupId>io.dropwizard</groupId>
             <artifactId>dropwizard-migrations</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.liquibase</groupId>
-                    <artifactId>liquibase-core</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>com.google.inject</groupId>
@@ -172,17 +139,6 @@
             <version>2.21.1</version>
         </dependency>
         <dependency>
-            <groupId>org.liquibase</groupId>
-            <artifactId>liquibase-core</artifactId>
-            <version>4.23.1</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>javax.servlet</groupId>
-                    <artifactId>jstl</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
             <version>42.6.0</version>
@@ -199,7 +155,7 @@
         </dependency>
         <dependency>
             <groupId>uk.gov.service.payments</groupId>
-            <artifactId>logging</artifactId>
+            <artifactId>logging-dropwizard-3</artifactId>
             <version>${pay-java-commons.version}</version>
         </dependency>
         <dependency>
@@ -208,7 +164,8 @@
             <version>2.1.2-4</version>
         </dependency>
 
-        <!-- Test dependencies that use a BOM so no explicit versions needed -->
+        <!-- Test dependencies that are imported from one of the BOMs specified
+             in <dependencyManagement> so no explicit versions needed -->
         <dependency>
             <groupId>io.dropwizard</groupId>
             <artifactId>dropwizard-testing</artifactId>
@@ -227,6 +184,11 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-params</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -256,7 +218,7 @@
         </dependency>
         <dependency>
             <groupId>com.github.tomakehurst</groupId>
-            <artifactId>wiremock-jre8</artifactId>
+            <artifactId>wiremock-jre8-standalone</artifactId>
             <version>2.35.1</version>
             <scope>test</scope>
         </dependency>

--- a/src/main/java/uk/gov/pay/webhooks/app/IdleConnectionMonitor.java
+++ b/src/main/java/uk/gov/pay/webhooks/app/IdleConnectionMonitor.java
@@ -1,7 +1,7 @@
 package uk.gov.pay.webhooks.app;
 
 import io.dropwizard.lifecycle.Managed;
-import io.dropwizard.setup.Environment;
+import io.dropwizard.core.setup.Environment;
 import org.apache.http.impl.conn.PoolingHttpClientConnectionManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/src/main/java/uk/gov/pay/webhooks/app/QueueMessageReceiverConfig.java
+++ b/src/main/java/uk/gov/pay/webhooks/app/QueueMessageReceiverConfig.java
@@ -1,6 +1,6 @@
 package uk.gov.pay.webhooks.app;
 
-import io.dropwizard.Configuration;
+import io.dropwizard.core.Configuration;
 
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;

--- a/src/main/java/uk/gov/pay/webhooks/app/SqsConfig.java
+++ b/src/main/java/uk/gov/pay/webhooks/app/SqsConfig.java
@@ -1,6 +1,6 @@
 package uk.gov.pay.webhooks.app;
 
-import io.dropwizard.Configuration;
+import io.dropwizard.core.Configuration;
 
 import javax.validation.constraints.Max;
 import javax.validation.constraints.NotNull;

--- a/src/main/java/uk/gov/pay/webhooks/app/WebhookMessageSendingQueueProcessorConfig.java
+++ b/src/main/java/uk/gov/pay/webhooks/app/WebhookMessageSendingQueueProcessorConfig.java
@@ -1,6 +1,6 @@
 package uk.gov.pay.webhooks.app;
 
-import io.dropwizard.Configuration;
+import io.dropwizard.core.Configuration;
 import io.dropwizard.util.Duration;
 
 import javax.validation.Valid;

--- a/src/main/java/uk/gov/pay/webhooks/app/WebhooksApp.java
+++ b/src/main/java/uk/gov/pay/webhooks/app/WebhooksApp.java
@@ -2,14 +2,14 @@ package uk.gov.pay.webhooks.app;
 
 import com.google.inject.Guice;
 import com.google.inject.Injector;
-import io.dropwizard.Application;
+import io.dropwizard.core.Application;
 import io.dropwizard.configuration.EnvironmentVariableSubstitutor;
 import io.dropwizard.configuration.SubstitutingSourceProvider;
 import io.dropwizard.db.DataSourceFactory;
 import io.dropwizard.hibernate.HibernateBundle;
 import io.dropwizard.migrations.MigrationsBundle;
-import io.dropwizard.setup.Bootstrap;
-import io.dropwizard.setup.Environment;
+import io.dropwizard.core.setup.Bootstrap;
+import io.dropwizard.core.setup.Environment;
 import io.prometheus.client.CollectorRegistry;
 import io.prometheus.client.dropwizard.DropwizardExports;
 import io.prometheus.client.exporter.MetricsServlet;

--- a/src/main/java/uk/gov/pay/webhooks/app/WebhooksConfig.java
+++ b/src/main/java/uk/gov/pay/webhooks/app/WebhooksConfig.java
@@ -1,7 +1,7 @@
 package uk.gov.pay.webhooks.app;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import io.dropwizard.Configuration;
+import io.dropwizard.core.Configuration;
 import io.dropwizard.db.DataSourceFactory;
 
 import javax.validation.Valid;

--- a/src/main/java/uk/gov/pay/webhooks/app/WebhooksModule.java
+++ b/src/main/java/uk/gov/pay/webhooks/app/WebhooksModule.java
@@ -9,7 +9,7 @@ import com.google.inject.AbstractModule;
 import com.google.inject.Provides;
 import io.dropwizard.hibernate.HibernateBundle;
 import io.dropwizard.hibernate.UnitOfWorkAwareProxyFactory;
-import io.dropwizard.setup.Environment;
+import io.dropwizard.core.setup.Environment;
 import org.apache.http.client.config.CookieSpecs;
 import org.apache.http.client.config.RequestConfig;
 import org.apache.http.conn.ssl.SSLConnectionSocketFactory;

--- a/src/main/java/uk/gov/pay/webhooks/deliveryqueue/managed/SendAttempter.java
+++ b/src/main/java/uk/gov/pay/webhooks/deliveryqueue/managed/SendAttempter.java
@@ -1,7 +1,7 @@
 package uk.gov.pay.webhooks.deliveryqueue.managed;
 
 import com.codahale.metrics.MetricRegistry;
-import io.dropwizard.setup.Environment;
+import io.dropwizard.core.setup.Environment;
 import net.logstash.logback.marker.LogstashMarker;
 import net.logstash.logback.marker.Markers;
 import org.apache.http.NoHttpResponseException;

--- a/src/main/java/uk/gov/pay/webhooks/deliveryqueue/managed/WebhookMessageSendingQueueProcessor.java
+++ b/src/main/java/uk/gov/pay/webhooks/deliveryqueue/managed/WebhookMessageSendingQueueProcessor.java
@@ -2,7 +2,7 @@ package uk.gov.pay.webhooks.deliveryqueue.managed;
 
 import io.dropwizard.hibernate.UnitOfWorkAwareProxyFactory;
 import io.dropwizard.lifecycle.Managed;
-import io.dropwizard.setup.Environment;
+import io.dropwizard.core.setup.Environment;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;

--- a/src/main/java/uk/gov/pay/webhooks/healthcheck/HealthCheckResource.java
+++ b/src/main/java/uk/gov/pay/webhooks/healthcheck/HealthCheckResource.java
@@ -2,7 +2,7 @@ package uk.gov.pay.webhooks.healthcheck;
 
 import com.codahale.metrics.health.HealthCheck;
 import com.google.common.collect.ImmutableMap;
-import io.dropwizard.setup.Environment;
+import io.dropwizard.core.setup.Environment;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -21,8 +21,6 @@ import java.util.SortedMap;
 import java.util.stream.Collectors;
 
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
-import static javax.ws.rs.core.Response.Status.OK;
-import static javax.ws.rs.core.Response.Status.SERVICE_UNAVAILABLE;
 import static org.apache.commons.lang3.StringUtils.defaultString;
 
 @Path("/")

--- a/src/main/java/uk/gov/pay/webhooks/queue/QueueMessageReceiver.java
+++ b/src/main/java/uk/gov/pay/webhooks/queue/QueueMessageReceiver.java
@@ -3,7 +3,7 @@ package uk.gov.pay.webhooks.queue;
 import com.google.inject.Inject;
 import io.dropwizard.hibernate.UnitOfWorkAwareProxyFactory;
 import io.dropwizard.lifecycle.Managed;
-import io.dropwizard.setup.Environment;
+import io.dropwizard.core.setup.Environment;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;

--- a/src/test/java/uk/gov/pay/webhooks/deliveryqueue/managed/SendAttempterTest.java
+++ b/src/test/java/uk/gov/pay/webhooks/deliveryqueue/managed/SendAttempterTest.java
@@ -1,7 +1,7 @@
 package uk.gov.pay.webhooks.deliveryqueue.managed;
 
 import com.codahale.metrics.MetricRegistry;
-import io.dropwizard.setup.Environment;
+import io.dropwizard.core.setup.Environment;
 import io.dropwizard.testing.junit5.DAOTestExtension;
 import io.dropwizard.testing.junit5.DropwizardExtensionsSupport;
 import org.apache.http.StatusLine;

--- a/src/test/java/uk/gov/pay/webhooks/deliveryqueue/managed/WebhookMessagePollingServiceTest.java
+++ b/src/test/java/uk/gov/pay/webhooks/deliveryqueue/managed/WebhookMessagePollingServiceTest.java
@@ -2,7 +2,7 @@ package uk.gov.pay.webhooks.deliveryqueue.managed;
 
 import com.codahale.metrics.MetricRegistry;
 import io.dropwizard.hibernate.UnitOfWorkAwareProxyFactory;
-import io.dropwizard.setup.Environment;
+import io.dropwizard.core.setup.Environment;
 import io.dropwizard.testing.junit5.DAOTestExtension;
 import io.dropwizard.testing.junit5.DropwizardExtensionsSupport;
 import org.apache.http.StatusLine;

--- a/src/test/java/uk/gov/pay/webhooks/ledger/LedgerStub.java
+++ b/src/test/java/uk/gov/pay/webhooks/ledger/LedgerStub.java
@@ -1,21 +1,27 @@
 package uk.gov.pay.webhooks.ledger;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
-import static com.github.tomakehurst.wiremock.client.ResponseDefinitionBuilder.okForJson;
+import static com.github.tomakehurst.wiremock.client.WireMock.okForContentType;
+import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 
 public class LedgerStub {
     private final WireMockExtension wireMock;
+    private final ObjectMapper objectMapper = new ObjectMapper();
 
     public LedgerStub(WireMockExtension wireMock) {
         this.wireMock = wireMock;
     }
 
-    public void returnLedgerTransaction(TransactionFromLedgerFixture transaction) {
+    public void returnLedgerTransaction(TransactionFromLedgerFixture transaction) throws JsonProcessingException {
+        // Construct the JSON ourselves because the standalone WireMock’s okForJson(…) does not
+        // use our Jackson configuration (e.g. PropertyNamingStrategies.SnakeCaseStrategy)
+        var json = objectMapper.writeValueAsString(transaction);
+        var response = okForContentType(APPLICATION_JSON, json);
         var request = get("/v1/transaction/" + transaction.getTransactionId() + "?override_account_id_restriction=true");
-        var response = okForJson(transaction);
         wireMock.stubFor(request.willReturn(response));
     }
 }


### PR DESCRIPTION
- Upgrade Dropwizard to v3 latest.

- Use dropwizard-dependencies BOM, which removes the need to pull in some dependencies ourselves (this does make us use slightly older versions of Liquibase and Mockito but the newer contain no security fixes and we’ve used the older ones before so this should be fine.

- Dropwizard uses Jetty 10, which conflicts with WireMock, which requires Jetty 9. Fortunately, WireMock has a standalone version that includes all its dependencies. Unfortunately, the standalone version will not use our Jackson configuration, so we need to change to the way we generate some JSON for tests.

- Add JUnit Vintage so that the Pact tests, which use JUnit 4, run.

with @alexbishop1