### PR TITLE
PP-14206 Send webhook messages encoded as UTF-8

### DIFF
--- a/src/main/java/uk/gov/pay/webhooks/app/WebhooksModule.java
+++ b/src/main/java/uk/gov/pay/webhooks/app/WebhooksModule.java
@@ -2,9 +2,11 @@ package uk.gov.pay.webhooks.app;
 
 import com.google.inject.AbstractModule;
 import com.google.inject.Provides;
+import io.dropwizard.core.setup.Environment;
 import io.dropwizard.hibernate.HibernateBundle;
 import io.dropwizard.hibernate.UnitOfWorkAwareProxyFactory;
-import io.dropwizard.core.setup.Environment;
+import jakarta.inject.Singleton;
+import jakarta.ws.rs.client.Client;
 import org.apache.http.client.config.CookieSpecs;
 import org.apache.http.client.config.RequestConfig;
 import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
@@ -15,15 +17,12 @@ import org.apache.http.ssl.SSLContexts;
 import org.hibernate.SessionFactory;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
-import software.amazon.awssdk.awscore.client.builder.AwsSyncClientBuilder;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.sqs.SqsClient;
 import software.amazon.awssdk.services.sqs.SqsClientBuilder;
+import uk.gov.pay.webhooks.message.HttpPostFactory;
 import uk.gov.pay.webhooks.message.WebhookMessageSignatureGenerator;
 import uk.gov.pay.webhooks.util.IdGenerator;
-
-import jakarta.inject.Singleton;
-import jakarta.ws.rs.client.Client;
 
 import java.net.URI;
 import java.time.InstantSource;
@@ -108,6 +107,12 @@ public class WebhooksModule extends AbstractModule {
                 .setDefaultRequestConfig(config)
                 .setConnectionManager(poolingConnManager)
                 .build();
+    }
+
+    @Provides
+    @Singleton
+    public HttpPostFactory httpPostFactory() {
+        return new HttpPostFactory();
     }
 
     @Provides

--- a/src/main/java/uk/gov/pay/webhooks/message/HttpPostFactory.java
+++ b/src/main/java/uk/gov/pay/webhooks/message/HttpPostFactory.java
@@ -1,0 +1,13 @@
+package uk.gov.pay.webhooks.message;
+
+import org.apache.http.client.methods.HttpPost;
+
+import java.net.URI;
+
+public class HttpPostFactory {
+
+    public HttpPost newHttpPost(URI uri) {
+        return new HttpPost(uri);
+    }
+
+}

--- a/src/test/java/uk/gov/pay/webhooks/message/WebhookMessageSenderTest.java
+++ b/src/test/java/uk/gov/pay/webhooks/message/WebhookMessageSenderTest.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpPost;
 import org.apache.http.client.methods.HttpUriRequest;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.junit.jupiter.api.BeforeEach;
@@ -26,6 +27,7 @@ import java.net.URI;
 import java.security.InvalidKeyException;
 import java.time.Instant;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -39,18 +41,9 @@ class WebhookMessageSenderTest {
 
     private static final String PAYLOAD = """
         {
-            "id": "externalId",
-            "created_date": "2022-01-12T17:31:06.809Z",
-            "resource_id": "foo",
-            "api_version": 1,
-            "resource_type": null,
-            "event_type_name": "card_payment_captured",
-            "resource": {
-                "json": "and",
-                "the": "argonauts"
-            }
+            "Iñtërnâtiônàlizætiøn": "🌎🌍🌏"
         }
-            """;
+        """;
 
     private static final URI CALLBACK_URL = URI.create("http://www.callbackurl.test/webhook-handler");
     private static final String SIGNING_KEY = "Signing key";
@@ -60,23 +53,26 @@ class WebhookMessageSenderTest {
     private CloseableHttpClient mockHttpClient;
 
     @Mock
+    private HttpPostFactory mockHttpPostFactory;
+
+    @Mock
     private WebhookMessageSignatureGenerator mockWebhookMessageSignatureGenerator;
 
     @Mock
-    private CallbackUrlService callbackUrlService;
+    private CallbackUrlService mockCallbackUrlService;
 
     @Mock
     private CloseableHttpResponse mockHttpResponse;
     
     private final ObjectMapper objectMapper = new ObjectMapper();
+    private final HttpPost httpPost = new HttpPost(CALLBACK_URL);
     private WebhookMessageSender webhookMessageSender;
     private WebhookMessageEntity webhookMessageEntity;
     private WebhookEntity webhookEntity;
-    private JsonNode jsonPayload;
 
     @BeforeEach
-    void setUp() throws JsonProcessingException, InvalidKeyException {
-        jsonPayload = objectMapper.readTree(PAYLOAD);
+    public void setUp() throws JsonProcessingException, InvalidKeyException {
+        JsonNode jsonPayload = objectMapper.readTree(PAYLOAD);
 
         webhookEntity = new WebhookEntity(); 
         webhookEntity.setStatus(WebhookStatus.ACTIVE);
@@ -94,13 +90,18 @@ class WebhookMessageSenderTest {
         webhookMessageEntity.setExternalId("externalId");
         webhookMessageEntity.setResourceType("payment");
 
-        webhookMessageSender = new WebhookMessageSender(mockHttpClient, objectMapper, callbackUrlService, mockWebhookMessageSignatureGenerator);
+        webhookMessageSender = new WebhookMessageSender(mockHttpClient, mockHttpPostFactory, objectMapper,
+                mockCallbackUrlService, mockWebhookMessageSignatureGenerator);
     }
 
     @Test
     void constructsHttpRequestAndReturnsHttpResponse() throws IOException, InvalidKeyException, InterruptedException {
+        String httpRequestBody = objectMapper.writeValueAsString(WebhookMessageBody.from(webhookMessageEntity));
+
+        given(mockWebhookMessageSignatureGenerator.generate(httpRequestBody, SIGNING_KEY)).willReturn(SIGNATURE);
+        given(mockHttpPostFactory.newHttpPost(CALLBACK_URL)).willReturn(httpPost);
+
         var httpRequestArgumentCaptor = ArgumentCaptor.forClass(HttpUriRequest.class);
-        given(mockWebhookMessageSignatureGenerator.generate(objectMapper.writeValueAsString(WebhookMessageBody.from(webhookMessageEntity)), SIGNING_KEY)).willReturn(SIGNATURE);
         given(mockHttpClient.execute(httpRequestArgumentCaptor.capture())).willReturn(mockHttpResponse);
 
         HttpResponse result = webhookMessageSender.sendWebhookMessage(webhookMessageEntity);
@@ -110,12 +111,16 @@ class WebhookMessageSenderTest {
         assertThat(httpRequest.getFirstHeader("Content-Type").getValue(), is("application/json"));
         assertThat(httpRequest.getFirstHeader(SIGNATURE_HEADER_NAME).getValue(), is(SIGNATURE));
         assertThat(result, is(mockHttpResponse));
+
+        byte[] bodyBytes = httpPost.getEntity().getContent().readAllBytes();
+        assertThat(bodyBytes, is(httpRequestBody.getBytes(UTF_8)));
     }
 
     @Test
     void propagatesIOException() throws IOException, InterruptedException, InvalidKeyException {
         given(mockHttpClient.execute(any(HttpUriRequest.class))).willThrow(IOException.class);
         given(mockWebhookMessageSignatureGenerator.generate(objectMapper.writeValueAsString(WebhookMessageBody.from(webhookMessageEntity)), SIGNING_KEY)).willReturn(SIGNATURE);
+        given(mockHttpPostFactory.newHttpPost(CALLBACK_URL)).willReturn(httpPost);
         assertThrows(IOException.class, () -> webhookMessageSender.sendWebhookMessage(webhookMessageEntity));
     }
 
@@ -127,7 +132,7 @@ class WebhookMessageSenderTest {
 
     @Test
     void propagatesAndValidatesForLiveDataCallbackUrlDomainNotOnAllowListException() {
-        doThrow(CallbackUrlDomainNotOnAllowListException.class).when(callbackUrlService).validateCallbackUrl(webhookEntity.getCallbackUrl(), webhookEntity.isLive());
+        doThrow(CallbackUrlDomainNotOnAllowListException.class).when(mockCallbackUrlService).validateCallbackUrl(webhookEntity.getCallbackUrl(), webhookEntity.isLive());
         assertThrows(CallbackUrlDomainNotOnAllowListException.class, () -> webhookMessageSender.sendWebhookMessage(webhookMessageEntity));
     }
 


### PR DESCRIPTION
Send webhook messages encoded as UTF-8. We used to do this but when we switched to the Apache HttpClient (which uses different defaults) in commit 65aaa6c00b6b623411b1b40236982ac6261ee12b we unintentionally started using ISO-8859-1.

Worse, the signature generation code continued to calculate based on UTF-8 bytes so in some cases our signatures did not actually match the bytes sent!