### PR TITLE
PP-12211: Run CodeQL on Java code only

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,10 +1,10 @@
 name: CodeQL
 
 on:
-  push:
-    branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
+    paths:
+      - 'src/**'
   schedule:
     # Weekly schedule
     - cron: '43 9 * * 6'


### PR DESCRIPTION
The CodeQL scans should now only run on changes to Java code (so e.g. it won't run on Docker image Dependabot PRs).

Also removes post-merge workflow trigger - this is probably overkill given we also have weekly scheduled scans.

