### PR TITLE
PP-15018 add more comprehensive logging for sending webhook messages

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -225,6 +225,7 @@
             <groupId>io.github.netmikey.logunit</groupId>
             <artifactId>logunit-logback</artifactId>
             <version>2.0.0</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>io.rest-assured</groupId>
@@ -288,8 +289,10 @@
                     <outputFile>target/${project.artifactId}-${project.version}-allinone.jar</outputFile>
                     <createDependencyReducedPom>false</createDependencyReducedPom>
                     <transformers>
-                        <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
-                        <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                        <transformer
+                                implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+                        <transformer
+                                implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
                             <mainClass>${mainClass}</mainClass>
                         </transformer>
                     </transformers>

--- a/pom.xml
+++ b/pom.xml
@@ -204,10 +204,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.assertj</groupId>
-            <artifactId>assertj-core</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-junit-jupiter</artifactId>
             <scope>test</scope>

--- a/pom.xml
+++ b/pom.xml
@@ -204,6 +204,10 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-junit-jupiter</artifactId>
             <scope>test</scope>
@@ -220,6 +224,11 @@
             <artifactId>hamcrest-core</artifactId>
             <version>3.0</version>
             <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.github.netmikey.logunit</groupId>
+            <artifactId>logunit-logback</artifactId>
+            <version>2.0.0</version>
         </dependency>
         <dependency>
             <groupId>io.rest-assured</groupId>

--- a/src/main/java/uk/gov/pay/webhooks/deliveryqueue/managed/SendAttempter.java
+++ b/src/main/java/uk/gov/pay/webhooks/deliveryqueue/managed/SendAttempter.java
@@ -2,6 +2,8 @@ package uk.gov.pay.webhooks.deliveryqueue.managed;
 
 import com.codahale.metrics.MetricRegistry;
 import io.dropwizard.core.setup.Environment;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.core.Response;
 import net.logstash.logback.marker.LogstashMarker;
 import net.logstash.logback.marker.Markers;
 import org.apache.http.NoHttpResponseException;
@@ -15,8 +17,6 @@ import uk.gov.pay.webhooks.deliveryqueue.dao.WebhookDeliveryQueueEntity;
 import uk.gov.pay.webhooks.message.WebhookMessageSender;
 import uk.gov.pay.webhooks.validations.CallbackUrlDomainNotOnAllowListException;
 
-import jakarta.inject.Inject;
-import jakarta.ws.rs.core.Response;
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.SocketTimeoutException;
@@ -72,7 +72,7 @@ public class SendAttempter {
         Instant start = instantSource.instant();
 
         URL url = null;
-        
+
         try {
             url = new URL(webhook.getCallbackUrl().strip());
         } catch (MalformedURLException e) {
@@ -87,7 +87,7 @@ public class SendAttempter {
                             .and(Markers.append(WEBHOOK_CALLBACK_URL_DOMAIN, url.getHost()))
                             .and(Markers.append(WEBHOOK_MESSAGE_DELAY_BETWEEN_ATTEMPT_SCHEDULED_SEND_AT_TIME_AND_NOW, Duration.between(queueItem.getSendAt(), instantSource.instant()).toMillis())),
                     "Sending webhook message started"
-            ); 
+            );
             var response = webhookMessageSender.sendWebhookMessage(queueItem.getWebhookMessageEntity());
 
             var statusCode = response.getStatusLine().getStatusCode();
@@ -116,6 +116,11 @@ public class SendAttempter {
             handleResponse(queueItem, DeliveryStatus.WILL_NOT_SEND, null, "Violates security rules", retryCount, start);
         } catch (Exception e) {
             handleGenericException(queueItem, retryCount, start, e);
+        } catch (Throwable throwable) {
+            LOGGER.atError()
+                    .setCause(throwable)
+                    .log("Error during webhook message send");
+            throw throwable;
         }
     }
 
@@ -138,25 +143,25 @@ public class SendAttempter {
         handleResponse(webhookDeliveryQueueEntity, status, statusCode, reason, retryCount, startTime, Optional.empty());
     }
 
-    private void handleResponse(WebhookDeliveryQueueEntity webhookDeliveryQueueEntity, 
-                                DeliveryStatus status, 
-                                Integer statusCode, 
-                                String reason, 
-                                Long retryCount, 
+    private void handleResponse(WebhookDeliveryQueueEntity webhookDeliveryQueueEntity,
+                                DeliveryStatus status,
+                                Integer statusCode,
+                                String reason,
+                                Long retryCount,
                                 Instant startTime,
                                 Optional<URL> domain) {
         var responseTime = Duration.between(startTime, instantSource.instant());
-        
+
         LogstashMarker logstashMarker = Markers.append(HTTP_STATUS, statusCode)
                 .and(Markers.append(WEBHOOK_MESSAGE_RETRY_COUNT, retryCount))
                 .and(Markers.append(STATE_TRANSITION_TO_STATE, status))
                 .and(Markers.append(RESPONSE_TIME, responseTime.toMillis()))
                 .and(Markers.append(WEBHOOK_MESSAGE_ATTEMPT_RESPONSE_REASON, reason));
-        
+
         domain.ifPresent(d -> logstashMarker.and(Markers.append(WEBHOOK_CALLBACK_URL_DOMAIN, d.getHost())));
-        
-        LOGGER.info(logstashMarker, "Sending webhook message finished"); 
-        
+
+        LOGGER.info(logstashMarker, "Sending webhook message finished");
+
         webhookDeliveryQueueDao.recordResult(webhookDeliveryQueueEntity, reason, responseTime, statusCode, status, metricRegistry);
         webhookDeliveryQueueEntity.getWebhookMessageEntity().setLastDeliveryStatus(status);
 
@@ -184,7 +189,7 @@ public class SendAttempter {
             default -> null;
         };
     }
-    
+
     private String getReasonFromStatusCode(int statusCode) {
         return Stream.of(String.valueOf(statusCode), Response.Status.fromStatusCode(statusCode).getReasonPhrase())
                 .filter(Objects::nonNull)

--- a/src/test/java/uk/gov/pay/webhooks/deliveryqueue/dao/WebhookDeliveryQueueEntityFixture.java
+++ b/src/test/java/uk/gov/pay/webhooks/deliveryqueue/dao/WebhookDeliveryQueueEntityFixture.java
@@ -1,0 +1,27 @@
+package uk.gov.pay.webhooks.deliveryqueue.dao;
+
+import uk.gov.pay.webhooks.message.dao.entity.WebhookMessageEntity;
+
+import java.time.Instant;
+
+public class WebhookDeliveryQueueEntityFixture {
+
+    private WebhookMessageEntity webhookMessageEntity;
+    private final Instant sendAt = Instant.parse("2023-02-01T12:00:00Z");
+
+    public static WebhookDeliveryQueueEntityFixture aWebhookDeliveryQueueEntity() {
+        return new WebhookDeliveryQueueEntityFixture();
+    }
+
+    public WebhookDeliveryQueueEntityFixture withWebhookMessageEntity(WebhookMessageEntity webhookMessageEntity) {
+        this.webhookMessageEntity = webhookMessageEntity;
+        return this;
+    }
+
+    public WebhookDeliveryQueueEntity build() {
+        var webhookDeliveryQueueEntity = new WebhookDeliveryQueueEntity();
+        webhookDeliveryQueueEntity.setWebhookMessageEntity(webhookMessageEntity);
+        webhookDeliveryQueueEntity.setSendAt(sendAt);
+        return webhookDeliveryQueueEntity;
+    }
+}

--- a/src/test/java/uk/gov/pay/webhooks/deliveryqueue/managed/SendAttempterIT.java
+++ b/src/test/java/uk/gov/pay/webhooks/deliveryqueue/managed/SendAttempterIT.java
@@ -110,7 +110,7 @@ class SendAttempterIT {
     }
 
     @Test
-    void should_log_connection_reset_by_peer_fault_with_error_message() {
+    void should_log_error_message_when_connection_is_reset_by_peer() {
         givenThat(post(CALLBACK_URL)
                 .willReturn(aResponse()
                         .withFault(CONNECTION_RESET_BY_PEER)));

--- a/src/test/java/uk/gov/pay/webhooks/deliveryqueue/managed/SendAttempterIT.java
+++ b/src/test/java/uk/gov/pay/webhooks/deliveryqueue/managed/SendAttempterIT.java
@@ -125,7 +125,7 @@ class SendAttempterIT {
     }
 
     @Test
-    void should_log_random_data_then_close_fault() {
+    void should_log_when_response_is_random_data_and_the_connection_is_closed() {
         givenThat(post(CALLBACK_URL)
                 .willReturn(aResponse()
                         .withFault(RANDOM_DATA_THEN_CLOSE)));

--- a/src/test/java/uk/gov/pay/webhooks/deliveryqueue/managed/SendAttempterIT.java
+++ b/src/test/java/uk/gov/pay/webhooks/deliveryqueue/managed/SendAttempterIT.java
@@ -1,0 +1,106 @@
+package uk.gov.pay.webhooks.deliveryqueue.managed;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
+import com.github.tomakehurst.wiremock.junit5.WireMockTest;
+import io.dropwizard.core.setup.Environment;
+import org.apache.http.impl.client.HttpClients;
+import org.jspecify.annotations.NonNull;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import uk.gov.pay.webhooks.deliveryqueue.dao.WebhookDeliveryQueueDao;
+import uk.gov.pay.webhooks.deliveryqueue.dao.WebhookDeliveryQueueEntity;
+import uk.gov.pay.webhooks.message.HttpPostFactory;
+import uk.gov.pay.webhooks.message.WebhookMessageSender;
+import uk.gov.pay.webhooks.message.WebhookMessageSignatureGenerator;
+import uk.gov.pay.webhooks.validations.CallbackUrlService;
+
+import java.time.Instant;
+import java.time.InstantSource;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.equalToJson;
+import static com.github.tomakehurst.wiremock.client.WireMock.givenThat;
+import static com.github.tomakehurst.wiremock.client.WireMock.ok;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.verify;
+import static org.mockito.Mockito.mock;
+import static uk.gov.pay.webhooks.deliveryqueue.dao.WebhookDeliveryQueueEntityFixture.aWebhookDeliveryQueueEntity;
+import static uk.gov.pay.webhooks.message.dao.entity.WebhookMessageEntityFixture.aWebhookMessageEntity;
+import static uk.gov.pay.webhooks.webhook.dao.entity.WebhookEntityFixture.aWebhookEntity;
+
+@WireMockTest
+class SendAttempterIT {
+
+    private static final String CALLBACK_URL = "/callback-url";
+    private static final String NOW = "2022-01-01T00:00:00.000Z";
+    private SendAttempter sendAttempter;
+
+    @BeforeEach
+    void setUp() {
+        sendAttempter = buildSendAttempter();
+    }
+
+    @Test
+    void should_POST_item_to_callback_URL(WireMockRuntimeInfo wmRuntimeInfo) {
+        givenThat(post(CALLBACK_URL)
+                .willReturn(ok()));
+        var enqueuedItem = buildWebhookDeliveryQueueEntityWithCallbackURL(wmRuntimeInfo.getHttpBaseUrl() + CALLBACK_URL);
+
+        sendAttempter.attemptSend(enqueuedItem);
+
+        verify(postRequestedFor(urlEqualTo(CALLBACK_URL))
+                .withRequestBody(equalToJson("""
+                        {
+                          "webhook_message_id": null,
+                          "created_date": "%s",
+                          "resource_id": null,
+                          "api_version": 1,
+                          "resource_type": null,
+                          "event_type": null,
+                          "resource": null
+                        }
+                        """.formatted(NOW))));
+    }
+
+    private static WebhookDeliveryQueueEntity buildWebhookDeliveryQueueEntityWithCallbackURL(String callbackUrl) {
+        var webhook = aWebhookEntity()
+                .withCallbackUrl(callbackUrl)
+                .buld();
+        var webhookMessage = aWebhookMessageEntity()
+                .withWebhookEntity(webhook)
+                .build();
+        return aWebhookDeliveryQueueEntity()
+                .withWebhookMessageEntity(webhookMessage)
+                .build();
+    }
+
+    private static @NonNull SendAttempter buildSendAttempter() {
+        var instantSource = InstantSource.fixed(Instant.parse("2022-01-01T00:00:00Z"));
+        var webhookMessageSender = buildWebhookMessageSender();
+        var environment = new Environment("fake-environment");
+        var webhookDeliveryQueueDao = mock(WebhookDeliveryQueueDao.class);
+        return new SendAttempter(
+                webhookDeliveryQueueDao,
+                instantSource,
+                webhookMessageSender,
+                environment
+        );
+    }
+
+    private static @NonNull WebhookMessageSender buildWebhookMessageSender() {
+        var httpClient = HttpClients.createDefault();
+        var httpPostFactory = new HttpPostFactory();
+        var objectMapper = new ObjectMapper();
+        var callbackUrlService = mock(CallbackUrlService.class); // Using Mockito since the WebhooksConfig has no constructor
+        var webhookMessageSignatureGenerator = new WebhookMessageSignatureGenerator();
+        return new WebhookMessageSender(
+                httpClient,
+                httpPostFactory,
+                objectMapper,
+                callbackUrlService,
+                webhookMessageSignatureGenerator
+        );
+    }
+}

--- a/src/test/java/uk/gov/pay/webhooks/deliveryqueue/managed/SendAttempterIT.java
+++ b/src/test/java/uk/gov/pay/webhooks/deliveryqueue/managed/SendAttempterIT.java
@@ -4,10 +4,13 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
 import com.github.tomakehurst.wiremock.junit5.WireMockTest;
 import io.dropwizard.core.setup.Environment;
+import io.github.netmikey.logunit.api.LogCapturer;
 import org.apache.http.impl.client.HttpClients;
 import org.jspecify.annotations.NonNull;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 import uk.gov.pay.webhooks.deliveryqueue.dao.WebhookDeliveryQueueDao;
 import uk.gov.pay.webhooks.deliveryqueue.dao.WebhookDeliveryQueueEntity;
 import uk.gov.pay.webhooks.message.HttpPostFactory;
@@ -25,13 +28,18 @@ import static com.github.tomakehurst.wiremock.client.WireMock.post;
 import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.verify;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
+import static org.slf4j.Logger.ROOT_LOGGER_NAME;
 import static uk.gov.pay.webhooks.deliveryqueue.dao.WebhookDeliveryQueueEntityFixture.aWebhookDeliveryQueueEntity;
 import static uk.gov.pay.webhooks.message.dao.entity.WebhookMessageEntityFixture.aWebhookMessageEntity;
 import static uk.gov.pay.webhooks.webhook.dao.entity.WebhookEntityFixture.aWebhookEntity;
 
 @WireMockTest
 class SendAttempterIT {
+
+    @RegisterExtension
+    LogCapturer logs = LogCapturer.create().captureForLogger(ROOT_LOGGER_NAME);
 
     private static final String CALLBACK_URL = "/callback-url";
     private static final String NOW = "2022-01-01T00:00:00.000Z";
@@ -42,26 +50,45 @@ class SendAttempterIT {
         sendAttempter = buildSendAttempter();
     }
 
-    @Test
-    void should_POST_item_to_callback_URL(WireMockRuntimeInfo wmRuntimeInfo) {
-        givenThat(post(CALLBACK_URL)
-                .willReturn(ok()));
-        var enqueuedItem = buildWebhookDeliveryQueueEntityWithCallbackURL(wmRuntimeInfo.getHttpBaseUrl() + CALLBACK_URL);
+    @Nested
+    class when_send_successful {
 
-        sendAttempter.attemptSend(enqueuedItem);
+        private WebhookDeliveryQueueEntity enqueuedItem;
 
-        verify(postRequestedFor(urlEqualTo(CALLBACK_URL))
-                .withRequestBody(equalToJson("""
-                        {
-                          "webhook_message_id": null,
-                          "created_date": "%s",
-                          "resource_id": null,
-                          "api_version": 1,
-                          "resource_type": null,
-                          "event_type": null,
-                          "resource": null
-                        }
-                        """.formatted(NOW))));
+        @BeforeEach
+        void setUp(WireMockRuntimeInfo wmRuntimeInfo) {
+            givenThat(post(CALLBACK_URL)
+                    .willReturn(ok()));
+            enqueuedItem = buildWebhookDeliveryQueueEntityWithCallbackURL(wmRuntimeInfo.getHttpBaseUrl() + CALLBACK_URL);
+        }
+
+        @Test
+        void should_POST_item_to_callback_URL() {
+            sendAttempter.attemptSend(enqueuedItem);
+
+            verify(postRequestedFor(urlEqualTo(CALLBACK_URL))
+                    .withRequestBody(equalToJson("""
+                            {
+                              "webhook_message_id": null,
+                              "created_date": "%s",
+                              "resource_id": null,
+                              "api_version": 1,
+                              "resource_type": null,
+                              "event_type": null,
+                              "resource": null
+                            }
+                            """.formatted(NOW))));
+        }
+
+        @Test
+        void should_log_at_start_and_end_of_send_attempt() {
+            sendAttempter.attemptSend(enqueuedItem);
+
+            assertThat(logs.size())
+                    .isEqualTo(2);
+            logs.assertContains("Sending webhook message started");
+            logs.assertContains("Sending webhook message finished");
+        }
     }
 
     private static WebhookDeliveryQueueEntity buildWebhookDeliveryQueueEntityWithCallbackURL(String callbackUrl) {

--- a/src/test/java/uk/gov/pay/webhooks/deliveryqueue/managed/SendAttempterIT.java
+++ b/src/test/java/uk/gov/pay/webhooks/deliveryqueue/managed/SendAttempterIT.java
@@ -59,7 +59,7 @@ class SendAttempterIT {
     LogCapturer logs = LogCapturer.create().captureForLogger(ROOT_LOGGER_NAME);
 
     @Mock
-    private WebhookDeliveryQueueDao webhookDeliveryQueueDaoSpy;
+    private WebhookDeliveryQueueDao mockWebhookDeliveryQueueDao;
 
     private static final String CALLBACK_URL = "/callback-url";
     private static final String NOW = "2022-01-01T00:00:00.000Z";
@@ -161,7 +161,7 @@ class SendAttempterIT {
 
         sendAttempter.attemptSend(enqueuedItem);
 
-        Mockito.verify(webhookDeliveryQueueDaoSpy)
+        Mockito.verify(mockWebhookDeliveryQueueDao)
                 .enqueueFrom(
                         any(),
                         eq(DeliveryStatus.PENDING),
@@ -185,7 +185,7 @@ class SendAttempterIT {
         var webhookMessageSender = buildWebhookMessageSender();
         var environment = new Environment("fake-environment");
         return new SendAttempter(
-                webhookDeliveryQueueDaoSpy,
+                mockWebhookDeliveryQueueDao,
                 instantSource,
                 webhookMessageSender,
                 environment

--- a/src/test/java/uk/gov/pay/webhooks/deliveryqueue/managed/SendAttempterIT.java
+++ b/src/test/java/uk/gov/pay/webhooks/deliveryqueue/managed/SendAttempterIT.java
@@ -146,7 +146,7 @@ class SendAttempterIT {
 
         sendAttempter.attemptSend(enqueuedItem);
 
-        logs.assertContains("Request timed out"); // Is this the right thing?
+        logs.assertContains("Request timed out");
     }
 
     @ParameterizedTest

--- a/src/test/java/uk/gov/pay/webhooks/deliveryqueue/managed/SendAttempterIT.java
+++ b/src/test/java/uk/gov/pay/webhooks/deliveryqueue/managed/SendAttempterIT.java
@@ -40,7 +40,9 @@ import static com.github.tomakehurst.wiremock.client.WireMock.verify;
 import static com.github.tomakehurst.wiremock.http.Fault.CONNECTION_RESET_BY_PEER;
 import static com.github.tomakehurst.wiremock.http.Fault.EMPTY_RESPONSE;
 import static com.github.tomakehurst.wiremock.http.Fault.RANDOM_DATA_THEN_CLOSE;
-import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasToString;
+import static org.hamcrest.Matchers.is;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
@@ -102,8 +104,7 @@ class SendAttempterIT {
         void should_log_at_start_and_end_of_send_attempt() {
             sendAttempter.attemptSend(enqueuedItem);
 
-            assertThat(logs.size())
-                    .isEqualTo(2);
+            assertThat(logs.size(), is(2));
             logs.assertContains("Sending webhook message started");
             logs.assertContains("Sending webhook message finished");
         }
@@ -118,9 +119,9 @@ class SendAttempterIT {
         sendAttempter.attemptSend(enqueuedItem);
 
         var loggingEvent = logs.assertContains("Exception caught by request");
-        assertThat(loggingEvent.getMarkers())
-                .singleElement()
-                .hasToString("error_message=Connection reset");
+        var markers = loggingEvent.getMarkers();
+        assertThat(markers.size(), is(1));
+        assertThat(markers.getFirst(), hasToString("error_message=Connection reset"));
     }
 
     @Test
@@ -132,9 +133,9 @@ class SendAttempterIT {
         sendAttempter.attemptSend(enqueuedItem);
 
         var loggingEvent = logs.assertContains("Exception caught by request");
-        assertThat(loggingEvent.getMarkers())
-                .singleElement()
-                .hasToString("error_message=null");
+        var markers = loggingEvent.getMarkers();
+        assertThat(markers.size(), is(1));
+        assertThat(markers.getFirst(), hasToString("error_message=null"));
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/webhooks/deliveryqueue/managed/SendAttempterIT.java
+++ b/src/test/java/uk/gov/pay/webhooks/deliveryqueue/managed/SendAttempterIT.java
@@ -44,22 +44,21 @@ class SendAttempterIT {
     private static final String CALLBACK_URL = "/callback-url";
     private static final String NOW = "2022-01-01T00:00:00.000Z";
     private SendAttempter sendAttempter;
+    private WebhookDeliveryQueueEntity enqueuedItem;
 
     @BeforeEach
-    void setUp() {
+    void setUp(WireMockRuntimeInfo wmRuntimeInfo) {
         sendAttempter = buildSendAttempter();
+        enqueuedItem = buildWebhookDeliveryQueueEntityWithCallbackURL(wmRuntimeInfo.getHttpBaseUrl() + CALLBACK_URL);
     }
 
     @Nested
     class when_send_successful {
 
-        private WebhookDeliveryQueueEntity enqueuedItem;
-
         @BeforeEach
-        void setUp(WireMockRuntimeInfo wmRuntimeInfo) {
+        void setUp() {
             givenThat(post(CALLBACK_URL)
                     .willReturn(ok()));
-            enqueuedItem = buildWebhookDeliveryQueueEntityWithCallbackURL(wmRuntimeInfo.getHttpBaseUrl() + CALLBACK_URL);
         }
 
         @Test

--- a/src/test/java/uk/gov/pay/webhooks/deliveryqueue/managed/SendAttempterIT.java
+++ b/src/test/java/uk/gov/pay/webhooks/deliveryqueue/managed/SendAttempterIT.java
@@ -154,10 +154,10 @@ class SendAttempterIT {
             "RANDOM_DATA_THEN_CLOSE",
             "EMPTY_RESPONSE"
     })
-    void should_enqueue_for_retry_on_fault(Fault fault) {
+    void should_enqueue_for_retry_on_connection_error(Fault connectionError) {
         givenThat(post(CALLBACK_URL)
                 .willReturn(aResponse()
-                        .withFault(fault)));
+                        .withFault(connectionError)));
 
         sendAttempter.attemptSend(enqueuedItem);
 

--- a/src/test/java/uk/gov/pay/webhooks/deliveryqueue/managed/SendAttempterIT.java
+++ b/src/test/java/uk/gov/pay/webhooks/deliveryqueue/managed/SendAttempterIT.java
@@ -197,7 +197,7 @@ class SendAttempterIT {
         var httpClient = HttpClients.createDefault();
         var httpPostFactory = new HttpPostFactory();
         var objectMapper = new ObjectMapper();
-        var callbackUrlService = mock(CallbackUrlService.class); // Using Mockito since the WebhooksConfig has no constructor
+        var callbackUrlService = mock(CallbackUrlService.class);
         var webhookMessageSignatureGenerator = new WebhookMessageSignatureGenerator();
         return new WebhookMessageSender(
                 httpClient,

--- a/src/test/java/uk/gov/pay/webhooks/deliveryqueue/managed/SendAttempterIT.java
+++ b/src/test/java/uk/gov/pay/webhooks/deliveryqueue/managed/SendAttempterIT.java
@@ -7,7 +7,6 @@ import com.github.tomakehurst.wiremock.junit5.WireMockTest;
 import io.dropwizard.core.setup.Environment;
 import io.github.netmikey.logunit.api.LogCapturer;
 import org.apache.http.impl.client.HttpClients;
-import org.jspecify.annotations.NonNull;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -181,7 +180,7 @@ class SendAttempterIT {
                 .build();
     }
 
-    private @NonNull SendAttempter buildSendAttempter() {
+    private SendAttempter buildSendAttempter() {
         var instantSource = InstantSource.fixed(Instant.parse(NOW));
         var webhookMessageSender = buildWebhookMessageSender();
         var environment = new Environment("fake-environment");
@@ -193,7 +192,7 @@ class SendAttempterIT {
         );
     }
 
-    private static @NonNull WebhookMessageSender buildWebhookMessageSender() {
+    private static WebhookMessageSender buildWebhookMessageSender() {
         var httpClient = HttpClients.createDefault();
         var httpPostFactory = new HttpPostFactory();
         var objectMapper = new ObjectMapper();

--- a/src/test/java/uk/gov/pay/webhooks/deliveryqueue/managed/SendAttempterIT.java
+++ b/src/test/java/uk/gov/pay/webhooks/deliveryqueue/managed/SendAttempterIT.java
@@ -1,6 +1,7 @@
 package uk.gov.pay.webhooks.deliveryqueue.managed;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.tomakehurst.wiremock.http.Fault;
 import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
 import com.github.tomakehurst.wiremock.junit5.WireMockTest;
 import io.dropwizard.core.setup.Environment;
@@ -10,7 +11,14 @@ import org.jspecify.annotations.NonNull;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.pay.webhooks.deliveryqueue.DeliveryStatus;
 import uk.gov.pay.webhooks.deliveryqueue.dao.WebhookDeliveryQueueDao;
 import uk.gov.pay.webhooks.deliveryqueue.dao.WebhookDeliveryQueueEntity;
 import uk.gov.pay.webhooks.message.HttpPostFactory;
@@ -21,6 +29,7 @@ import uk.gov.pay.webhooks.validations.CallbackUrlService;
 import java.time.Instant;
 import java.time.InstantSource;
 
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.equalToJson;
 import static com.github.tomakehurst.wiremock.client.WireMock.givenThat;
 import static com.github.tomakehurst.wiremock.client.WireMock.ok;
@@ -28,7 +37,13 @@ import static com.github.tomakehurst.wiremock.client.WireMock.post;
 import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.verify;
+import static com.github.tomakehurst.wiremock.http.Fault.CONNECTION_RESET_BY_PEER;
+import static com.github.tomakehurst.wiremock.http.Fault.EMPTY_RESPONSE;
+import static com.github.tomakehurst.wiremock.http.Fault.RANDOM_DATA_THEN_CLOSE;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.slf4j.Logger.ROOT_LOGGER_NAME;
 import static uk.gov.pay.webhooks.deliveryqueue.dao.WebhookDeliveryQueueEntityFixture.aWebhookDeliveryQueueEntity;
@@ -36,10 +51,14 @@ import static uk.gov.pay.webhooks.message.dao.entity.WebhookMessageEntityFixture
 import static uk.gov.pay.webhooks.webhook.dao.entity.WebhookEntityFixture.aWebhookEntity;
 
 @WireMockTest
+@ExtendWith(MockitoExtension.class)
 class SendAttempterIT {
 
     @RegisterExtension
     LogCapturer logs = LogCapturer.create().captureForLogger(ROOT_LOGGER_NAME);
+
+    @Mock
+    private WebhookDeliveryQueueDao webhookDeliveryQueueDaoSpy;
 
     private static final String CALLBACK_URL = "/callback-url";
     private static final String NOW = "2022-01-01T00:00:00.000Z";
@@ -90,6 +109,65 @@ class SendAttempterIT {
         }
     }
 
+    @Test
+    void should_log_connection_reset_by_peer_fault_with_error_message() {
+        givenThat(post(CALLBACK_URL)
+                .willReturn(aResponse()
+                        .withFault(CONNECTION_RESET_BY_PEER)));
+
+        sendAttempter.attemptSend(enqueuedItem);
+
+        var loggingEvent = logs.assertContains("Exception caught by request");
+        assertThat(loggingEvent.getMarkers())
+                .singleElement()
+                .hasToString("error_message=Connection reset");
+    }
+
+    @Test
+    void should_log_random_data_then_close_fault() {
+        givenThat(post(CALLBACK_URL)
+                .willReturn(aResponse()
+                        .withFault(RANDOM_DATA_THEN_CLOSE)));
+
+        sendAttempter.attemptSend(enqueuedItem);
+
+        var loggingEvent = logs.assertContains("Exception caught by request");
+        assertThat(loggingEvent.getMarkers())
+                .singleElement()
+                .hasToString("error_message=null");
+    }
+
+    @Test
+    void should_log_empty_response_fault() {
+        givenThat(post(CALLBACK_URL)
+                .willReturn(aResponse()
+                        .withFault(EMPTY_RESPONSE)));
+
+        sendAttempter.attemptSend(enqueuedItem);
+
+        logs.assertContains("Request timed out"); // Is this the right thing?
+    }
+
+    @ParameterizedTest
+    @EnumSource(names = {
+            "CONNECTION_RESET_BY_PEER",
+            "RANDOM_DATA_THEN_CLOSE",
+            "EMPTY_RESPONSE"
+    })
+    void should_enqueue_for_retry_on_fault(Fault fault) {
+        givenThat(post(CALLBACK_URL)
+                .willReturn(aResponse()
+                        .withFault(fault)));
+
+        sendAttempter.attemptSend(enqueuedItem);
+
+        Mockito.verify(webhookDeliveryQueueDaoSpy)
+                .enqueueFrom(
+                        any(),
+                        eq(DeliveryStatus.PENDING),
+                        argThat(instant -> instant.isAfter(Instant.parse(NOW))));
+    }
+
     private static WebhookDeliveryQueueEntity buildWebhookDeliveryQueueEntityWithCallbackURL(String callbackUrl) {
         var webhook = aWebhookEntity()
                 .withCallbackUrl(callbackUrl)
@@ -102,13 +180,12 @@ class SendAttempterIT {
                 .build();
     }
 
-    private static @NonNull SendAttempter buildSendAttempter() {
-        var instantSource = InstantSource.fixed(Instant.parse("2022-01-01T00:00:00Z"));
+    private @NonNull SendAttempter buildSendAttempter() {
+        var instantSource = InstantSource.fixed(Instant.parse(NOW));
         var webhookMessageSender = buildWebhookMessageSender();
         var environment = new Environment("fake-environment");
-        var webhookDeliveryQueueDao = mock(WebhookDeliveryQueueDao.class);
         return new SendAttempter(
-                webhookDeliveryQueueDao,
+                webhookDeliveryQueueDaoSpy,
                 instantSource,
                 webhookMessageSender,
                 environment

--- a/src/test/java/uk/gov/pay/webhooks/deliveryqueue/managed/SendAttempterIT.java
+++ b/src/test/java/uk/gov/pay/webhooks/deliveryqueue/managed/SendAttempterIT.java
@@ -138,7 +138,7 @@ class SendAttempterIT {
     }
 
     @Test
-    void should_log_empty_response_fault() {
+    void should_log_when_empty_error_response_is_received() {
         givenThat(post(CALLBACK_URL)
                 .willReturn(aResponse()
                         .withFault(EMPTY_RESPONSE)));

--- a/src/test/java/uk/gov/pay/webhooks/deliveryqueue/managed/SendAttempterTest.java
+++ b/src/test/java/uk/gov/pay/webhooks/deliveryqueue/managed/SendAttempterTest.java
@@ -7,7 +7,6 @@ import io.dropwizard.testing.junit5.DropwizardExtensionsSupport;
 import io.github.netmikey.logunit.api.LogCapturer;
 import org.apache.http.StatusLine;
 import org.apache.http.client.methods.CloseableHttpResponse;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -163,10 +162,8 @@ class SendAttempterTest {
         assertThrows(Error.class, () -> sendAttempter.attemptSend(enqueuedItem));
 
         var loggingEvent = logs.assertContains("Error during webhook message send");
-        Assertions.assertThat(loggingEvent.getLevel())
-                .isEqualTo(ERROR);
-        Assertions.assertThat(loggingEvent.getThrowable())
-                .hasMessage(errorMessage);
+        assertThat(loggingEvent.getLevel(), is(ERROR));
+        assertThat(loggingEvent.getThrowable().getMessage(), is(errorMessage));
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/webhooks/deliveryqueue/managed/SendAttempterTest.java
+++ b/src/test/java/uk/gov/pay/webhooks/deliveryqueue/managed/SendAttempterTest.java
@@ -87,7 +87,7 @@ class SendAttempterTest {
     }
 
     @Test
-    void sendAttempterSetsDeliveryStatusBasedOnStatusCode() throws IOException, InterruptedException, InvalidKeyException {
+    void should_set_delivery_status_based_on_status_code() throws IOException, InterruptedException, InvalidKeyException {
         given(mockHttpResponse.getStatusLine()).willReturn(mockStatusLine);
         given(mockWebhookMessageSender.sendWebhookMessage(any(WebhookMessageEntity.class))).willReturn(mockHttpResponse);
         var webhookMessage = webhookMessageDao.create(webhookMessageEntity);
@@ -96,7 +96,7 @@ class SendAttempterTest {
         given(mockStatusLine.getStatusCode()).willReturn(404, 200);
 
         sendAttempter.attemptSend(enqueuedItem);
-        
+
         assertThat(enqueuedItem.getDeliveryStatus(), is(DeliveryStatus.FAILED));
         assertThat(webhookMessage.getLastDeliveryStatus(), is(DeliveryStatus.FAILED));
         assertThat(enqueuedItem.getDeliveryResult(), is("404 Not Found"));
@@ -107,43 +107,43 @@ class SendAttempterTest {
     }
 
     @Test
-    void sendAttempterEmitsDeliveryStatusMetric() throws IOException, InvalidKeyException, InterruptedException {
+    void should_emit_delivery_status_metric() throws IOException, InvalidKeyException, InterruptedException {
         given(mockHttpResponse.getStatusLine()).willReturn(mockStatusLine);
         given(mockWebhookMessageSender.sendWebhookMessage(any(WebhookMessageEntity.class))).willReturn(mockHttpResponse);
         var webhookMessage = webhookMessageDao.create(webhookMessageEntity);
         var sendAttempter = new SendAttempter(webhookDeliveryQueueDao, instantSource, mockWebhookMessageSender, mockEnvironment);
         var enqueuedItem = webhookDeliveryQueueDao.enqueueFrom(webhookMessage, DeliveryStatus.PENDING, instantSource.instant());
         given(mockStatusLine.getStatusCode()).willReturn(200);
-        
+
         sendAttempter.attemptSend(enqueuedItem);
-        
+
         verify(mockMetricRegistry).counter("delivery-status.SUCCESSFUL");
     }
 
     @Test
-    void sendAttempterCatchesExceptions() throws IOException, InterruptedException, InvalidKeyException {
+    void should_catch_exceptions() throws IOException, InterruptedException, InvalidKeyException {
         var webhookMessage = webhookMessageDao.create(webhookMessageEntity);
         var sendAttempter = new SendAttempter(webhookDeliveryQueueDao, instantSource, mockWebhookMessageSender, mockEnvironment);
         var enqueuedItem = webhookDeliveryQueueDao.enqueueFrom(webhookMessage, DeliveryStatus.PENDING, instantSource.instant());
         given(mockWebhookMessageSender.sendWebhookMessage(any(WebhookMessageEntity.class))).willThrow(IOException.class, HttpTimeoutException.class);
 
         assertDoesNotThrow(() -> sendAttempter.attemptSend(enqueuedItem));
-        
+
         assertThat(enqueuedItem.getDeliveryStatus(), is(DeliveryStatus.FAILED));
         assertThat(webhookMessage.getLastDeliveryStatus(), is(DeliveryStatus.FAILED));
     }
 
     @Test
-    void sendAttempterEnqueuesRetriesIfFailure() throws IOException, InvalidKeyException, InterruptedException {
+    void should_enqueue_retries_if_failure() throws IOException, InvalidKeyException, InterruptedException {
         given(mockHttpResponse.getStatusLine()).willReturn(mockStatusLine);
         given(mockWebhookMessageSender.sendWebhookMessage(any(WebhookMessageEntity.class))).willReturn(mockHttpResponse);
         var webhookMessage = webhookMessageDao.create(webhookMessageEntity);
         var sendAttempter = new SendAttempter(webhookDeliveryQueueDao, instantSource, mockWebhookMessageSender, mockEnvironment);
         var enqueuedItem = webhookDeliveryQueueDao.enqueueFrom(webhookMessage, DeliveryStatus.PENDING, instantSource.instant());
         given(mockStatusLine.getStatusCode()).willReturn(404);
-        
+
         sendAttempter.attemptSend(enqueuedItem);
-        
+
         assertThat(enqueuedItem.getDeliveryStatus(), is(DeliveryStatus.FAILED));
         assertThat(webhookMessage.getLastDeliveryStatus(), is(DeliveryStatus.FAILED));
         database.inTransaction(() -> {
@@ -153,27 +153,27 @@ class SendAttempterTest {
     }
 
     @Test
-    void sendAttempterDoesNotEnqueueRetryForRejectedForSecurityRules() throws IOException, InvalidKeyException, InterruptedException {
+    void should_not_enqueue_retry_for_rejected_for_security_rules() throws IOException, InvalidKeyException, InterruptedException {
         given(mockWebhookMessageSender.sendWebhookMessage(any(WebhookMessageEntity.class))).willThrow(CallbackUrlDomainNotOnAllowListException.class);
         var webhookMessage = webhookMessageDao.create(webhookMessageEntity);
         var sendAttempter = new SendAttempter(webhookDeliveryQueueDao, instantSource, mockWebhookMessageSender, mockEnvironment);
         var enqueuedItem = webhookDeliveryQueueDao.enqueueFrom(webhookMessage, DeliveryStatus.PENDING, instantSource.instant());
-        
+
         sendAttempter.attemptSend(enqueuedItem);
-        
+
         assertThat(enqueuedItem.getDeliveryStatus(), is(DeliveryStatus.WILL_NOT_SEND));
         assertThat(webhookMessage.getLastDeliveryStatus(), is(DeliveryStatus.WILL_NOT_SEND));
     }
 
     @Test
-    void sendAttempterDoesNotEnqueueRetryForNotActiveWebhooks() throws IOException, InvalidKeyException, InterruptedException {
+    void should_not_enqueue_retry_for_not_active_webhooks() throws IOException, InvalidKeyException, InterruptedException {
         given(mockWebhookMessageSender.sendWebhookMessage(any(WebhookMessageEntity.class))).willThrow(WebhookNotActiveException.class);
         var webhookMessage = webhookMessageDao.create(webhookMessageEntity);
         var sendAttempter = new SendAttempter(webhookDeliveryQueueDao, instantSource, mockWebhookMessageSender, mockEnvironment);
         var enqueuedItem = webhookDeliveryQueueDao.enqueueFrom(webhookMessage, DeliveryStatus.PENDING, instantSource.instant());
 
         sendAttempter.attemptSend(enqueuedItem);
-        
+
         assertThat(enqueuedItem.getDeliveryStatus(), is(DeliveryStatus.WILL_NOT_SEND));
         assertThat(webhookMessage.getLastDeliveryStatus(), is(DeliveryStatus.WILL_NOT_SEND));
     }

--- a/src/test/java/uk/gov/pay/webhooks/deliveryqueue/managed/SendAttempterTest.java
+++ b/src/test/java/uk/gov/pay/webhooks/deliveryqueue/managed/SendAttempterTest.java
@@ -4,11 +4,14 @@ import com.codahale.metrics.MetricRegistry;
 import io.dropwizard.core.setup.Environment;
 import io.dropwizard.testing.junit5.DAOTestExtension;
 import io.dropwizard.testing.junit5.DropwizardExtensionsSupport;
+import io.github.netmikey.logunit.api.LogCapturer;
 import org.apache.http.StatusLine;
 import org.apache.http.client.methods.CloseableHttpResponse;
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.FieldSource;
 import org.mockito.Mock;
@@ -35,13 +38,18 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
+import static org.slf4j.event.Level.ERROR;
 
 @ExtendWith(MockitoExtension.class)
 @ExtendWith(DropwizardExtensionsSupport.class)
 class SendAttempterTest {
+
+    @RegisterExtension
+    LogCapturer logs = LogCapturer.create().captureForType(SendAttempter.class);
 
     public DAOTestExtension database = DAOTestExtension.newBuilder()
             .addEntityClass(EventTypeEntity.class)
@@ -141,6 +149,24 @@ class SendAttempterTest {
 
         assertThat(enqueuedItem.getDeliveryStatus(), is(DeliveryStatus.FAILED));
         assertThat(webhookMessage.getLastDeliveryStatus(), is(DeliveryStatus.FAILED));
+    }
+
+    @Test
+    void should_catch_log_and_rethrow_Errors() throws IOException, InvalidKeyException, InterruptedException {
+        var errorMessage = "BOOM!";
+        given(mockWebhookMessageSender.sendWebhookMessage(any(WebhookMessageEntity.class)))
+                .willThrow(new Error(errorMessage));
+        var webhookMessage = webhookMessageDao.create(webhookMessageEntity);
+        var enqueuedItem = webhookDeliveryQueueDao.enqueueFrom(webhookMessage, DeliveryStatus.PENDING, instantSource.instant());
+        var sendAttempter = new SendAttempter(webhookDeliveryQueueDao, instantSource, mockWebhookMessageSender, mockEnvironment);
+
+        assertThrows(Error.class, () -> sendAttempter.attemptSend(enqueuedItem));
+
+        var loggingEvent = logs.assertContains("Error during webhook message send");
+        Assertions.assertThat(loggingEvent.getLevel())
+                .isEqualTo(ERROR);
+        Assertions.assertThat(loggingEvent.getThrowable())
+                .hasMessage(errorMessage);
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/webhooks/deliveryqueue/managed/SendAttempterTest.java
+++ b/src/test/java/uk/gov/pay/webhooks/deliveryqueue/managed/SendAttempterTest.java
@@ -51,7 +51,6 @@ class SendAttempterTest {
     private WebhookDeliveryQueueDao webhookDeliveryQueueDao;
     private InstantSource instantSource;
     private WebhookMessageDao webhookMessageDao;
-    private WebhookDao webhookDao;
     private WebhookMessageEntity webhookMessageEntity;
 
     @Mock
@@ -72,7 +71,6 @@ class SendAttempterTest {
     void setUp() {
         instantSource = InstantSource.fixed(Instant.now());
         webhookMessageDao = new WebhookMessageDao(database.getSessionFactory());
-        webhookDao = new WebhookDao(database.getSessionFactory());
         webhookDeliveryQueueDao = new WebhookDeliveryQueueDao(database.getSessionFactory(), instantSource);
         webhookMessageEntity = new WebhookMessageEntity();
         WebhookEntity webhookEntity = new WebhookEntity();
@@ -81,6 +79,7 @@ class SendAttempterTest {
         webhookEntity.setCreatedDate(Instant.parse("2007-12-03T10:15:30.00Z"));
         webhookEntity.setCallbackUrl("http://example.com");
         webhookEntity.setSigningKey("some-signing-key");
+        WebhookDao webhookDao = new WebhookDao(database.getSessionFactory());
         webhookDao.create(webhookEntity);
         webhookMessageEntity.setWebhookEntity(webhookEntity);
         webhookMessageEntity.setCreatedDate(instantSource.instant());

--- a/src/test/java/uk/gov/pay/webhooks/deliveryqueue/managed/SendAttempterTest.java
+++ b/src/test/java/uk/gov/pay/webhooks/deliveryqueue/managed/SendAttempterTest.java
@@ -90,13 +90,13 @@ class SendAttempterTest {
     void sendAttempterSetsDeliveryStatusBasedOnStatusCode() throws IOException, InterruptedException, InvalidKeyException {
         given(mockHttpResponse.getStatusLine()).willReturn(mockStatusLine);
         given(mockWebhookMessageSender.sendWebhookMessage(any(WebhookMessageEntity.class))).willReturn(mockHttpResponse);
-
         var webhookMessage = webhookMessageDao.create(webhookMessageEntity);
         var sendAttempter = new SendAttempter(webhookDeliveryQueueDao, instantSource, mockWebhookMessageSender, mockEnvironment);
         var enqueuedItem = webhookDeliveryQueueDao.enqueueFrom(webhookMessage, DeliveryStatus.PENDING, instantSource.instant());
         given(mockStatusLine.getStatusCode()).willReturn(404, 200);
 
         sendAttempter.attemptSend(enqueuedItem);
+        
         assertThat(enqueuedItem.getDeliveryStatus(), is(DeliveryStatus.FAILED));
         assertThat(webhookMessage.getLastDeliveryStatus(), is(DeliveryStatus.FAILED));
         assertThat(enqueuedItem.getDeliveryResult(), is("404 Not Found"));
@@ -110,12 +110,13 @@ class SendAttempterTest {
     void sendAttempterEmitsDeliveryStatusMetric() throws IOException, InvalidKeyException, InterruptedException {
         given(mockHttpResponse.getStatusLine()).willReturn(mockStatusLine);
         given(mockWebhookMessageSender.sendWebhookMessage(any(WebhookMessageEntity.class))).willReturn(mockHttpResponse);
-
         var webhookMessage = webhookMessageDao.create(webhookMessageEntity);
         var sendAttempter = new SendAttempter(webhookDeliveryQueueDao, instantSource, mockWebhookMessageSender, mockEnvironment);
         var enqueuedItem = webhookDeliveryQueueDao.enqueueFrom(webhookMessage, DeliveryStatus.PENDING, instantSource.instant());
         given(mockStatusLine.getStatusCode()).willReturn(200);
+        
         sendAttempter.attemptSend(enqueuedItem);
+        
         verify(mockMetricRegistry).counter("delivery-status.SUCCESSFUL");
     }
 
@@ -127,6 +128,7 @@ class SendAttempterTest {
         given(mockWebhookMessageSender.sendWebhookMessage(any(WebhookMessageEntity.class))).willThrow(IOException.class, HttpTimeoutException.class);
 
         assertDoesNotThrow(() -> sendAttempter.attemptSend(enqueuedItem));
+        
         assertThat(enqueuedItem.getDeliveryStatus(), is(DeliveryStatus.FAILED));
         assertThat(webhookMessage.getLastDeliveryStatus(), is(DeliveryStatus.FAILED));
     }
@@ -139,11 +141,11 @@ class SendAttempterTest {
         var sendAttempter = new SendAttempter(webhookDeliveryQueueDao, instantSource, mockWebhookMessageSender, mockEnvironment);
         var enqueuedItem = webhookDeliveryQueueDao.enqueueFrom(webhookMessage, DeliveryStatus.PENDING, instantSource.instant());
         given(mockStatusLine.getStatusCode()).willReturn(404);
-
+        
         sendAttempter.attemptSend(enqueuedItem);
+        
         assertThat(enqueuedItem.getDeliveryStatus(), is(DeliveryStatus.FAILED));
         assertThat(webhookMessage.getLastDeliveryStatus(), is(DeliveryStatus.FAILED));
-
         database.inTransaction(() -> {
             assertThat(webhookDeliveryQueueDao.nextToSend((Instant.parse("2007-12-03T10:15:30.00Z"))), is(notNullValue()));
             assertThat(webhookDeliveryQueueDao.countFailed(webhookMessageEntity), is(1L));
@@ -156,8 +158,9 @@ class SendAttempterTest {
         var webhookMessage = webhookMessageDao.create(webhookMessageEntity);
         var sendAttempter = new SendAttempter(webhookDeliveryQueueDao, instantSource, mockWebhookMessageSender, mockEnvironment);
         var enqueuedItem = webhookDeliveryQueueDao.enqueueFrom(webhookMessage, DeliveryStatus.PENDING, instantSource.instant());
-
+        
         sendAttempter.attemptSend(enqueuedItem);
+        
         assertThat(enqueuedItem.getDeliveryStatus(), is(DeliveryStatus.WILL_NOT_SEND));
         assertThat(webhookMessage.getLastDeliveryStatus(), is(DeliveryStatus.WILL_NOT_SEND));
     }
@@ -170,6 +173,7 @@ class SendAttempterTest {
         var enqueuedItem = webhookDeliveryQueueDao.enqueueFrom(webhookMessage, DeliveryStatus.PENDING, instantSource.instant());
 
         sendAttempter.attemptSend(enqueuedItem);
+        
         assertThat(enqueuedItem.getDeliveryStatus(), is(DeliveryStatus.WILL_NOT_SEND));
         assertThat(webhookMessage.getLastDeliveryStatus(), is(DeliveryStatus.WILL_NOT_SEND));
     }

--- a/src/test/java/uk/gov/pay/webhooks/deliveryqueue/managed/SendAttempterTest.java
+++ b/src/test/java/uk/gov/pay/webhooks/deliveryqueue/managed/SendAttempterTest.java
@@ -53,22 +53,23 @@ class SendAttempterTest {
     private WebhookMessageDao webhookMessageDao;
     private WebhookDao webhookDao;
     private WebhookMessageEntity webhookMessageEntity;
-    
+
     @Mock
     private WebhookMessageSender mockWebhookMessageSender;
-    
+
     @Mock
     private CloseableHttpResponse mockHttpResponse;
-    @Mock private StatusLine mockStatusLine;
-    
     @Mock
-    private Environment mockEnvironment;    
-    
+    private StatusLine mockStatusLine;
+
+    @Mock
+    private Environment mockEnvironment;
+
     @Mock
     private MetricRegistry mockMetricRegistry;
-            
+
     @BeforeEach
-    void setUp(){
+    void setUp() {
         instantSource = InstantSource.fixed(Instant.now());
         webhookMessageDao = new WebhookMessageDao(database.getSessionFactory());
         webhookDao = new WebhookDao(database.getSessionFactory());
@@ -85,17 +86,17 @@ class SendAttempterTest {
         webhookMessageEntity.setCreatedDate(instantSource.instant());
         given(mockEnvironment.metrics()).willReturn(mockMetricRegistry);
     }
-    
+
     @Test
     void sendAttempterSetsDeliveryStatusBasedOnStatusCode() throws IOException, InterruptedException, InvalidKeyException {
         given(mockHttpResponse.getStatusLine()).willReturn(mockStatusLine);
         given(mockWebhookMessageSender.sendWebhookMessage(any(WebhookMessageEntity.class))).willReturn(mockHttpResponse);
-        
+
         var webhookMessage = webhookMessageDao.create(webhookMessageEntity);
         var sendAttempter = new SendAttempter(webhookDeliveryQueueDao, instantSource, mockWebhookMessageSender, mockEnvironment);
         var enqueuedItem = webhookDeliveryQueueDao.enqueueFrom(webhookMessage, DeliveryStatus.PENDING, instantSource.instant());
         given(mockStatusLine.getStatusCode()).willReturn(404, 200);
-        
+
         sendAttempter.attemptSend(enqueuedItem);
         assertThat(enqueuedItem.getDeliveryStatus(), is(DeliveryStatus.FAILED));
         assertThat(webhookMessage.getLastDeliveryStatus(), is(DeliveryStatus.FAILED));
@@ -104,13 +105,13 @@ class SendAttempterTest {
         assertThat(enqueuedItem.getDeliveryStatus(), is(DeliveryStatus.SUCCESSFUL));
         assertThat(webhookMessage.getLastDeliveryStatus(), is(DeliveryStatus.SUCCESSFUL));
         assertThat(enqueuedItem.getDeliveryResult(), is("200 OK"));
-    }    
-    
+    }
+
     @Test
     void sendAttempterEmitsDeliveryStatusMetric() throws IOException, InvalidKeyException, InterruptedException {
         given(mockHttpResponse.getStatusLine()).willReturn(mockStatusLine);
         given(mockWebhookMessageSender.sendWebhookMessage(any(WebhookMessageEntity.class))).willReturn(mockHttpResponse);
-        
+
         var webhookMessage = webhookMessageDao.create(webhookMessageEntity);
         var sendAttempter = new SendAttempter(webhookDeliveryQueueDao, instantSource, mockWebhookMessageSender, mockEnvironment);
         var enqueuedItem = webhookDeliveryQueueDao.enqueueFrom(webhookMessage, DeliveryStatus.PENDING, instantSource.instant());
@@ -130,7 +131,7 @@ class SendAttempterTest {
         assertThat(enqueuedItem.getDeliveryStatus(), is(DeliveryStatus.FAILED));
         assertThat(webhookMessage.getLastDeliveryStatus(), is(DeliveryStatus.FAILED));
     }
-    
+
     @Test
     void sendAttempterEnqueuesRetriesIfFailure() throws IOException, InvalidKeyException, InterruptedException {
         given(mockHttpResponse.getStatusLine()).willReturn(mockStatusLine);
@@ -139,7 +140,7 @@ class SendAttempterTest {
         var sendAttempter = new SendAttempter(webhookDeliveryQueueDao, instantSource, mockWebhookMessageSender, mockEnvironment);
         var enqueuedItem = webhookDeliveryQueueDao.enqueueFrom(webhookMessage, DeliveryStatus.PENDING, instantSource.instant());
         given(mockStatusLine.getStatusCode()).willReturn(404);
-       
+
         sendAttempter.attemptSend(enqueuedItem);
         assertThat(enqueuedItem.getDeliveryStatus(), is(DeliveryStatus.FAILED));
         assertThat(webhookMessage.getLastDeliveryStatus(), is(DeliveryStatus.FAILED));

--- a/src/test/java/uk/gov/pay/webhooks/deliveryqueue/managed/SendAttempterTest.java
+++ b/src/test/java/uk/gov/pay/webhooks/deliveryqueue/managed/SendAttempterTest.java
@@ -9,6 +9,8 @@ import org.apache.http.client.methods.CloseableHttpResponse;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.FieldSource;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.pay.webhooks.deliveryqueue.DeliveryStatus;
@@ -24,10 +26,10 @@ import uk.gov.pay.webhooks.webhook.dao.WebhookDao;
 import uk.gov.pay.webhooks.webhook.dao.entity.WebhookEntity;
 
 import java.io.IOException;
-import java.net.http.HttpTimeoutException;
 import java.security.InvalidKeyException;
 import java.time.Instant;
 import java.time.InstantSource;
+import java.util.List;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
@@ -120,12 +122,20 @@ class SendAttempterTest {
         verify(mockMetricRegistry).counter("delivery-status.SUCCESSFUL");
     }
 
-    @Test
-    void should_catch_exceptions() throws IOException, InterruptedException, InvalidKeyException {
+    static List<Exception> exceptions = List.of(
+            new IOException(),
+            new InvalidKeyException(),
+            new InterruptedException(),
+            new RuntimeException());
+
+    @ParameterizedTest
+    @FieldSource("exceptions")
+    void should_catch_declared_checked_exceptions_and_all_runtime_exceptions(Exception exception) throws IOException, InvalidKeyException, InterruptedException {
+        given(mockWebhookMessageSender.sendWebhookMessage(any(WebhookMessageEntity.class)))
+                .willThrow(exception);
         var webhookMessage = webhookMessageDao.create(webhookMessageEntity);
-        var sendAttempter = new SendAttempter(webhookDeliveryQueueDao, instantSource, mockWebhookMessageSender, mockEnvironment);
         var enqueuedItem = webhookDeliveryQueueDao.enqueueFrom(webhookMessage, DeliveryStatus.PENDING, instantSource.instant());
-        given(mockWebhookMessageSender.sendWebhookMessage(any(WebhookMessageEntity.class))).willThrow(IOException.class, HttpTimeoutException.class);
+        var sendAttempter = new SendAttempter(webhookDeliveryQueueDao, instantSource, mockWebhookMessageSender, mockEnvironment);
 
         assertDoesNotThrow(() -> sendAttempter.attemptSend(enqueuedItem));
 

--- a/src/test/java/uk/gov/pay/webhooks/message/dao/entity/WebhookMessageEntityFixture.java
+++ b/src/test/java/uk/gov/pay/webhooks/message/dao/entity/WebhookMessageEntityFixture.java
@@ -1,0 +1,30 @@
+package uk.gov.pay.webhooks.message.dao.entity;
+
+import uk.gov.pay.webhooks.eventtype.dao.EventTypeEntity;
+import uk.gov.pay.webhooks.webhook.dao.entity.WebhookEntity;
+
+import java.time.Instant;
+
+public class WebhookMessageEntityFixture {
+
+    private WebhookEntity webhookEntity;
+    private final Instant eventDate = Instant.parse("2022-01-01T00:00:00Z");
+    private final EventTypeEntity eventType = new EventTypeEntity();
+
+    public static WebhookMessageEntityFixture aWebhookMessageEntity() {
+        return new WebhookMessageEntityFixture();
+    }
+
+    public WebhookMessageEntityFixture withWebhookEntity(WebhookEntity entity) {
+        this.webhookEntity = entity;
+        return this;
+    }
+
+    public WebhookMessageEntity build() {
+        var webhookMessageEntity = new WebhookMessageEntity();
+        webhookMessageEntity.setWebhookEntity(webhookEntity);
+        webhookMessageEntity.setEventDate(eventDate);
+        webhookMessageEntity.setEventType(eventType);
+        return webhookMessageEntity;
+    }
+}

--- a/src/test/java/uk/gov/pay/webhooks/webhook/dao/entity/WebhookEntityFixture.java
+++ b/src/test/java/uk/gov/pay/webhooks/webhook/dao/entity/WebhookEntityFixture.java
@@ -1,0 +1,27 @@
+package uk.gov.pay.webhooks.webhook.dao.entity;
+
+import static uk.gov.pay.webhooks.webhook.dao.entity.WebhookStatus.ACTIVE;
+
+public class WebhookEntityFixture {
+
+    private String callbackUrl;
+    private final WebhookStatus webhookStatus = ACTIVE;
+    private final String signingKey = "fake-signing-key";
+
+    public static WebhookEntityFixture aWebhookEntity() {
+        return new WebhookEntityFixture();
+    }
+
+    public WebhookEntityFixture withCallbackUrl(String callbackUrl) {
+        this.callbackUrl = callbackUrl;
+        return this;
+    }
+
+    public WebhookEntity buld() {
+        var webhookEntity = new WebhookEntity();
+        webhookEntity.setCallbackUrl(callbackUrl);
+        webhookEntity.setStatus(webhookStatus);
+        webhookEntity.setSigningKey(signingKey);
+        return webhookEntity;
+    }
+}


### PR DESCRIPTION
* Catches, logs and re-throws `Throwable` on webhook message send attempt
* Adds an initial narrow integration test for `SendAttempter` that describes the basic happy-path behaviour and fault behaviour against a mock target.

From studying the logs we see the following behaviour for these situations:

A send attempt is made (retry count is 0)

Nothing else relating to the webhook is logged

Exactly one day later (plus ε) another attempt is made, and generally succeeds. The retry count is also 0

It is clear that on the initial send attempt, we do not get past this line of SendAttempter:

[var response = webhookMessageSender.sendWebhookMessage(queueItem.getWebhookMessageEntity());](https://github.com/alphagov/pay-webhooks/blob/c427d94bd84929c55f878cc2af0f0585e30f899d/src/main/java/uk/gov/pay/webhooks/deliveryqueue/managed/SendAttempter.java#L91)

If an exception is thrown here, it must be caught, because the try-catch block includes Exception as the final catch. Therefore, it is possible that an Error is being thrown by the JVM. We do not log on Errors. It is possible that this Error interferes with the @UnitOfWork in which it is contained, the ScheduledExecutorService worker thread in which it runs, and/or the method by which we obtain the next entry to send (we obtain a “pessimistic write” lock on the entry with the lock timeout set to “skip locked” - see [WebhookDeliveryQueueDao#nextToSend](https://github.com/alphagov/pay-webhooks/blob/c427d94bd84929c55f878cc2af0f0585e30f899d/src/main/java/uk/gov/pay/webhooks/deliveryqueue/dao/WebhookDeliveryQueueDao.java#L35)). Perhaps the entry becomes “visible” again after exactly one day, by some mechanism.

In any case, additionally logging Throwables may very well point us to the source of the problem.