### PR TITLE
PP-13577 Add logging fields to Webhook request validation

### DIFF
--- a/src/main/java/uk/gov/pay/webhooks/validations/WebhookRequestValidator.java
+++ b/src/main/java/uk/gov/pay/webhooks/validations/WebhookRequestValidator.java
@@ -43,8 +43,11 @@ public class WebhookRequestValidator {
         MDC.put("gateway_account_id", createWebhookRequest.gatewayAccountId());
         MDC.put("service_id", createWebhookRequest.serviceId());
         MDC.put("live", createWebhookRequest.live().toString());
-        callbackUrlService.validateCallbackUrl(createWebhookRequest.callbackUrl(), createWebhookRequest.live());
-        MDC.clear();
+        try {
+            callbackUrlService.validateCallbackUrl(createWebhookRequest.callbackUrl(), createWebhookRequest.live());
+        } finally {
+            MDC.clear();
+        }
     }
 
     private JsonPatchRequestValidator validator(Boolean isLiveContext) {


### PR DESCRIPTION
- add logging of `gateway_account_id`, `servce_id` and `live` fields to log in Webhook request validation
- this will add these fields to logging of `Cannot set domains not found in the allow list` warnings

example logs:
```json
 {
  "@timestamp": "2025-02-20T11:49:47.035899375Z",
  "@version": "1",
  "message": "Cannot set domains not found in the allow list",
  "logger_name": "uk.gov.pay.webhooks.validations.CallbackUrlService",
  "thread_name": "dw-41 - POST /v1/webhook",
  "level": "WARN",
  "level_value": 30000,
  "gateway_account_id": "100",
  "live": "true",
  "service_id": "test_service_id",
  "webhook_callback_url": "https://gov.anotherdomain.com",
  "domain": "gov.anotherdomain.com",
  "container": "webhooks",
  "environment": "${ENVIRONMENT}"
}
```