### PR TITLE
PP-13521 Add total to webhook messages response

### DIFF
--- a/openapi/webhooks_spec.yaml
+++ b/openapi/webhooks_spec.yaml
@@ -488,7 +488,7 @@ components:
           type: integer
           format: int32
           description: The number of results in the current page
-          example: 100
+          example: 10
         page:
           type: integer
           format: int32
@@ -498,6 +498,11 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/WebhookMessageResponse"
+        total:
+          type: integer
+          format: int64
+          description: The total number of results
+          example: 100
     WebhookResponse:
       type: object
       properties:

--- a/src/main/java/uk/gov/pay/webhooks/message/dao/WebhookMessageDao.java
+++ b/src/main/java/uk/gov/pay/webhooks/message/dao/WebhookMessageDao.java
@@ -40,6 +40,20 @@ public class WebhookMessageDao extends AbstractDAO<WebhookMessageEntity> {
                 .stream()
                 .findFirst();
     }
+    
+    public long getTotalMessagesCount(WebhookEntity webhook, WebhookMessageSearchParams params) {
+        Query<?> query;
+        if (params.getDeliveryStatus() == null) {
+            query = namedQuery(WebhookMessageEntity.COUNT_MESSAGES_BY_WEBHOOK_ID)
+                    .setParameter("webhook", webhook);
+        } else {
+            query = namedQuery(WebhookMessageEntity.COUNT_MESSAGES_BY_WEBHOOK_ID_AND_STATUS)
+                    .setParameter("webhook", webhook)
+                    .setParameter("deliveryStatus", params.getDeliveryStatus());
+        }
+
+        return (Long) query.uniqueResult();
+    }
 
     public List<WebhookMessageEntity> list(WebhookEntity webhook, WebhookMessageSearchParams params) {
         String searchClauseTemplate = String.join(" AND ", params.getFilterTemplates());

--- a/src/main/java/uk/gov/pay/webhooks/message/resource/WebhookMessageSearchResponse.java
+++ b/src/main/java/uk/gov/pay/webhooks/message/resource/WebhookMessageSearchResponse.java
@@ -4,7 +4,8 @@ import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.util.List;
 
-public record WebhookMessageSearchResponse(@Schema(example = "100", description = "The number of results in the current page") int count,
+public record WebhookMessageSearchResponse(@Schema(example = "10", description = "The number of results in the current page") int count,
                                            @Schema(example = "1", description= "The page of results") int page,
+                                           @Schema(example = "100", description = "The total number of results") long total,
                                            List<WebhookMessageResponse> results) {
 }

--- a/src/main/java/uk/gov/pay/webhooks/webhook/WebhookService.java
+++ b/src/main/java/uk/gov/pay/webhooks/webhook/WebhookService.java
@@ -100,11 +100,12 @@ public class WebhookService {
 
     public WebhookMessageSearchResponse listMessages(String webhookId, WebhookMessageSearchParams queryParams) {
         var webhook = webhookDao.findByExternalId(webhookId).orElseThrow(NotFoundException::new);
+        var totalMessagesCount = webhookMessageDao.getTotalMessagesCount(webhook, queryParams);
         var messages = webhookMessageDao.list(webhook, queryParams)
                 .stream()
                 .map(WebhookMessageResponse::from)
                 .toList();
-        return new WebhookMessageSearchResponse(messages.size(), queryParams.getPage(), messages);
+        return new WebhookMessageSearchResponse(messages.size(), queryParams.getPage(), totalMessagesCount, messages);
     }
 
     public Optional<WebhookMessageResponse> getMessage(String webhookId, String messageId) {

--- a/src/main/java/uk/gov/pay/webhooks/webhook/resource/WebhookMessageSearchParams.java
+++ b/src/main/java/uk/gov/pay/webhooks/webhook/resource/WebhookMessageSearchParams.java
@@ -60,6 +60,10 @@ public class WebhookMessageSearchParams {
         return page;
     }
 
+    public DeliveryStatus getDeliveryStatus() {
+        return deliveryStatus;
+    }
+    
     public List<String> getFilterTemplates() {
         List<String> filters = new ArrayList<>();
 

--- a/src/test/java/uk/gov/pay/webhooks/message/dao/WebhookMessageDaoTest.java
+++ b/src/test/java/uk/gov/pay/webhooks/message/dao/WebhookMessageDaoTest.java
@@ -70,6 +70,26 @@ class WebhookMessageDaoTest {
     }
 
     @Test
+    public void shouldCountMessages() {
+        setup(1);
+        var webhook = webhookDao.findByExternalId(webhookExternalId).get();
+
+        var searchParams = new WebhookMessageSearchParams(1, null, null);
+        var count = webhookMessageDao.getTotalMessagesCount(webhook, searchParams);
+        assertThat(count, is(2L));
+    }
+    
+    @Test
+    public void shouldCountMessagesByStatus() {
+        setup(1);
+        var webhook = webhookDao.findByExternalId(webhookExternalId).get();
+
+        var searchParams = new WebhookMessageSearchParams(1, DeliveryStatus.SUCCESSFUL, null);
+        var count = webhookMessageDao.getTotalMessagesCount(webhook, searchParams);
+        assertThat(count, is(1L));
+    }
+
+    @Test
     public void shouldListFilteredMessages() {
         WebhookEntity webhook = insertWebhook();
         String resourceExternalId = "resource-external-id";

--- a/src/test/java/uk/gov/pay/webhooks/webhook/resource/WebhookResourceIT.java
+++ b/src/test/java/uk/gov/pay/webhooks/webhook/resource/WebhookResourceIT.java
@@ -121,6 +121,7 @@ public class WebhookResourceIT {
                 .statusCode(Response.Status.OK.getStatusCode())
                 .body("count", is(1))
                 .body("page", is(1))
+                .body("total", is(1))
                 .body("results.last_delivery_status[0]", is("FAILED"))
                 .body("results.latest_attempt[0].status", is("FAILED"));
     }
@@ -137,6 +138,7 @@ public class WebhookResourceIT {
                 .then()
                 .statusCode(Response.Status.OK.getStatusCode())
                 .body("count", is(10))
+                .body("total", is(12))
                 .body("page", is(1))
                 .body("results.size()", is(10));
     }
@@ -155,6 +157,7 @@ public class WebhookResourceIT {
                 .then()
                 .statusCode(Response.Status.OK.getStatusCode())
                 .body("count", is(2))
+                .body("total", is(12))
                 .body("page", is(2))
                 .body("results.size()", is(2));
     }


### PR DESCRIPTION
In order to implement better pagination of webhook events in selfservice, we need the total message count to be returned in response to a list webhook messages request.
- Add the total number of messages to the response
- Add unit tests for getting the total message count by webhook id and by status
- Update integration tests