### PR TITLE
PP-13648 Upgrade java aws sdk to version 2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,9 +52,9 @@
                 <type>pom</type>
             </dependency>
             <dependency>
-                <groupId>com.amazonaws</groupId>
-                <artifactId>aws-java-sdk-bom</artifactId>
-                <version>1.12.782</version>
+                <groupId>software.amazon.awssdk</groupId>
+                <artifactId>bom</artifactId>
+                <version>2.31.39</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -112,8 +112,8 @@
             <artifactId>jackson-datatype-jdk8</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.amazonaws</groupId>
-            <artifactId>aws-java-sdk-sqs</artifactId>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>sqs</artifactId>
         </dependency>
         <dependency>
             <groupId>io.dropwizard.metrics</groupId>
@@ -174,6 +174,12 @@
             <artifactId>dropwizard-sentry</artifactId>
             <version>2.1.6</version>
         </dependency>
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+            <version>4.5.14</version>
+        </dependency>
+
 
         <!-- Test dependencies that are imported from one of the BOMs specified
              in <dependencyManagement> so no explicit versions needed -->

--- a/src/main/java/uk/gov/pay/webhooks/queue/sqs/QueueMessage.java
+++ b/src/main/java/uk/gov/pay/webhooks/queue/sqs/QueueMessage.java
@@ -1,21 +1,21 @@
 package uk.gov.pay.webhooks.queue.sqs;
 
-import com.amazonaws.services.sqs.model.ReceiveMessageResult;
-import com.amazonaws.services.sqs.model.SendMessageResult;
+import software.amazon.awssdk.services.sqs.model.ReceiveMessageResponse;
+import software.amazon.awssdk.services.sqs.model.SendMessageResponse;
 
 import java.util.List;
 
 public record QueueMessage(String messageId, String receiptHandle, String messageBody) {
 
-    public static List<QueueMessage> of(ReceiveMessageResult receiveMessageResult) {
-        return receiveMessageResult.getMessages()
+    public static List<QueueMessage> of(ReceiveMessageResponse receiveMessageResult) {
+        return receiveMessageResult.messages()
                 .stream()
-                .map(message -> new QueueMessage(message.getMessageId(), message.getReceiptHandle(), message.getBody()))
+                .map(message -> new QueueMessage(message.messageId(), message.receiptHandle(), message.body()))
                 .toList();
     }
 
-    public static QueueMessage of(SendMessageResult messageResult, String validJsonMessage) {
-        return new QueueMessage(messageResult.getMessageId(), null, validJsonMessage);
+    public static QueueMessage of(SendMessageResponse messageResult, String validJsonMessage) {
+        return new QueueMessage(messageResult.messageId(), null, validJsonMessage);
     }
 
 }

--- a/src/test/java/uk/gov/pay/extension/AppWithPostgresAndSqsExtension.java
+++ b/src/test/java/uk/gov/pay/extension/AppWithPostgresAndSqsExtension.java
@@ -1,6 +1,5 @@
 package uk.gov.pay.extension;
 
-import com.amazonaws.services.sqs.AmazonSQS;
 import io.dropwizard.testing.ConfigOverride;
 import io.dropwizard.testing.junit5.DropwizardAppExtension;
 import org.jdbi.v3.core.Jdbi;
@@ -10,6 +9,7 @@ import org.junit.jupiter.api.extension.BeforeAllCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.services.sqs.SqsClient;
 import uk.gov.pay.rule.PostgresTestDocker;
 import uk.gov.pay.rule.SqsTestDocker;
 import uk.gov.pay.webhooks.app.WebhooksApp;
@@ -35,7 +35,7 @@ public class AppWithPostgresAndSqsExtension implements BeforeAllCallback, AfterA
 
     static final int wireMockPort = PortFactory.findFreePort();
 
-    private final AmazonSQS sqsClient;
+    private final SqsClient sqsClient;
 
     public AppWithPostgresAndSqsExtension() {
         this(new ConfigOverride[0]);
@@ -104,7 +104,7 @@ public class AppWithPostgresAndSqsExtension implements BeforeAllCallback, AfterA
         return jdbi;
     }
 
-    public AmazonSQS getSqsClient() {
+    public SqsClient getSqsClient() {
         return sqsClient;
     }
 

--- a/src/test/java/uk/gov/pay/webhooks/deliveryqueue/WebhookDeliveryQueueIT.java
+++ b/src/test/java/uk/gov/pay/webhooks/deliveryqueue/WebhookDeliveryQueueIT.java
@@ -7,6 +7,7 @@ import io.restassured.http.ContentType;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
+import software.amazon.awssdk.services.sqs.model.SendMessageRequest;
 import uk.gov.pay.extension.AppWithPostgresAndSqsExtension;
 import uk.gov.pay.rule.SqsTestDocker;
 import uk.gov.pay.webhooks.ledger.LedgerStub;
@@ -81,7 +82,11 @@ public class WebhookDeliveryQueueIT {
         ledgerStub.returnLedgerTransaction(transaction);
         wireMock.stubFor(post("/a-test-endpoint").willReturn(ResponseDefinitionBuilder.okForJson("{}")));
 
-        app.getSqsClient().sendMessage(SqsTestDocker.getQueueUrl("event-queue"), sqsMessage.build());
+        SendMessageRequest sendMessageRequest = SendMessageRequest.builder()
+                .queueUrl(SqsTestDocker.getQueueUrl("event-queue"))
+                .messageBody(sqsMessage.build())
+                .build();
+        app.getSqsClient().sendMessage(sendMessageRequest);
         Thread.sleep(1000);
 
         wireMock.verify(
@@ -133,7 +138,11 @@ public class WebhookDeliveryQueueIT {
         ledgerStub.returnLedgerTransaction(transaction);
         wireMock.stubFor(post("/a-test-endpoint").willReturn(ResponseDefinitionBuilder.okForJson("{}")));
 
-        app.getSqsClient().sendMessage(SqsTestDocker.getQueueUrl("event-queue"), sqsMessage.build());
+        SendMessageRequest sendMessageRequest = SendMessageRequest.builder()
+                .queueUrl(SqsTestDocker.getQueueUrl("event-queue"))
+                .messageBody(sqsMessage.build())
+                .build();
+        app.getSqsClient().sendMessage(sendMessageRequest);
         Thread.sleep(1000);
 
         // resource body is appropriately formatted as a payment
@@ -187,7 +196,11 @@ public class WebhookDeliveryQueueIT {
         wireMock.stubFor(post("/a-working-endpoint").willReturn(ResponseDefinitionBuilder.okForJson("{}")));
         wireMock.stubFor(post("/a-failing-endpoint").willReturn(WireMock.forbidden()));
 
-        app.getSqsClient().sendMessage(SqsTestDocker.getQueueUrl("event-queue"), sqsMessage.build());
+        SendMessageRequest sendMessageRequest = SendMessageRequest.builder()
+                .queueUrl(SqsTestDocker.getQueueUrl("event-queue"))
+                .messageBody(sqsMessage.build())
+                .build();
+        app.getSqsClient().sendMessage(sendMessageRequest);
         Thread.sleep(2000);
 
         wireMock.verify(

--- a/src/test/java/uk/gov/pay/webhooks/healthcheck/HealthCheckResourceIT.java
+++ b/src/test/java/uk/gov/pay/webhooks/healthcheck/HealthCheckResourceIT.java
@@ -4,6 +4,7 @@ import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
+import software.amazon.awssdk.services.sqs.model.DeleteQueueRequest;
 import uk.gov.pay.extension.AppWithPostgresAndSqsExtension;
 import uk.gov.pay.rule.PostgresTestDocker;
 import uk.gov.pay.rule.SqsTestDocker;
@@ -15,7 +16,7 @@ class HealthCheckResourceIT {
     public static AppWithPostgresAndSqsExtension app = new AppWithPostgresAndSqsExtension();
 
     @Test
-    void HealthCheckIsHealthyTest(){
+    void HealthCheckIsHealthyTest() {
         RestAssured.given().port(app.getAppRule().getLocalPort())
                 .contentType(ContentType.JSON)
                 .when()
@@ -33,7 +34,10 @@ class HealthCheckResourceIT {
     @Test
     void healthCheckShouldReturn503WhenDBAndSqsQueueDown() throws InterruptedException {
         PostgresTestDocker.shutDown();
-        app.getSqsClient().deleteQueue(SqsTestDocker.getQueueUrl("event-queue"));
+        DeleteQueueRequest deleteQueueRequest = DeleteQueueRequest.builder()
+                .queueUrl(SqsTestDocker.getQueueUrl("event-queue"))
+                .build();
+        app.getSqsClient().deleteQueue(deleteQueueRequest);
 
         RestAssured.given().port(app.getAppRule().getLocalPort())
                 .contentType(ContentType.JSON)

--- a/src/test/java/uk/gov/pay/webhooks/ledger/TransactionFromLedgerFixture.java
+++ b/src/test/java/uk/gov/pay/webhooks/ledger/TransactionFromLedgerFixture.java
@@ -1,6 +1,6 @@
 package uk.gov.pay.webhooks.ledger;
 
-import com.amazonaws.util.json.Jackson;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
@@ -24,6 +24,7 @@ public class TransactionFromLedgerFixture {
     private final Boolean moto = false;
     private final Boolean live = false;
     private final String transactionId = "e8eq11mi2ndmauvb51qsg8hccn";
+    private static final ObjectMapper objectMapper = new ObjectMapper();
 
     public TransactionFromLedgerFixture() {
     }
@@ -33,7 +34,7 @@ public class TransactionFromLedgerFixture {
     }
 
     public String build() throws JsonProcessingException {
-        return Jackson.getObjectMapper().writeValueAsString(this);
+        return objectMapper.writeValueAsString(this);
     }
 
     public String getTransactionId() {

--- a/src/test/java/uk/gov/pay/webhooks/util/SNSToSQSEventFixture.java
+++ b/src/test/java/uk/gov/pay/webhooks/util/SNSToSQSEventFixture.java
@@ -1,16 +1,20 @@
 package uk.gov.pay.webhooks.util;
 
-import com.amazonaws.util.json.Jackson;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 
 import java.io.IOException;
+import java.net.URL;
 import java.util.Optional;
 
 public class SNSToSQSEventFixture {
     private JsonNode body;
-    private final ObjectNode fixture = (ObjectNode) Jackson.getObjectMapper().readTree(getClass().getResource("/sns-to-sqs-event.json"));
+    private static final ObjectMapper objectMapper = new ObjectMapper();
+    private final ObjectNode fixture;
     public SNSToSQSEventFixture() throws IOException {
+        URL json = getClass().getResource("/sns-to-sqs-event.json");
+        this.fixture = (ObjectNode) objectMapper.readTree(json);
     }
 
     public static SNSToSQSEventFixture anSNSToSQSEventFixture() throws IOException {
@@ -23,7 +27,7 @@ public class SNSToSQSEventFixture {
     }
 
     public SNSToSQSEventFixture withBody(Object body) {
-        this.body = Jackson.getObjectMapper().valueToTree(body);
+        this.body = objectMapper.valueToTree(body);
         return this;
     }
 


### PR DESCRIPTION
The AWS SDK for Java 1.x is in maintenance mode, effective July 31, 2024.
The AWS SDK for Java 1.x will no longer receive updates for new or existing services.
We need to upgrade pay-ledger to use the AWS SDK version 2 for SQS operations. This will involve updating dependencies, refactoring code to accommodate changes in the SDK, and ensuring the new SDK's methods and patterns are followed.