### PR TITLE
BAU — Small tweaks to POM and Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,9 @@ updates:
       - dependency-name: "io.dropwizard:dropwizard-dependencies"
         versions:
           - ">= 4"
+      - dependency-name: "com.google.inject:guice-bom"
+        versions:
+          - ">= 7"
     open-pull-requests-limit: 10
     labels:
       - dependencies

--- a/pom.xml
+++ b/pom.xml
@@ -58,6 +58,13 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
+            <dependency>
+                <groupId>org.testcontainers</groupId>
+                <artifactId>testcontainers-bom</artifactId>
+                <version>1.19.0</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 
@@ -196,6 +203,11 @@
             <artifactId>mockito-junit-jupiter</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>postgresql</artifactId>
+            <scope>test</scope>
+        </dependency>
 
         <!-- Test dependencies that need explicit versions -->
         <dependency>
@@ -208,12 +220,6 @@
             <groupId>io.rest-assured</groupId>
             <artifactId>rest-assured</artifactId>
             <version>5.3.2</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.testcontainers</groupId>
-            <artifactId>postgresql</artifactId>
-            <version>1.19.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
- Use Testcontainers BOM
- Tell Dependabot not to try to upgrade us to Guice 7.0.0, which migrates from Java EE to Jakarta EE and is never going to be a just-merge-it upgrade