### PR TITLE
PP-13991 refactor config to use dropwizard-sentry 4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -170,11 +170,6 @@
             <version>${pay-java-commons.version}</version>
         </dependency>
         <dependency>
-            <groupId>org.dhatim</groupId>
-            <artifactId>dropwizard-sentry</artifactId>
-            <version>2.1.6</version>
-        </dependency>
-        <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
             <version>4.5.14</version>

--- a/src/main/resources/config/config.yaml
+++ b/src/main/resources/config/config.yaml
@@ -24,7 +24,7 @@ logging:
       customFields:
         container: "webhooks"
         environment: ${ENVIRONMENT}
-    - type: pay-dropwizard-4-sentry
+    - type: sentry
       threshold: ERROR
       dsn: ${SENTRY_DSN:-https://example.com@dummy/1}
       environment: ${ENVIRONMENT}


### PR DESCRIPTION
We can migrate to version 4.x now we use Dropwizard 4, which would allow us to remove some custom code.