### PR TITLE
PP 10972 refactor adhoc test sql database test helper

### DIFF
--- a/src/test/java/uk/gov/pay/webhooks/deliveryqueue/WebhookDeliveryQueueIT.java
+++ b/src/test/java/uk/gov/pay/webhooks/deliveryqueue/WebhookDeliveryQueueIT.java
@@ -50,7 +50,8 @@ public class WebhookDeliveryQueueIT {
     public void webhookMessageIsEmittedForSubscribedWebhook() throws IOException, InterruptedException {
         var serviceExternalId = "a-valid-service-id";
         var gatewayAccountId = "100";
-        dbHelper.addWebhookWithSubscription("a-valid-webhook-id", serviceExternalId, "http://localhost:%d/a-test-endpoint".formatted(app.getWireMockPort()), gatewayAccountId);
+        dbHelper.addWebhook("a-valid-webhook-id", serviceExternalId, "http://localhost:%d/a-test-endpoint".formatted(app.getWireMockPort()), gatewayAccountId);
+        dbHelper.addWebhookSubscription();
         var transaction = aTransactionFromLedgerFixture();
         var sqsMessage = anSNSToSQSEventFixture()
                 .withBody(Map.of(
@@ -87,8 +88,8 @@ public class WebhookDeliveryQueueIT {
     public void webhookMessageIsEmittedForSubscribedWebhook_forChildPaymentEvents() throws IOException, InterruptedException {
         var serviceExternalId = "a-valid-service-id";
         var gatewayAccountId = "100";
-        dbHelper.addWebhookWithSubscription("a-valid-webhook-id", serviceExternalId, "http://localhost:%d/a-test-endpoint".formatted(app.getWireMockPort()), gatewayAccountId);
-
+        dbHelper.addWebhook("a-valid-webhook-id", serviceExternalId, "http://localhost:%d/a-test-endpoint".formatted(app.getWireMockPort()), gatewayAccountId);
+        dbHelper.addWebhookSubscription();
         var transaction = aTransactionFromLedgerFixture();
         var sqsMessage = anSNSToSQSEventFixture()
                 .withBody(Map.of(

--- a/src/test/java/uk/gov/pay/webhooks/deliveryqueue/WebhookDeliveryQueueIT.java
+++ b/src/test/java/uk/gov/pay/webhooks/deliveryqueue/WebhookDeliveryQueueIT.java
@@ -29,7 +29,6 @@ import static org.hamcrest.CoreMatchers.is;
 import static uk.gov.pay.webhooks.ledger.TransactionFromLedgerFixture.aTransactionFromLedgerFixture;
 import static uk.gov.pay.webhooks.util.SNSToSQSEventFixture.anSNSToSQSEventFixture;
 
-
 public class WebhookDeliveryQueueIT {
     private static final int webhookCallbackEndpointStubPort = PortFactory.findFreePort();
     @RegisterExtension
@@ -122,11 +121,8 @@ public class WebhookDeliveryQueueIT {
     public void webhookMessageLastDeliveryStatusIsConsistent() throws InterruptedException, IOException {
         var serviceExternalId = "a-valid-service-id";
         var gatewayAccountId = "100";
-        app.getJdbi().withHandle(h -> h.execute("INSERT INTO webhooks VALUES (1, '2022-01-01', 'webhook-external-id-succeeds', 'signing-key', '%s', false, 'http://localhost:%d/a-working-endpoint', 'description', 'ACTIVE', '%s')".formatted(serviceExternalId, app.getWireMockPort(), gatewayAccountId)));
-        app.getJdbi().withHandle(h -> h.execute("INSERT INTO webhooks VALUES (2, '2022-01-01', 'webhook-external-id-fails', 'signing-key', '%s', false, 'http://localhost:%d/a-failing-endpoint', 'description', 'ACTIVE', '%s')".formatted(serviceExternalId, app.getWireMockPort(), gatewayAccountId)));
-        app.getJdbi().withHandle(h -> h.execute("INSERT INTO webhook_subscriptions VALUES (1, (SELECT id FROM event_types WHERE name = 'card_payment_succeeded'))"));
-        app.getJdbi().withHandle(h -> h.execute("INSERT INTO webhook_subscriptions VALUES (2, (SELECT id FROM event_types WHERE name = 'card_payment_succeeded'))"));
-
+        dbHelper.addWebhookMessageLastDeliveryStatusIsConsistent(serviceExternalId,gatewayAccountId,app.getWireMockPort());
+        
         var transaction = aTransactionFromLedgerFixture();
         var sqsMessage = anSNSToSQSEventFixture()
                 .withBody(Map.of(

--- a/src/test/java/uk/gov/pay/webhooks/deliveryqueue/WebhookDeliveryQueueIT.java
+++ b/src/test/java/uk/gov/pay/webhooks/deliveryqueue/WebhookDeliveryQueueIT.java
@@ -43,7 +43,7 @@ public class WebhookDeliveryQueueIT {
     @BeforeEach
     public void setUp() {
         dbHelper = DatabaseTestHelper.aDatabaseTestHelper(app.getJdbi());
-        dbHelper.truncateAllData();
+        dbHelper.truncateAllWebhooksData();
     }
 
     @Test
@@ -122,6 +122,7 @@ public class WebhookDeliveryQueueIT {
         var serviceExternalId = "a-valid-service-id";
         var gatewayAccountId = "100";
         dbHelper.addWebhookMessageLastDeliveryStatusIsConsistent(serviceExternalId,gatewayAccountId,app.getWireMockPort());
+        dbHelper.addWebhookSubscriptionsMessageLastDeliveryStatusIsConsistent();
         
         var transaction = aTransactionFromLedgerFixture();
         var sqsMessage = anSNSToSQSEventFixture()

--- a/src/test/java/uk/gov/pay/webhooks/deliveryqueue/WebhookDeliveryQueueStatusIT.java
+++ b/src/test/java/uk/gov/pay/webhooks/deliveryqueue/WebhookDeliveryQueueStatusIT.java
@@ -7,6 +7,8 @@ import org.junit.jupiter.params.provider.EnumSource;
 import uk.gov.pay.extension.AppWithPostgresAndSqsExtension;
 import uk.gov.pay.webhooks.util.DatabaseTestHelper;
 
+import java.util.Optional;
+
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
 
@@ -24,8 +26,8 @@ public class WebhookDeliveryQueueStatusIT {
     @ParameterizedTest
     @EnumSource(value = DeliveryStatus.class)
     public void deliveryStatusEnumIsConsistentWithDatabase(DeliveryStatus status) {
-        dbHelper.addWebhooksDeliveryStatusEnumIsConsistentWithDatabase();
-        dbHelper.addWebhookMessagesDeliveryStatusEnumIsConsistentWithDatabase();
-        assertDoesNotThrow(() -> dbHelper.addWebhookDeliveryStatusQueueEnumIsConsistentWithDatabase(status));
+        dbHelper.addWebhook();
+        dbHelper.addWebhookMessagesDeliveryStatusEnumIsConsistent(Optional.empty());
+        assertDoesNotThrow(() -> dbHelper.addWebhookDeliveryQueueStatusEnumIsConsistentWithDatabase(status));
     }
 }

--- a/src/test/java/uk/gov/pay/webhooks/deliveryqueue/WebhookDeliveryQueueStatusIT.java
+++ b/src/test/java/uk/gov/pay/webhooks/deliveryqueue/WebhookDeliveryQueueStatusIT.java
@@ -24,8 +24,7 @@ public class WebhookDeliveryQueueStatusIT {
     @ParameterizedTest
     @EnumSource(value = DeliveryStatus.class)
     public void deliveryStatusEnumIsConsistentWithDatabase(DeliveryStatus status) {
-        app.getJdbi().withHandle(h -> h.execute("INSERT INTO webhooks VALUES (1, '2022-01-01', 'webhook-external-id', 'signing-key', 'service-id', true, 'https://callback-url.test', 'description', 'ACTIVE')"));
-        app.getJdbi().withHandle(h -> h.execute("INSERT INTO webhook_messages VALUES (1, 'message-external-id', '2022-01-01', 1, '2022-01-01', 1, '{}', 'transaction-external-id', 'payment')"));
-        assertDoesNotThrow(() -> app.getJdbi().withHandle(h -> h.execute("INSERT INTO webhook_delivery_queue VALUES (1, '2022-01-01', '2022-01-01', '200', 200, 1, '%s', 1250)".formatted(status))));
+        dbHelper.addDeliveryStatusEnumIsConsistentWithDatabase();
+        assertDoesNotThrow(() -> dbHelper.executeSql("INSERT INTO webhook_delivery_queue VALUES (1, '2022-01-01', '2022-01-01', '200', 200, 1, '%s', 1250)".formatted(status)));
     }
 }

--- a/src/test/java/uk/gov/pay/webhooks/deliveryqueue/WebhookDeliveryQueueStatusIT.java
+++ b/src/test/java/uk/gov/pay/webhooks/deliveryqueue/WebhookDeliveryQueueStatusIT.java
@@ -18,13 +18,14 @@ public class WebhookDeliveryQueueStatusIT {
     @BeforeEach
     public void setUp() {
         dbHelper = DatabaseTestHelper.aDatabaseTestHelper(app.getJdbi());
-        dbHelper.truncateAllData();
+        dbHelper.truncateAllWebhooksData();
     }
 
     @ParameterizedTest
     @EnumSource(value = DeliveryStatus.class)
     public void deliveryStatusEnumIsConsistentWithDatabase(DeliveryStatus status) {
-        dbHelper.addDeliveryStatusEnumIsConsistentWithDatabase();
-        assertDoesNotThrow(() -> dbHelper.addDeliveryStatusEnumIsConsistentWithDatabaseWebHookDeliveryQueueInsert(status));
+        dbHelper.addWebhooksDeliveryStatusEnumIsConsistentWithDatabase();
+        dbHelper.addWebhookMessagesDeliveryStatusEnumIsConsistentWithDatabase();
+        assertDoesNotThrow(() -> dbHelper.addWebhookDeliveryStatusQueueEnumIsConsistentWithDatabase(status));
     }
 }

--- a/src/test/java/uk/gov/pay/webhooks/deliveryqueue/WebhookDeliveryQueueStatusIT.java
+++ b/src/test/java/uk/gov/pay/webhooks/deliveryqueue/WebhookDeliveryQueueStatusIT.java
@@ -25,6 +25,6 @@ public class WebhookDeliveryQueueStatusIT {
     @EnumSource(value = DeliveryStatus.class)
     public void deliveryStatusEnumIsConsistentWithDatabase(DeliveryStatus status) {
         dbHelper.addDeliveryStatusEnumIsConsistentWithDatabase();
-        assertDoesNotThrow(() -> dbHelper.executeSql("INSERT INTO webhook_delivery_queue VALUES (1, '2022-01-01', '2022-01-01', '200', 200, 1, '%s', 1250)".formatted(status)));
+        assertDoesNotThrow(() -> dbHelper.addDeliveryStatusEnumIsConsistentWithDatabaseWebHookDeliveryQueueInsert(status));
     }
 }

--- a/src/test/java/uk/gov/pay/webhooks/healthcheck/HealthCheckResourceIT.java
+++ b/src/test/java/uk/gov/pay/webhooks/healthcheck/HealthCheckResourceIT.java
@@ -6,7 +6,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import uk.gov.pay.extension.AppWithPostgresAndSqsExtension;
 import uk.gov.pay.rule.PostgresTestDocker;
-import uk.gov.pay.rule.SqsTestDocker;
 
 import static org.hamcrest.Matchers.equalTo;
 

--- a/src/test/java/uk/gov/pay/webhooks/ledger/pact/LedgerServiceConsumerTest.java
+++ b/src/test/java/uk/gov/pay/webhooks/ledger/pact/LedgerServiceConsumerTest.java
@@ -14,12 +14,8 @@ import uk.gov.pay.webhooks.ledger.LedgerService;
 import uk.gov.pay.webhooks.ledger.model.LedgerTransaction;
 import uk.gov.service.payments.commons.testing.pact.consumers.PactProviderRule;
 import uk.gov.service.payments.commons.testing.pact.consumers.Pacts;
-import uk.gov.service.payments.logging.RestClientLoggingFilter;
 
-import javax.ws.rs.client.Client;
-import javax.ws.rs.client.ClientBuilder;
 import java.util.Optional;
-import java.util.concurrent.TimeUnit;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;

--- a/src/test/java/uk/gov/pay/webhooks/message/WebhookMessageIT.java
+++ b/src/test/java/uk/gov/pay/webhooks/message/WebhookMessageIT.java
@@ -25,7 +25,7 @@ public class WebhookMessageIT {
     @ParameterizedTest
     @EnumSource(value = DeliveryStatus.class)
     public void deliveryStatusEnumIsConsistentWithWebhookMessageLastDeliveryStatus(DeliveryStatus status) {
-        app.getJdbi().withHandle(h -> h.execute("INSERT INTO webhooks VALUES (1, '2022-01-01', 'webhook-external-id', 'signing-key', 'service-id', true, 'https://callback-url.test', 'description', 'ACTIVE')"));
-        assertDoesNotThrow(() -> app.getJdbi().withHandle(h -> h.execute("INSERT INTO webhook_messages VALUES (1, 'message-external-id', '2022-01-01', 1, '2022-01-01', 1, '{}', 'transaction-external-id', 'payment', '%s')".formatted(status))));
+        dbHelper.executeSql("INSERT INTO webhooks VALUES (1, '2022-01-01', 'webhook-external-id', 'signing-key', 'service-id', true, 'https://callback-url.test', 'description', 'ACTIVE')");
+        assertDoesNotThrow(() -> dbHelper.executeSql("INSERT INTO webhook_messages VALUES (1, 'message-external-id', '2022-01-01', 1, '2022-01-01', 1, '{}', 'transaction-external-id', 'payment', '%s')".formatted(status)));
     }
 }

--- a/src/test/java/uk/gov/pay/webhooks/message/WebhookMessageIT.java
+++ b/src/test/java/uk/gov/pay/webhooks/message/WebhookMessageIT.java
@@ -25,7 +25,7 @@ public class WebhookMessageIT {
     @ParameterizedTest
     @EnumSource(value = DeliveryStatus.class)
     public void deliveryStatusEnumIsConsistentWithWebhookMessageLastDeliveryStatus(DeliveryStatus status) {
-        dbHelper.executeSql("INSERT INTO webhooks VALUES (1, '2022-01-01', 'webhook-external-id', 'signing-key', 'service-id', true, 'https://callback-url.test', 'description', 'ACTIVE')");
-        assertDoesNotThrow(() -> dbHelper.executeSql("INSERT INTO webhook_messages VALUES (1, 'message-external-id', '2022-01-01', 1, '2022-01-01', 1, '{}', 'transaction-external-id', 'payment', '%s')".formatted(status)));
+        dbHelper.deliveryStatusEnumIsConsistentWithWebhookMessageLastDeliveryStatusWebHooksInsert();
+        assertDoesNotThrow(() -> dbHelper.deliveryStatusEnumIsConsistentWithWebhookMessageLastDeliveryStatusMessagesInsert(status));
     }
 }

--- a/src/test/java/uk/gov/pay/webhooks/message/WebhookMessageIT.java
+++ b/src/test/java/uk/gov/pay/webhooks/message/WebhookMessageIT.java
@@ -19,13 +19,13 @@ public class WebhookMessageIT {
     @BeforeEach
     public void setUp() {
         dbHelper = DatabaseTestHelper.aDatabaseTestHelper(app.getJdbi());
-        dbHelper.truncateAllData();
+        dbHelper.truncateAllWebhooksData();
     }
 
     @ParameterizedTest
     @EnumSource(value = DeliveryStatus.class)
     public void deliveryStatusEnumIsConsistentWithWebhookMessageLastDeliveryStatus(DeliveryStatus status) {
-        dbHelper.deliveryStatusEnumIsConsistentWithWebhookMessageLastDeliveryStatusWebHooksInsert();
-        assertDoesNotThrow(() -> dbHelper.deliveryStatusEnumIsConsistentWithWebhookMessageLastDeliveryStatusMessagesInsert(status));
+        dbHelper.addWebhooksDeliveryStatusEnumIsConsistentWithWebhookMessageLast();
+        assertDoesNotThrow(() -> dbHelper.addWebhookMessagesDeliveryStatusEnumIsConsistent(status));
     }
 }

--- a/src/test/java/uk/gov/pay/webhooks/message/WebhookMessageIT.java
+++ b/src/test/java/uk/gov/pay/webhooks/message/WebhookMessageIT.java
@@ -8,6 +8,8 @@ import uk.gov.pay.extension.AppWithPostgresAndSqsExtension;
 import uk.gov.pay.webhooks.deliveryqueue.DeliveryStatus;
 import uk.gov.pay.webhooks.util.DatabaseTestHelper;
 
+import java.util.Optional;
+
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
 
@@ -24,8 +26,8 @@ public class WebhookMessageIT {
 
     @ParameterizedTest
     @EnumSource(value = DeliveryStatus.class)
-    public void deliveryStatusEnumIsConsistentWithWebhookMessageLastDeliveryStatus(DeliveryStatus status) {
-        dbHelper.addWebhooksDeliveryStatusEnumIsConsistentWithWebhookMessageLast();
+    public void deliveryStatusEnumIsConsistentWithWebhookMessageLastDeliveryStatus(Optional<DeliveryStatus> status) {
+        dbHelper.addWebhook();
         assertDoesNotThrow(() -> dbHelper.addWebhookMessagesDeliveryStatusEnumIsConsistent(status));
     }
 }

--- a/src/test/java/uk/gov/pay/webhooks/message/WebhookMessageSenderTest.java
+++ b/src/test/java/uk/gov/pay/webhooks/message/WebhookMessageSenderTest.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.http.HttpResponse;
-import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpUriRequest;
 import org.apache.http.impl.client.CloseableHttpClient;

--- a/src/test/java/uk/gov/pay/webhooks/util/DatabaseTestHelper.java
+++ b/src/test/java/uk/gov/pay/webhooks/util/DatabaseTestHelper.java
@@ -13,6 +13,10 @@ public class DatabaseTestHelper {
     public static DatabaseTestHelper aDatabaseTestHelper(Jdbi jdbi) {
         return new DatabaseTestHelper(jdbi);
     }
+
+    public void executeSql(String sql) {
+        jdbi.withHandle(h -> h.execute(sql));
+    }
     
     public void addWebhookWithSubscription(String webhookExternalId, String serviceExternalId, String callbackUrl, String gatewayAccountId) {
         jdbi.withHandle(h -> h.execute("INSERT INTO webhooks VALUES (1, '2022-01-01', '%s', 'signing-key', '%s', false, '%s', 'description', 'ACTIVE', '%s')".formatted(webhookExternalId, serviceExternalId, callbackUrl, gatewayAccountId)));
@@ -20,6 +24,18 @@ public class DatabaseTestHelper {
         jdbi.withHandle(h -> h.execute("INSERT INTO webhook_subscriptions VALUES (1, (SELECT id FROM event_types WHERE name = 'card_payment_refunded'))"));
     }
 
+    public void addWebhookMessageLastDeliveryStatusIsConsistent(String serviceExternalId, String gatewayAccountId, int wireMockPort) {
+        jdbi.withHandle(h -> h.execute("INSERT INTO webhooks VALUES (1, '2022-01-01', 'webhook-external-id-succeeds', 'signing-key', '%s', false, 'http://localhost:%d/a-working-endpoint', 'description', 'ACTIVE', '%s')".formatted(serviceExternalId, wireMockPort, gatewayAccountId)));
+        jdbi.withHandle(h -> h.execute("INSERT INTO webhooks VALUES (2, '2022-01-01', 'webhook-external-id-fails', 'signing-key', '%s', false, 'http://localhost:%d/a-failing-endpoint', 'description', 'ACTIVE', '%s')".formatted(serviceExternalId, wireMockPort, gatewayAccountId)));
+        jdbi.withHandle(h -> h.execute("INSERT INTO webhook_subscriptions VALUES (1, (SELECT id FROM event_types WHERE name = 'card_payment_succeeded'))"));
+        jdbi.withHandle(h -> h.execute("INSERT INTO webhook_subscriptions VALUES (2, (SELECT id FROM event_types WHERE name = 'card_payment_succeeded'))"));
+    }
+
+    public void addDeliveryStatusEnumIsConsistentWithDatabase() {
+        jdbi.withHandle(h -> h.execute("INSERT INTO webhooks VALUES (1, '2022-01-01', 'webhook-external-id', 'signing-key', 'service-id', true, 'https://callback-url.test', 'description', 'ACTIVE')"));
+        jdbi.withHandle(h -> h.execute("INSERT INTO webhook_messages VALUES (1, 'message-external-id', '2022-01-01', 1, '2022-01-01', 1, '{}', 'transaction-external-id', 'payment')"));
+    }
+    
     public void truncateAllData() {
         jdbi.withHandle(h -> h.createScript(
                 "TRUNCATE TABLE webhooks CASCADE; "

--- a/src/test/java/uk/gov/pay/webhooks/util/DatabaseTestHelper.java
+++ b/src/test/java/uk/gov/pay/webhooks/util/DatabaseTestHelper.java
@@ -1,9 +1,14 @@
 package uk.gov.pay.webhooks.util;
 
 import org.jdbi.v3.core.Jdbi;
+import uk.gov.pay.webhooks.deliveryqueue.DeliveryStatus;
+
+import java.util.List;
 
 public class DatabaseTestHelper {
 
+    public static final String EVENT_TYPE_SELECT_QUERY_CARD_PAYMENT_SUCCEEDED = "SELECT id FROM event_types WHERE name = 'card_payment_succeeded'";
+    public static final String EVENT_TYPE_SELECT_QUERY_CARD_PAYMENT_REFUNDED = "SELECT id FROM event_types WHERE name = 'card_payment_refunded'";
     private Jdbi jdbi;
 
     private DatabaseTestHelper(Jdbi jdbi) {
@@ -13,33 +18,157 @@ public class DatabaseTestHelper {
     public static DatabaseTestHelper aDatabaseTestHelper(Jdbi jdbi) {
         return new DatabaseTestHelper(jdbi);
     }
-
-    public void executeSql(String sql) {
-        jdbi.withHandle(h -> h.execute(sql));
-    }
     
     public void addWebhookWithSubscription(String webhookExternalId, String serviceExternalId, String callbackUrl, String gatewayAccountId) {
         jdbi.withHandle(h -> h.execute("INSERT INTO webhooks VALUES (1, '2022-01-01', '%s', 'signing-key', '%s', false, '%s', 'description', 'ACTIVE', '%s')".formatted(webhookExternalId, serviceExternalId, callbackUrl, gatewayAccountId)));
-        jdbi.withHandle(h -> h.execute("INSERT INTO webhook_subscriptions VALUES (1, (SELECT id FROM event_types WHERE name = 'card_payment_succeeded'))"));
-        jdbi.withHandle(h -> h.execute("INSERT INTO webhook_subscriptions VALUES (1, (SELECT id FROM event_types WHERE name = 'card_payment_refunded'))"));
+        jdbi.withHandle(h -> h.execute("INSERT INTO webhook_subscriptions VALUES (1, (" + EVENT_TYPE_SELECT_QUERY_CARD_PAYMENT_SUCCEEDED + "))"));
+        jdbi.withHandle(h -> h.execute("INSERT INTO webhook_subscriptions VALUES (1, (" + EVENT_TYPE_SELECT_QUERY_CARD_PAYMENT_REFUNDED + "))"));
     }
 
     public void addWebhookMessageLastDeliveryStatusIsConsistent(String serviceExternalId, String gatewayAccountId, int wireMockPort) {
         jdbi.withHandle(h -> h.execute("INSERT INTO webhooks VALUES (1, '2022-01-01', 'webhook-external-id-succeeds', 'signing-key', '%s', false, 'http://localhost:%d/a-working-endpoint', 'description', 'ACTIVE', '%s')".formatted(serviceExternalId, wireMockPort, gatewayAccountId)));
         jdbi.withHandle(h -> h.execute("INSERT INTO webhooks VALUES (2, '2022-01-01', 'webhook-external-id-fails', 'signing-key', '%s', false, 'http://localhost:%d/a-failing-endpoint', 'description', 'ACTIVE', '%s')".formatted(serviceExternalId, wireMockPort, gatewayAccountId)));
-        jdbi.withHandle(h -> h.execute("INSERT INTO webhook_subscriptions VALUES (1, (SELECT id FROM event_types WHERE name = 'card_payment_succeeded'))"));
-        jdbi.withHandle(h -> h.execute("INSERT INTO webhook_subscriptions VALUES (2, (SELECT id FROM event_types WHERE name = 'card_payment_succeeded'))"));
+        jdbi.withHandle(h -> h.execute("INSERT INTO webhook_subscriptions VALUES (1, (" + EVENT_TYPE_SELECT_QUERY_CARD_PAYMENT_SUCCEEDED + "))"));
+        jdbi.withHandle(h -> h.execute("INSERT INTO webhook_subscriptions VALUES (2, (" + EVENT_TYPE_SELECT_QUERY_CARD_PAYMENT_SUCCEEDED + "))"));
     }
 
     public void addDeliveryStatusEnumIsConsistentWithDatabase() {
         jdbi.withHandle(h -> h.execute("INSERT INTO webhooks VALUES (1, '2022-01-01', 'webhook-external-id', 'signing-key', 'service-id', true, 'https://callback-url.test', 'description', 'ACTIVE')"));
         jdbi.withHandle(h -> h.execute("INSERT INTO webhook_messages VALUES (1, 'message-external-id', '2022-01-01', 1, '2022-01-01', 1, '{}', 'transaction-external-id', 'payment')"));
     }
-    
+
+    public void addDeliveryStatusEnumIsConsistentWithDatabaseWebHookDeliveryQueueInsert(DeliveryStatus status) {
+        jdbi.withHandle(h -> h.execute("INSERT INTO webhook_delivery_queue VALUES (1, '2022-01-01', '2022-01-01', '200', 200, 1, '%s', 1250)".formatted(status)));
+    }
+
+    public void deliveryStatusEnumIsConsistentWithWebhookMessageLastDeliveryStatusWebHooksInsert() {
+        jdbi.withHandle(h -> h.execute("INSERT INTO webhooks VALUES (1, '2022-01-01', 'webhook-external-id', 'signing-key', 'service-id', true, 'https://callback-url.test', 'description', 'ACTIVE')"));
+    }
+
+    public void deliveryStatusEnumIsConsistentWithWebhookMessageLastDeliveryStatusMessagesInsert(DeliveryStatus status) {
+        jdbi.withHandle(h -> h.execute("INSERT INTO webhook_messages VALUES (1, 'message-external-id', '2022-01-01', 1, '2022-01-01', 1, '{}', 'transaction-external-id', 'payment', '%s')".formatted(status)));
+    }
+
     public void truncateAllData() {
         jdbi.withHandle(h -> h.createScript(
                 "TRUNCATE TABLE webhooks CASCADE; "
         ).execute());
     }
-    
+
+    public void shouldReturnAndCountEmptyMessagesWebhooksInsert(String externalId) {
+        jdbi.withHandle(h -> h.execute("INSERT INTO webhooks VALUES (1, '2022-01-01', '%s', 'signing-key', 'service-id', true, 'http://callback-url.com', 'description', 'ACTIVE')".formatted(externalId)));
+    }
+
+    public void setupThreeWebhookMessagesThatShouldNotBeDeletedWebhookMessagesInsert(List<String> webhookMessageExternalIds, String date) {
+        jdbi.withHandle(h -> h.execute("""
+                    INSERT INTO webhook_messages VALUES
+                    (13, '%s', '%s', 1, '%s', 1, '{}', 'transaction-external-id', 'payment', 'FAILED'),
+                    (14, '%s', '%s', 1, '%s', 1, '{}', null, null, null),
+                    (15, '%s', '%s', 1, '%s', 1, '{}', null, null, null)
+                """.formatted(
+                webhookMessageExternalIds.get(0), date, date,
+                webhookMessageExternalIds.get(1), date, date,
+                webhookMessageExternalIds.get(2), date, date)
+        ));
+    }
+
+    public void setupThreeWebhookMessagesThatShouldNotBeDeletedWebhookDeliveryQueueInsert(String date) {
+        jdbi.withHandle(h -> h.execute("""
+                INSERT INTO webhook_delivery_queue VALUES
+                    (15, '%s', '%s', '200', 200, 13, 'SUCCESSFUL', 1250),
+                    (16, '%s', '%s', '404', 404, 14, 'FAILED', 25),
+                    (17, '%s', '%s', null, null, 15, 'PENDING', null)
+                """.formatted(date, date, date, date, date, date)
+        ));
+    }
+
+    public void setupWebhookWithMessagesExpectedToBePartiallyDeletedWebhooksInsert(String externalId) {
+        jdbi.withHandle(h -> h.execute(
+                "INSERT INTO webhooks VALUES (1, '2022-01-01', '%s', 'signing-key', 'service-id', true, 'http://callback-url.com', 'description', 'ACTIVE')".formatted(externalId)
+        ));
+    }
+
+    public void setupWebhookWithMessagesExpectedToBePartiallyDeletedWebhookMessagesInsert() {
+        jdbi.withHandle(h -> h.execute("""
+                    INSERT INTO webhook_messages VALUES
+                    (1, 'first-message-external-id', '2022-01-01', 1, '2022-01-01', 1, '{}', 'transaction-external-id', 'payment', 'FAILED'),
+                    (2, 'second-message-external-id', '2022-01-01', 1, '2022-01-01', 1, '{}', null, null, null),
+                    (3, 'third-message-external-id', '2022-01-01', 1, '2022-01-01', 1, '{}', null, null, null),
+                    (4, 'fourth-message-external-id', '2022-01-01', 1, '2022-01-01', 1, '{}', null, null, null),
+                    (5, 'fifth-message-external-id', '2022-01-01', 1, '2022-01-01', 1, '{}', null, null, null),
+                    (6, 'sixth-message-external-id', '2022-01-01', 1, '2022-01-01', 1, '{}', null, null, null),
+                    (7, 'seventh-message-external-id', '2022-01-01', 1, '2022-01-01', 1, '{}', null, null, null),
+                    (8, 'eighth-message-external-id', '2022-01-01', 1, '2022-01-01', 1, '{}', null, null, null),
+                    (9, 'ninth-message-external-id', '2022-01-01', 1, '2022-01-01', 1, '{}', null, null, null),
+                    (10, 'tenth-message-external-id', '2022-01-01', 1, '2022-01-01', 1, '{}', null, null, null),
+                    (11, 'eleventh-message-external-id', '2022-01-01', 1, '2022-01-01', 1, '{}', null, null, null)
+                """
+        ));
+    }
+
+    public void setupWebhookWithMessagesExpectedToBePartiallyDeletedWebhookDeliveryQueueInsert() {
+        jdbi.withHandle(h -> h.execute("""
+                INSERT INTO webhook_delivery_queue VALUES
+                    (1, '2022-01-01', '2022-01-01', '200', 200, 1, 'SUCCESSFUL', 1250),
+                    (2, '2022-01-02', '2022-01-01', '404', 404, 1, 'FAILED', 25),
+                    (3, '2022-01-02', '2022-01-01', null, null, 1, 'PENDING', null),
+                    (4, '2022-01-01', '2022-01-01', '404', 404, 2, 'PENDING', null),
+                    (5, '2022-01-01', '2022-01-01', '404', 404, 3, 'PENDING', null),
+                    (6, '2022-01-01', '2022-01-01', '404', 404, 4, 'PENDING', null),
+                    (7, '2022-01-01', '2022-01-01', '404', 404, 5, 'PENDING', null),
+                    (8, '2022-01-01', '2022-01-01', '404', 404, 6, 'PENDING', null),
+                    (9, '2022-01-01', '2022-01-01', '404', 404, 7, 'PENDING', null),
+                    (10, '2022-01-01', '2022-01-01', '404', 404, 8, 'PENDING', null),
+                    (11, '2022-01-01', '2022-01-01', '404', 404, 9, 'PENDING', null),
+                    (12, '2022-01-01', '2022-01-01', '404', 404, 10, 'PENDING', null),
+                    (13, '2022-01-01', '2022-01-01', '404', 404, 11, 'PENDING', null)
+                """
+        ));
+    }
+
+    public void setupWebhookWithMessagesWebHooksInsert(String externalId) {
+        jdbi.withHandle(h -> h.execute(
+                "INSERT INTO webhooks VALUES (1, '2022-01-01', '%s', 'signing-key', 'service-id', true, 'http://callback-url.com', 'description', 'ACTIVE', '100')".formatted(externalId)
+        ));
+    }
+
+    public void setupWebhookWithMessagesWebhookMessagesInsert(String messageExternalId) {
+        jdbi.withHandle(h -> h.execute("""
+                    INSERT INTO webhook_messages VALUES
+                    (1, '%s', '2022-01-01', 1, '2022-01-01', 1, '{}', 'transaction-external-id', 'payment', 'FAILED'),
+                    (2, 'second-message-external-id', '2022-01-01', 1, '2022-01-01', 1, '{}', 'transaction-external-id-2', 'payment', 'FAILED'),
+                    (3, 'third-message-external-id', '2022-01-01', 1, '2022-01-01', 1, '{}', null, null, null),
+                    (4, 'fourth-message-external-id', '2022-01-01', 1, '2022-01-01', 1, '{}', null, null, null),
+                    (5, 'fifth-message-external-id', '2022-01-01', 1, '2022-01-01', 1, '{}', null, null, null),
+                    (6, 'sixth-message-external-id', '2022-01-01', 1, '2022-01-01', 1, '{}', null, null, null),
+                    (7, 'seventh-message-external-id', '2022-01-01', 1, '2022-01-01', 1, '{}', null, null, null),
+                    (8, 'eighth-message-external-id', '2022-01-01', 1, '2022-01-01', 1, '{}', null, null, null),
+                    (9, 'ninth-message-external-id', '2022-01-01', 1, '2022-01-01', 1, '{}', null, null, null),
+                    (10, 'tenth-message-external-id', '2022-01-01', 1, '2022-01-01', 1, '{}', null, null, null),
+                    (11, 'eleventh-message-external-id', '2022-01-01', 1, '2022-01-01', 1, '{}', null, null, null),
+                    (12, 'twelfth-message-external-id', '2022-01-01', 1, '2022-01-01', 1, '{}', null, null, null)
+                """.formatted(messageExternalId)
+        ));
+    }
+
+    public void setupWebhookWithMessagesWebhookDeliveryQueueInsert() {
+        jdbi.withHandle(h -> h.execute("""
+                INSERT INTO webhook_delivery_queue VALUES
+                    (1, '2022-01-01', '2022-01-01', '200', 200, 1, 'SUCCESSFUL', 1250),
+                    (2, '2022-01-02', '2022-01-01', '404', 404, 1, 'FAILED', 25),
+                    (3, '2022-01-02', '2022-01-01', null, null, 1, 'PENDING', null),
+                    (4, '2022-01-01', '2022-01-01', '404', 404, 2, 'PENDING', null),
+                    (5, '2022-01-01', '2022-01-01', '404', 404, 3, 'PENDING', null),
+                    (6, '2022-01-01', '2022-01-01', '404', 404, 4, 'PENDING', null),
+                    (7, '2022-01-01', '2022-01-01', '404', 404, 5, 'PENDING', null),
+                    (8, '2022-01-01', '2022-01-01', '404', 404, 6, 'PENDING', null),
+                    (9, '2022-01-01', '2022-01-01', '404', 404, 7, 'PENDING', null),
+                    (10, '2022-01-01', '2022-01-01', '404', 404, 8, 'PENDING', null),
+                    (11, '2022-01-01', '2022-01-01', '404', 404, 9, 'PENDING', null),
+                    (12, '2022-01-01', '2022-01-01', '404', 404, 10, 'PENDING', null),
+                    (13, '2022-01-01', '2022-01-01', '404', 404, 11, 'PENDING', null),
+                    (14, '2022-01-01', '2022-01-01', '404', 404, 12, 'PENDING', null)
+                """
+        ));
+    }
 }

--- a/src/test/java/uk/gov/pay/webhooks/webhook/resource/WebhookListIT.java
+++ b/src/test/java/uk/gov/pay/webhooks/webhook/resource/WebhookListIT.java
@@ -28,7 +28,7 @@ public class WebhookListIT {
     @BeforeEach
     public void setUp() {
         dbHelper = DatabaseTestHelper.aDatabaseTestHelper(app.getJdbi());
-        dbHelper.truncateAllData();
+        dbHelper.truncateAllWebhooksData();
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/webhooks/webhook/resource/WebhookResourceIT.java
+++ b/src/test/java/uk/gov/pay/webhooks/webhook/resource/WebhookResourceIT.java
@@ -109,7 +109,7 @@ public class WebhookResourceIT {
     public void shouldReturnFilteredMessages() {
         var externalId = "awebhookexternalid";
         var messageExternalId = "message-external-id-1";
-        setupWebhookWithMessages(externalId, messageExternalId);
+        setupWebhookWithMessages(messageExternalId);
 
         given().port(port)
                 .contentType(JSON)
@@ -128,7 +128,7 @@ public class WebhookResourceIT {
     public void shouldReturnUnfilteredMessages() {
         var externalId = "awebhookexternalid";
         var messageExternalId = "message-external-id-1";
-        setupWebhookWithMessages(externalId, messageExternalId);
+        setupWebhookWithMessages(messageExternalId);
 
         given().port(port)
                 .contentType(JSON)
@@ -144,7 +144,7 @@ public class WebhookResourceIT {
     public void shouldReturnPage2OfMessages() {
         var externalId = "awebhookexternalid";
         var messageExternalId = "message-external-id-1";
-        setupWebhookWithMessages(externalId, messageExternalId);
+        setupWebhookWithMessages(messageExternalId);
 
         io.restassured.response.Response response = given().port(port)
                 .contentType(JSON)
@@ -170,7 +170,7 @@ public class WebhookResourceIT {
     @Test
     public void shouldReturnAndCountEmptyMessages() {
         var externalId = "a-valid-webhook-id";
-        dbHelper.addWebhooksForReturnAndCountEmptyMessages(externalId);
+        dbHelper.addWebhook();
         given().port(port)
                 .contentType(JSON)
                 .get("/v1/webhook/%s/message".formatted(externalId))
@@ -185,7 +185,7 @@ public class WebhookResourceIT {
     public void shouldReturnMessageAttempts() {
         var externalId = "awebhookexternalid";
         var messageExternalId = "message-external-id-1";
-        setupWebhookWithMessages(externalId, messageExternalId);
+        setupWebhookWithMessages(messageExternalId);
 
         given().port(port)
                 .contentType(JSON)
@@ -199,7 +199,7 @@ public class WebhookResourceIT {
     public void shouldReturnMessageDetail() {
         var externalId = "awebhookexternalid";
         var messageExternalId = "message-external-id-1";
-        setupWebhookWithMessages(externalId, messageExternalId);
+        setupWebhookWithMessages(messageExternalId);
 
         given().port(port)
                 .contentType(JSON)
@@ -218,7 +218,7 @@ public class WebhookResourceIT {
     public void shouldReturn404ForMessageNotFound() {
         var externalId = "awebhookexternalid";
         var messageExternalId = "message-external-id-1";
-        setupWebhookWithMessages(externalId, messageExternalId);
+        setupWebhookWithMessages(messageExternalId);
 
         given().port(port)
                 .contentType(JSON)
@@ -239,7 +239,7 @@ public class WebhookResourceIT {
     @Test
     public void shouldDeleteSomeWebhookMessages() {
         var webhookExternalId = "a-webhook-external-id";
-        WebhookMessageExternalIds webhookMessageExternalIds = setupWebhookWithMessagesExpectedToBePartiallyDeleted(webhookExternalId);
+        WebhookMessageExternalIds webhookMessageExternalIds = setupWebhookWithMessagesExpectedToBePartiallyDeleted();
         List<String> expectedWebhookExternalIdsNotDeleted = webhookMessageExternalIds.notDeleted;
         List<String> expectedWebhookMessageExternalIds = setupThreeWebhookMessagesThatShouldNotBeDeleted(); // maxAgeOfMessages=7 so these webhook messages should not be deleted
 
@@ -283,8 +283,8 @@ public class WebhookResourceIT {
         return webhookMessageExternalIds;
     }
 
-    private WebhookMessageExternalIds setupWebhookWithMessagesExpectedToBePartiallyDeleted(String externalId) {
-        dbHelper.addWebhookWithMessagesExpectedToBePartiallyDeleted(externalId);
+    private WebhookMessageExternalIds setupWebhookWithMessagesExpectedToBePartiallyDeleted() {
+        dbHelper.addWebhook();
         dbHelper.addWebhookMessagesExpectedToBePartiallyDeleted();
         dbHelper.addWebhookDeliveryQueueWithMessagesExpectedToBePartiallyDeleted();
         return new WebhookMessageExternalIds(
@@ -307,8 +307,8 @@ public class WebhookResourceIT {
                 """.formatted(isLive, callbackUrl);
     }
 
-    private void setupWebhookWithMessages(String externalId, String messageExternalId) {
-        dbHelper.addWebhook(externalId);
+    private void setupWebhookWithMessages(String messageExternalId) {
+        dbHelper.addWebhook();
         dbHelper.addWebhookMessages(messageExternalId);
         dbHelper.addWebhookDeliveryQueueWithMessages();
     }

--- a/src/test/java/uk/gov/pay/webhooks/webhook/resource/WebhookResourceIT.java
+++ b/src/test/java/uk/gov/pay/webhooks/webhook/resource/WebhookResourceIT.java
@@ -36,7 +36,7 @@ public class WebhookResourceIT {
     @BeforeEach
     public void setUp() {
         dbHelper = DatabaseTestHelper.aDatabaseTestHelper(app.getJdbi());
-        dbHelper.truncateAllData();
+        dbHelper.truncateAllWebhooksData();
     }
 
     @Test
@@ -170,7 +170,7 @@ public class WebhookResourceIT {
     @Test
     public void shouldReturnAndCountEmptyMessages() {
         var externalId = "a-valid-webhook-id";
-        dbHelper.shouldReturnAndCountEmptyMessagesWebhooksInsert(externalId);
+        dbHelper.addWebhooksForReturnAndCountEmptyMessages(externalId);
         given().port(port)
                 .contentType(JSON)
                 .get("/v1/webhook/%s/message".formatted(externalId))
@@ -278,15 +278,15 @@ public class WebhookResourceIT {
         DateFormat df = new SimpleDateFormat("yyyy-MM-dd");
         String date = df.format(Date.from(OffsetDateTime.now().minusDays(1).toInstant()));
         List<String> webhookMessageExternalIds = List.of("thirteenth-message-external-id", "fourteenth-message-external-id", "fifteenth-message-external-id");
-        dbHelper.setupThreeWebhookMessagesThatShouldNotBeDeletedWebhookMessagesInsert(webhookMessageExternalIds,date);
-        dbHelper.setupThreeWebhookMessagesThatShouldNotBeDeletedWebhookDeliveryQueueInsert(date);
+        dbHelper.addThreeWebhookMessagesThatShouldNotBeDeleted(webhookMessageExternalIds,date);
+        dbHelper.addThreeWebhookDeliveryQueueThatShouldNotBeDeleted(date);
         return webhookMessageExternalIds;
     }
 
     private WebhookMessageExternalIds setupWebhookWithMessagesExpectedToBePartiallyDeleted(String externalId) {
-        dbHelper.setupWebhookWithMessagesExpectedToBePartiallyDeletedWebhooksInsert(externalId);
-        dbHelper.setupWebhookWithMessagesExpectedToBePartiallyDeletedWebhookMessagesInsert();
-        dbHelper.setupWebhookWithMessagesExpectedToBePartiallyDeletedWebhookDeliveryQueueInsert();
+        dbHelper.addWebhookWithMessagesExpectedToBePartiallyDeleted(externalId);
+        dbHelper.addWebhookMessagesExpectedToBePartiallyDeleted();
+        dbHelper.addWebhookDeliveryQueueWithMessagesExpectedToBePartiallyDeleted();
         return new WebhookMessageExternalIds(
                 List.of("first-message-external-id", "second-message-external-id", "third-message-external-id", "fourth-message-external-id", "fifth-message-external-id", "sixth-message-external-id"),
                 List.of("seventh-message-external-id", "eighth-message-external-id", "ninth-message-external-id", "tenth-message-external-id", "eleventh-message-external-id")); // <-- Given maxNumOfMessagesToExpire=6, the webhook messages with these IDs won't be deleted
@@ -308,8 +308,8 @@ public class WebhookResourceIT {
     }
 
     private void setupWebhookWithMessages(String externalId, String messageExternalId) {
-        dbHelper.setupWebhookWithMessagesWebHooksInsert(externalId);
-        dbHelper.setupWebhookWithMessagesWebhookMessagesInsert(messageExternalId);
-        dbHelper.setupWebhookWithMessagesWebhookDeliveryQueueInsert();
+        dbHelper.addWebhook(externalId);
+        dbHelper.addWebhookMessages(messageExternalId);
+        dbHelper.addWebhookDeliveryQueueWithMessages();
     }
 }

--- a/src/test/java/uk/gov/pay/webhooks/webhook/resource/WebhookSigningKeyIT.java
+++ b/src/test/java/uk/gov/pay/webhooks/webhook/resource/WebhookSigningKeyIT.java
@@ -28,7 +28,7 @@ public class WebhookSigningKeyIT {
     @BeforeEach
     public void setUp() {
         dbHelper = DatabaseTestHelper.aDatabaseTestHelper(app.getJdbi());
-        dbHelper.truncateAllData();
+        dbHelper.truncateAllWebhooksData();
     }
     
     @Test

--- a/src/test/java/uk/gov/pay/webhooks/webhook/resource/WebhookUpdateIT.java
+++ b/src/test/java/uk/gov/pay/webhooks/webhook/resource/WebhookUpdateIT.java
@@ -27,7 +27,7 @@ public class WebhookUpdateIT {
     @BeforeEach
     public void setUp() {
         dbHelper = DatabaseTestHelper.aDatabaseTestHelper(app.getJdbi());
-        dbHelper.truncateAllData();
+        dbHelper.truncateAllWebhooksData();
     }
 
     @Test


### PR DESCRIPTION
### Description

There are a number of tests that write ad-hoc SQL (executed by JDBI taken from the running DropWizard instance) for setting up the environment. In a number of these tests the setup and entities created are shared. 

Identify any places this setup could be extracted into the DatabaseTestHelper (see https://github.com/alphagov/pay-webhooks/blob/main/src/test/java/uk/gov/pay/webhooks/util/DatabaseTestHelper.java#L5) and shared between different tests. This should allow future tests to make use of the same boilerplate code and focus on the logic under test.

The change also included the following:
- De-duplicating SQL statements and updating the code references
- Grouping methods referencing same database table together for ease of future rework . code maintenance
- Combining multiple database calls in a method into one call for performance of test execution
- Renaming method names to reflect the CRUD operation and associated table
- Primarily abstracting methods out of test classes to the DB Test Helper
- Rework of redundant test data or parameters logic
- Rename of misleading method names

### How to test
Review of code and comparison of previous version with current and running all impacted tests.