### PR TITLE
PP-12789 upgrade to pay-java-commons

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <mainClass>uk.gov.pay.webhooks.app.WebhooksApp</mainClass>
-        <pay-java-commons.version>1.0.20240603094506</pay-java-commons.version>
+        <pay-java-commons.version>1.0.20240711152628</pay-java-commons.version>
         <swagger-version>2.2.22</swagger-version>
         <pact.version>4.6.11</pact.version>
         <prometheus.version>0.16.0</prometheus.version>

--- a/src/test/java/uk/gov/pay/webhooks/ledger/pact/LedgerServiceConsumerTest.java
+++ b/src/test/java/uk/gov/pay/webhooks/ledger/pact/LedgerServiceConsumerTest.java
@@ -1,6 +1,6 @@
 package uk.gov.pay.webhooks.ledger.pact;
 
-import au.com.dius.pact.consumer.PactVerification;
+import au.com.dius.pact.consumer.junit.PactVerification;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -12,8 +12,8 @@ import uk.gov.pay.webhooks.app.InternalRestClientFactory;
 import uk.gov.pay.webhooks.app.WebhooksConfig;
 import uk.gov.pay.webhooks.ledger.LedgerService;
 import uk.gov.pay.webhooks.ledger.model.LedgerTransaction;
-import uk.gov.service.payments.commons.testing.pact.consumers.PactProviderRule;
 import uk.gov.service.payments.commons.testing.pact.consumers.Pacts;
+import uk.gov.service.payments.commons.testing.pact.consumers.PayPactProviderRule;
 
 import java.util.Optional;
 
@@ -25,7 +25,7 @@ import static org.mockito.Mockito.when;
 public class LedgerServiceConsumerTest {
 
     @Rule
-    public PactProviderRule ledgerRule = new PactProviderRule("ledger", this);
+    public PayPactProviderRule ledgerRule = new PayPactProviderRule("ledger", this);
 
     @Mock
     WebhooksConfig configuration;


### PR DESCRIPTION
`pay-java-commons` was upgraded to Java 21. Some of the imports needed update as they are transative dependencies.