### PR TITLE
PP-12244: Use shared workflow for CodeQL scanning

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -11,41 +11,12 @@ on:
     # Weekly schedule
     - cron: '43 9 * * 6'
 
+permissions:
+  security-events: write
+
 jobs:
   analyze:
-    name: Analyze
-    runs-on: 'ubuntu-latest'
-    timeout-minutes: 360
-    permissions:
-      # required for CodeQL to raise security issues on the repo
-      security-events: write
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab
-        with:
-          fetch-depth: '0'
-
-      # Initializes the CodeQL tools for scanning.
-      - name: Initialize CodeQL
-        uses: github/codeql-action/init@379614612a29c9e28f31f39a59013eb8012a51f0
-        with:
-          # CodeQL options: [ 'c-cpp', 'csharp', 'go', 'java-kotlin', 'javascript-typescript', 'python', 'ruby', 'swift' ]
-          languages: 'java-kotlin'
-          config: |
-            paths:
-              - 'src/**'
-
-      - name: Set up JDK 21
-        uses: actions/setup-java@5ffc13f4174014e2d4d4572b3d74c3fa61aeb2c2
-        with:
-          java-version: '21'
-          distribution: 'adopt'
-
-      - name: Compile project
-        run: mvn clean compile
-
-      - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@379614612a29c9e28f31f39a59013eb8012a51f0
-        with:
-          category: "/language:java-kotlin"
+    name: "Run CodeQL"
+    uses: alphagov/pay-ci/.github/workflows/_run-codeql-scan.yml@master
+    with:
+      is_java_repo: true


### PR DESCRIPTION
Part of the effort to remove duplicated workflow code across our app repositories. There is now a [shared workflow for CodeQL in the pay-ci repo](https://github.com/alphagov/pay-ci/pull/1321).

[This was tested before the CI branch was merged, by](https://github.com/alphagov/pay-webhooks/actions/runs/11481457620/job/31952175141?pr=1434):
- making a whitespace commit in the `src` folder to trigger the workflow
- pointing to the shared workflow in the branch instead of `@master`
- this commit has since been dropped from this branch