### PR TITLE
PP-14806 - Webhooks: add gateway account and service IDs to MDC

### DIFF
--- a/src/main/java/uk/gov/pay/webhooks/app/filters/LoggingMDCRequestFilter.java
+++ b/src/main/java/uk/gov/pay/webhooks/app/filters/LoggingMDCRequestFilter.java
@@ -1,14 +1,15 @@
 package uk.gov.pay.webhooks.app.filters;
 
-import org.slf4j.MDC;
-
 import jakarta.ws.rs.container.ContainerRequestContext;
 import jakarta.ws.rs.container.ContainerRequestFilter;
+import org.slf4j.MDC;
+
 import java.util.Optional;
 
 import static uk.gov.pay.webhooks.app.WebhooksKeys.RESOURCE_IS_LIVE;
 import static uk.gov.pay.webhooks.app.WebhooksKeys.WEBHOOK_EXTERNAL_ID;
 import static uk.gov.pay.webhooks.app.WebhooksKeys.WEBHOOK_MESSAGE_EXTERNAL_ID;
+import static uk.gov.service.payments.logging.LoggingKeys.GATEWAY_ACCOUNT_ID;
 import static uk.gov.service.payments.logging.LoggingKeys.SERVICE_EXTERNAL_ID;
 
 public class LoggingMDCRequestFilter implements ContainerRequestFilter {
@@ -22,6 +23,9 @@ public class LoggingMDCRequestFilter implements ContainerRequestFilter {
 
         getQueryParameterFromRequest("service_id", containerRequestContext)
                 .ifPresent(serviceExternalId -> MDC.put(SERVICE_EXTERNAL_ID, serviceExternalId));
+
+        getQueryParameterFromRequest("gateway_account_id", containerRequestContext)
+                .ifPresent(gatewayAccountId -> MDC.put(GATEWAY_ACCOUNT_ID, gatewayAccountId));
 
         getQueryParameterFromRequest("live", containerRequestContext)
                 .ifPresent(isLive -> MDC.put(RESOURCE_IS_LIVE, isLive));

--- a/src/main/java/uk/gov/pay/webhooks/app/filters/LoggingMDCResponseFilter.java
+++ b/src/main/java/uk/gov/pay/webhooks/app/filters/LoggingMDCResponseFilter.java
@@ -1,21 +1,23 @@
 package uk.gov.pay.webhooks.app.filters;
 
-import org.slf4j.MDC;
-
 import jakarta.ws.rs.container.ContainerRequestContext;
 import jakarta.ws.rs.container.ContainerResponseContext;
 import jakarta.ws.rs.container.ContainerResponseFilter;
-
-import java.util.List;
+import org.slf4j.MDC;
 
 import static uk.gov.pay.webhooks.app.WebhooksKeys.RESOURCE_IS_LIVE;
 import static uk.gov.pay.webhooks.app.WebhooksKeys.WEBHOOK_EXTERNAL_ID;
 import static uk.gov.pay.webhooks.app.WebhooksKeys.WEBHOOK_MESSAGE_EXTERNAL_ID;
+import static uk.gov.service.payments.logging.LoggingKeys.GATEWAY_ACCOUNT_ID;
 import static uk.gov.service.payments.logging.LoggingKeys.SERVICE_EXTERNAL_ID;
 
 public class LoggingMDCResponseFilter implements ContainerResponseFilter {
     @Override
     public void filter(ContainerRequestContext containerRequestContext, ContainerResponseContext containerResponseContext) {
-        List.of(WEBHOOK_EXTERNAL_ID, WEBHOOK_MESSAGE_EXTERNAL_ID, SERVICE_EXTERNAL_ID, RESOURCE_IS_LIVE).forEach(MDC::remove);
+        MDC.remove(WEBHOOK_EXTERNAL_ID);
+        MDC.remove(WEBHOOK_MESSAGE_EXTERNAL_ID);
+        MDC.remove(SERVICE_EXTERNAL_ID);
+        MDC.remove(GATEWAY_ACCOUNT_ID);
+        MDC.remove(RESOURCE_IS_LIVE);
     }
 }

--- a/src/main/java/uk/gov/pay/webhooks/deliveryqueue/managed/SendAttempter.java
+++ b/src/main/java/uk/gov/pay/webhooks/deliveryqueue/managed/SendAttempter.java
@@ -103,10 +103,7 @@ public class SendAttempter {
         } catch (SocketTimeoutException | HttpTimeoutException | NoHttpResponseException | ConnectTimeoutException _) {
             LOGGER.info("Request timed out");
             handleResponse(queueItem, DeliveryStatus.FAILED, null, "HTTP Timeout", retryCount, start, Optional.of(callbackUrl));
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            handleRequestException(queueItem, retryCount, start, e);
-        } catch (IOException | InvalidKeyException e) {
+        } catch (IOException | InvalidKeyException | InterruptedException e) {
             handleRequestException(queueItem, retryCount, start, e);
         } catch (WebhookNotActiveException _) {
             LOGGER.info("Not sending webhook message for non-active webhook");

--- a/src/main/java/uk/gov/pay/webhooks/deliveryqueue/managed/SendAttempter.java
+++ b/src/main/java/uk/gov/pay/webhooks/deliveryqueue/managed/SendAttempter.java
@@ -10,7 +10,6 @@ import org.apache.http.NoHttpResponseException;
 import org.apache.http.conn.ConnectTimeoutException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.slf4j.MDC;
 import uk.gov.pay.webhooks.deliveryqueue.DeliveryStatus;
 import uk.gov.pay.webhooks.deliveryqueue.WebhookNotActiveException;
 import uk.gov.pay.webhooks.deliveryqueue.dao.WebhookDeliveryQueueDao;
@@ -42,10 +41,8 @@ import static uk.gov.pay.webhooks.app.WebhooksKeys.WEBHOOK_CALLBACK_URL_DOMAIN;
 import static uk.gov.pay.webhooks.app.WebhooksKeys.WEBHOOK_MESSAGE_ATTEMPT_RESPONSE_REASON;
 import static uk.gov.pay.webhooks.app.WebhooksKeys.WEBHOOK_MESSAGE_DELAY_BETWEEN_ATTEMPT_SCHEDULED_SEND_AT_TIME_AND_NOW;
 import static uk.gov.pay.webhooks.app.WebhooksKeys.WEBHOOK_MESSAGE_RETRY_COUNT;
-import static uk.gov.service.payments.logging.LoggingKeys.GATEWAY_ACCOUNT_ID;
 import static uk.gov.service.payments.logging.LoggingKeys.HTTP_STATUS;
 import static uk.gov.service.payments.logging.LoggingKeys.RESPONSE_TIME;
-import static uk.gov.service.payments.logging.LoggingKeys.SERVICE_EXTERNAL_ID;
 
 public class SendAttempter {
     private static final Logger LOGGER = LoggerFactory.getLogger(SendAttempter.class);
@@ -74,9 +71,6 @@ public class SendAttempter {
         var webhook = queueItem.getWebhookMessageEntity().getWebhookEntity();
         var retryCount = webhookDeliveryQueueDao.countFailed(queueItem.getWebhookMessageEntity());
         Instant start = instantSource.instant();
-
-        MDC.put(GATEWAY_ACCOUNT_ID, webhook.getGatewayAccountId());
-        MDC.put(SERVICE_EXTERNAL_ID, webhook.getServiceId());
 
         URL callbackUrl;
 

--- a/src/main/java/uk/gov/pay/webhooks/deliveryqueue/managed/SendAttempter.java
+++ b/src/main/java/uk/gov/pay/webhooks/deliveryqueue/managed/SendAttempter.java
@@ -10,6 +10,7 @@ import org.apache.http.NoHttpResponseException;
 import org.apache.http.conn.ConnectTimeoutException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
 import uk.gov.pay.webhooks.deliveryqueue.DeliveryStatus;
 import uk.gov.pay.webhooks.deliveryqueue.WebhookNotActiveException;
 import uk.gov.pay.webhooks.deliveryqueue.dao.WebhookDeliveryQueueDao;
@@ -20,6 +21,7 @@ import uk.gov.pay.webhooks.validations.CallbackUrlDomainNotOnAllowListException;
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.SocketTimeoutException;
+import java.net.URI;
 import java.net.URL;
 import java.net.http.HttpTimeoutException;
 import java.security.InvalidKeyException;
@@ -40,8 +42,10 @@ import static uk.gov.pay.webhooks.app.WebhooksKeys.WEBHOOK_CALLBACK_URL_DOMAIN;
 import static uk.gov.pay.webhooks.app.WebhooksKeys.WEBHOOK_MESSAGE_ATTEMPT_RESPONSE_REASON;
 import static uk.gov.pay.webhooks.app.WebhooksKeys.WEBHOOK_MESSAGE_DELAY_BETWEEN_ATTEMPT_SCHEDULED_SEND_AT_TIME_AND_NOW;
 import static uk.gov.pay.webhooks.app.WebhooksKeys.WEBHOOK_MESSAGE_RETRY_COUNT;
+import static uk.gov.service.payments.logging.LoggingKeys.GATEWAY_ACCOUNT_ID;
 import static uk.gov.service.payments.logging.LoggingKeys.HTTP_STATUS;
 import static uk.gov.service.payments.logging.LoggingKeys.RESPONSE_TIME;
+import static uk.gov.service.payments.logging.LoggingKeys.SERVICE_EXTERNAL_ID;
 
 public class SendAttempter {
     private static final Logger LOGGER = LoggerFactory.getLogger(SendAttempter.class);
@@ -71,12 +75,17 @@ public class SendAttempter {
         var retryCount = webhookDeliveryQueueDao.countFailed(queueItem.getWebhookMessageEntity());
         Instant start = instantSource.instant();
 
-        URL url = null;
+        MDC.put(GATEWAY_ACCOUNT_ID, webhook.getGatewayAccountId());
+        MDC.put(SERVICE_EXTERNAL_ID, webhook.getServiceId());
+
+        URL callbackUrl;
 
         try {
-            url = new URL(webhook.getCallbackUrl().strip());
-        } catch (MalformedURLException e) {
+            callbackUrl = URI.create(webhook.getCallbackUrl().strip()).toURL();
+        } catch (IllegalArgumentException | MalformedURLException e) {
             handleGenericException(queueItem, retryCount, start, e);
+            // stops code from proceeding if it fails to parse URL
+            return;
         }
 
         try {
@@ -84,43 +93,43 @@ public class SendAttempter {
             LOGGER.info(
                     Markers.append(WEBHOOK_CALLBACK_URL, queueItem.getWebhookMessageEntity().getWebhookEntity().getCallbackUrl())
                             .and(Markers.append(WEBHOOK_MESSAGE_RETRY_COUNT, retryCount))
-                            .and(Markers.append(WEBHOOK_CALLBACK_URL_DOMAIN, url.getHost()))
+                            .and(Markers.append(WEBHOOK_CALLBACK_URL_DOMAIN, callbackUrl.getHost()))
                             .and(Markers.append(WEBHOOK_MESSAGE_DELAY_BETWEEN_ATTEMPT_SCHEDULED_SEND_AT_TIME_AND_NOW, Duration.between(queueItem.getSendAt(), instantSource.instant()).toMillis())),
                     "Sending webhook message started"
             );
-            var response = webhookMessageSender.sendWebhookMessage(queueItem.getWebhookMessageEntity());
+            try (var response = webhookMessageSender.sendWebhookMessage(queueItem.getWebhookMessageEntity())) {
 
-            var statusCode = response.getStatusLine().getStatusCode();
-            if (statusCode >= 200 && statusCode <= 299) {
-                handleResponse(queueItem, DeliveryStatus.SUCCESSFUL, statusCode, getReasonFromStatusCode(statusCode), retryCount, start, Optional.of(url));
-            } else {
-                handleResponse(queueItem, DeliveryStatus.FAILED, statusCode, getReasonFromStatusCode(statusCode), retryCount, start, Optional.of(url));
+                var statusCode = response.getStatusLine().getStatusCode();
+                if (statusCode >= 200 && statusCode <= 299) {
+                    handleResponse(queueItem, DeliveryStatus.SUCCESSFUL, statusCode, getReasonFromStatusCode(statusCode), retryCount, start, Optional.of(callbackUrl));
+                } else {
+                    handleResponse(queueItem, DeliveryStatus.FAILED, statusCode, getReasonFromStatusCode(statusCode), retryCount, start, Optional.of(callbackUrl));
+                }
             }
-        } catch (SocketTimeoutException | HttpTimeoutException | NoHttpResponseException | ConnectTimeoutException e) {
+        } catch (SocketTimeoutException | HttpTimeoutException | NoHttpResponseException | ConnectTimeoutException _) {
             LOGGER.info("Request timed out");
-            handleResponse(queueItem, DeliveryStatus.FAILED, null, "HTTP Timeout", retryCount, start, Optional.of(url));
-        } catch (IOException | InterruptedException | InvalidKeyException e) {
-            LOGGER.info(
-                    Markers.append(ERROR_MESSAGE, e.getMessage()),
-                    "Exception caught by request"
-            );
-            handleResponse(queueItem, DeliveryStatus.FAILED, null, e.getMessage(), retryCount, start);
-        } catch (WebhookNotActiveException e) {
+            handleResponse(queueItem, DeliveryStatus.FAILED, null, "HTTP Timeout", retryCount, start, Optional.of(callbackUrl));
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            handleRequestException(queueItem, retryCount, start, e);
+        } catch (IOException | InvalidKeyException e) {
+            handleRequestException(queueItem, retryCount, start, e);
+        } catch (WebhookNotActiveException _) {
             LOGGER.info("Not sending webhook message for non-active webhook");
-            handleResponse(queueItem, DeliveryStatus.WILL_NOT_SEND, null, "Webhook not active", retryCount, start);
+            handleResponse(queueItem, DeliveryStatus.WILL_NOT_SEND, null, "Webhook not active", retryCount, start, Optional.empty());
         } catch (CallbackUrlDomainNotOnAllowListException e) {
             LOGGER.error(
                     Markers.append(WEBHOOK_CALLBACK_URL_DOMAIN, e.getUrl()),
                     "Attempt to send to a domain not on the allow list has been blocked"
             );
-            handleResponse(queueItem, DeliveryStatus.WILL_NOT_SEND, null, "Violates security rules", retryCount, start);
+            handleResponse(queueItem, DeliveryStatus.WILL_NOT_SEND, null, "Violates security rules", retryCount, start, Optional.empty());
         } catch (Exception e) {
             handleGenericException(queueItem, retryCount, start, e);
-        } catch (Throwable throwable) {
+        } catch (Error error) {
             LOGGER.atError()
-                    .setCause(throwable)
+                    .setCause(error)
                     .log("Error during webhook message send");
-            throw throwable;
+            throw error;
         }
     }
 
@@ -131,16 +140,15 @@ public class SendAttempter {
                 Markers.append(ERROR_MESSAGE, e.getMessage()),
                 "Unexpected exception thrown by request"
         );
-        handleResponse(queueItem, DeliveryStatus.FAILED, null, "Unknown error", retryCount, start);
+        handleResponse(queueItem, DeliveryStatus.FAILED, null, "Unknown error", retryCount, start, Optional.empty());
     }
 
-    private void handleResponse(WebhookDeliveryQueueEntity webhookDeliveryQueueEntity,
-                                DeliveryStatus status,
-                                Integer statusCode,
-                                String reason,
-                                Long retryCount,
-                                Instant startTime) {
-        handleResponse(webhookDeliveryQueueEntity, status, statusCode, reason, retryCount, startTime, Optional.empty());
+    private void handleRequestException(WebhookDeliveryQueueEntity queueItem, Long retryCount, Instant start, Exception e) {
+        LOGGER.info(
+                Markers.append(ERROR_MESSAGE, e.getMessage()),
+                "Exception caught by request"
+        );
+        handleResponse(queueItem, DeliveryStatus.FAILED, null, e.getMessage(), retryCount, start, Optional.empty());
     }
 
     private void handleResponse(WebhookDeliveryQueueEntity webhookDeliveryQueueEntity,
@@ -174,9 +182,7 @@ public class SendAttempter {
         Optional.ofNullable(nextRetryIn).ifPresentOrElse(retryDelay -> {
             LOGGER.info("Scheduling webhook message for retry");
             webhookDeliveryQueueDao.enqueueFrom(queueItem.getWebhookMessageEntity(), DeliveryStatus.PENDING, instantSource.instant().plus(retryDelay));
-        }, () -> {
-            LOGGER.warn("Webhook message terminally failed to deliver");
-        });
+        }, () -> LOGGER.warn("Webhook message terminally failed to deliver"));
     }
 
     private Duration nextRetryIn(Long retryCount) {

--- a/src/main/java/uk/gov/pay/webhooks/deliveryqueue/managed/SendAttempter.java
+++ b/src/main/java/uk/gov/pay/webhooks/deliveryqueue/managed/SendAttempter.java
@@ -78,7 +78,6 @@ public class SendAttempter {
             callbackUrl = URI.create(webhook.getCallbackUrl().strip()).toURL();
         } catch (IllegalArgumentException | MalformedURLException e) {
             handleGenericException(queueItem, retryCount, start, e);
-            // stops code from proceeding if it fails to parse URL
             return;
         }
 

--- a/src/main/java/uk/gov/pay/webhooks/deliveryqueue/managed/WebhookMessagePollingService.java
+++ b/src/main/java/uk/gov/pay/webhooks/deliveryqueue/managed/WebhookMessagePollingService.java
@@ -1,14 +1,13 @@
 package uk.gov.pay.webhooks.deliveryqueue.managed;
 
 import io.dropwizard.hibernate.UnitOfWork;
+import jakarta.inject.Inject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
 import uk.gov.pay.webhooks.deliveryqueue.dao.WebhookDeliveryQueueDao;
 import uk.gov.pay.webhooks.deliveryqueue.dao.WebhookDeliveryQueueEntity;
 
-import jakarta.inject.Inject;
-import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -16,6 +15,7 @@ import static uk.gov.pay.webhooks.app.WebhooksKeys.RESOURCE_IS_LIVE;
 import static uk.gov.pay.webhooks.app.WebhooksKeys.WEBHOOK_EXTERNAL_ID;
 import static uk.gov.pay.webhooks.app.WebhooksKeys.WEBHOOK_MESSAGE_EVENT_TYPE;
 import static uk.gov.pay.webhooks.app.WebhooksKeys.WEBHOOK_MESSAGE_EXTERNAL_ID;
+import static uk.gov.service.payments.logging.LoggingKeys.GATEWAY_ACCOUNT_ID;
 import static uk.gov.service.payments.logging.LoggingKeys.MDC_REQUEST_ID_KEY;
 import static uk.gov.service.payments.logging.LoggingKeys.RESOURCE_EXTERNAL_ID;
 import static uk.gov.service.payments.logging.LoggingKeys.SERVICE_EXTERNAL_ID;
@@ -51,6 +51,7 @@ public class WebhookMessagePollingService {
                         MDC.put(WEBHOOK_MESSAGE_EXTERNAL_ID, webhookMessage.getExternalId());
                         MDC.put(WEBHOOK_MESSAGE_EVENT_TYPE, webhookMessage.getEventType().getName().getName());
                         MDC.put(SERVICE_EXTERNAL_ID, webhook.getServiceId());
+                        MDC.put(GATEWAY_ACCOUNT_ID, webhook.getGatewayAccountId());
                         MDC.put(RESOURCE_IS_LIVE, String.valueOf(webhook.isLive()));
 
                         sendAttempter.attemptSend(webhookDeliveryQueueEntity);
@@ -60,12 +61,14 @@ public class WebhookMessagePollingService {
             LOGGER.error("Webhook message sender polling thread exception", e);
             return Optional.empty();
         } finally {
-            List.of(MDC_REQUEST_ID_KEY,
-                    WEBHOOK_EXTERNAL_ID,
-                    RESOURCE_EXTERNAL_ID,
-                    WEBHOOK_MESSAGE_EVENT_TYPE,
-                    SERVICE_EXTERNAL_ID,
-                    RESOURCE_IS_LIVE).forEach(MDC::remove);
+            MDC.remove(MDC_REQUEST_ID_KEY);
+            MDC.remove(WEBHOOK_EXTERNAL_ID);
+            MDC.remove(RESOURCE_EXTERNAL_ID);
+            MDC.remove(WEBHOOK_MESSAGE_EXTERNAL_ID);
+            MDC.remove(WEBHOOK_MESSAGE_EVENT_TYPE);
+            MDC.remove(SERVICE_EXTERNAL_ID);
+            MDC.remove(GATEWAY_ACCOUNT_ID);
+            MDC.remove(RESOURCE_IS_LIVE);
         }
     }
 }

--- a/src/main/java/uk/gov/pay/webhooks/queue/EventMessageHandler.java
+++ b/src/main/java/uk/gov/pay/webhooks/queue/EventMessageHandler.java
@@ -9,13 +9,12 @@ import org.slf4j.MDC;
 import uk.gov.pay.webhooks.message.WebhookMessageService;
 import uk.gov.pay.webhooks.queue.sqs.QueueException;
 
-import java.util.List;
-import java.util.Optional;
 import java.util.UUID;
 
 import static uk.gov.pay.webhooks.app.WebhooksKeys.ERROR;
 import static uk.gov.pay.webhooks.app.WebhooksKeys.ERROR_MESSAGE;
 import static uk.gov.pay.webhooks.app.WebhooksKeys.RESOURCE_IS_LIVE;
+import static uk.gov.service.payments.logging.LoggingKeys.GATEWAY_ACCOUNT_ID;
 import static uk.gov.service.payments.logging.LoggingKeys.LEDGER_EVENT_TYPE;
 import static uk.gov.service.payments.logging.LoggingKeys.MDC_REQUEST_ID_KEY;
 import static uk.gov.service.payments.logging.LoggingKeys.RESOURCE_EXTERNAL_ID;
@@ -41,7 +40,8 @@ public class EventMessageHandler {
                 MDC.put(MDC_REQUEST_ID_KEY, UUID.randomUUID().toString());
                 MDC.put(SQS_MESSAGE_ID, message.queueMessage().messageId());
                 MDC.put(SERVICE_EXTERNAL_ID, message.eventMessageDto().serviceId());
-                MDC.put(RESOURCE_IS_LIVE, Optional.ofNullable(message.eventMessageDto().live()).map(String::valueOf).orElse(null));
+                MDC.put(GATEWAY_ACCOUNT_ID, message.eventMessageDto().gatewayAccountId());
+                MDC.put(RESOURCE_IS_LIVE, String.valueOf(message.eventMessageDto().live()));
                 MDC.put(RESOURCE_EXTERNAL_ID, message.eventMessageDto().resourceExternalId());
                 MDC.put(LEDGER_EVENT_TYPE, message.eventMessageDto().eventType());
                 processSingleMessage(message);
@@ -52,12 +52,13 @@ public class EventMessageHandler {
                         "Error during handling event message"
                 );
             } finally {
-                List.of(MDC_REQUEST_ID_KEY,
-                        SQS_MESSAGE_ID,
-                        SERVICE_EXTERNAL_ID,
-                        RESOURCE_IS_LIVE,
-                        RESOURCE_EXTERNAL_ID,
-                        LEDGER_EVENT_TYPE).forEach(MDC::remove);
+                MDC.remove(MDC_REQUEST_ID_KEY);
+                MDC.remove(SQS_MESSAGE_ID);
+                MDC.remove(SERVICE_EXTERNAL_ID);
+                MDC.remove(GATEWAY_ACCOUNT_ID);
+                MDC.remove(RESOURCE_IS_LIVE);
+                MDC.remove(RESOURCE_EXTERNAL_ID);
+                MDC.remove(LEDGER_EVENT_TYPE);
             }
         }
     }

--- a/src/main/java/uk/gov/pay/webhooks/validations/WebhookRequestValidator.java
+++ b/src/main/java/uk/gov/pay/webhooks/validations/WebhookRequestValidator.java
@@ -11,10 +11,13 @@ import uk.gov.service.payments.commons.model.jsonpatch.JsonPatchRequest;
 
 import java.util.Map;
 
+import static uk.gov.pay.webhooks.app.WebhooksKeys.RESOURCE_IS_LIVE;
 import static uk.gov.pay.webhooks.webhook.resource.WebhookResponse.FIELD_CALLBACK_URL;
 import static uk.gov.pay.webhooks.webhook.resource.WebhookResponse.FIELD_DESCRIPTION;
 import static uk.gov.pay.webhooks.webhook.resource.WebhookResponse.FIELD_STATUS;
 import static uk.gov.pay.webhooks.webhook.resource.WebhookResponse.FIELD_SUBSCRIPTIONS;
+import static uk.gov.service.payments.logging.LoggingKeys.GATEWAY_ACCOUNT_ID;
+import static uk.gov.service.payments.logging.LoggingKeys.SERVICE_EXTERNAL_ID;
 
 
 public class WebhookRequestValidator {
@@ -28,7 +31,7 @@ public class WebhookRequestValidator {
         this.callbackUrlService = callbackUrlService;
     }
 
-    public void validate(JsonNode payload, Boolean isLiveContext)  {
+    public void validate(JsonNode payload, Boolean isLiveContext) {
         if (isLiveContext) {
             liveContextValidator.validate(payload);
         } else {
@@ -40,13 +43,15 @@ public class WebhookRequestValidator {
     //                callback url. This will require guice injection in the validator contexts and is out of scoped here
     //                but would allow for all of the validation to be processed in one place
     public void validate(CreateWebhookRequest createWebhookRequest) {
-        MDC.put("gateway_account_id", createWebhookRequest.gatewayAccountId());
-        MDC.put("service_id", createWebhookRequest.serviceId());
-        MDC.put("live", createWebhookRequest.live().toString());
+        MDC.put(GATEWAY_ACCOUNT_ID, createWebhookRequest.gatewayAccountId());
+        MDC.put(SERVICE_EXTERNAL_ID, createWebhookRequest.serviceId());
+        MDC.put(RESOURCE_IS_LIVE, String.valueOf(createWebhookRequest.live()));
         try {
             callbackUrlService.validateCallbackUrl(createWebhookRequest.callbackUrl(), createWebhookRequest.live());
         } finally {
-            MDC.clear();
+            MDC.remove(RESOURCE_IS_LIVE);
+            MDC.remove(GATEWAY_ACCOUNT_ID);
+            MDC.remove(SERVICE_EXTERNAL_ID);
         }
     }
 
@@ -56,7 +61,9 @@ public class WebhookRequestValidator {
                         new PatchPathOperation(FIELD_DESCRIPTION, JsonPatchOp.REPLACE), JsonPatchRequestValidator::throwIfValueNotString,
                         new PatchPathOperation(FIELD_STATUS, JsonPatchOp.REPLACE), RequestValidations::throwIfValueNotValidStatusEnum,
                         new PatchPathOperation(FIELD_SUBSCRIPTIONS, JsonPatchOp.REPLACE), RequestValidations::throwIfValueNotValidSubscriptionsArray,
-                        new PatchPathOperation(FIELD_CALLBACK_URL, JsonPatchOp.REPLACE), (jsonPatchRequest) -> { throwIfCallbackUrlNotValid(jsonPatchRequest, isLiveContext); }
+                        new PatchPathOperation(FIELD_CALLBACK_URL, JsonPatchOp.REPLACE), (jsonPatchRequest) -> {
+                            throwIfCallbackUrlNotValid(jsonPatchRequest, isLiveContext);
+                        }
                 )
         );
     }

--- a/src/test/java/uk/gov/pay/webhooks/deliveryqueue/managed/SendAttempterTest.java
+++ b/src/test/java/uk/gov/pay/webhooks/deliveryqueue/managed/SendAttempterTest.java
@@ -95,8 +95,7 @@ class SendAttempterTest {
         webhookMessageEntity.setCreatedDate(instantSource.instant());
         given(mockEnvironment.metrics()).willReturn(mockMetricRegistry);
     }
-
-
+    
     @Test
     void should_set_delivery_status_based_on_status_code() throws IOException, InterruptedException, InvalidKeyException {
         given(mockHttpResponse.getStatusLine()).willReturn(mockStatusLine);

--- a/src/test/java/uk/gov/pay/webhooks/deliveryqueue/managed/SendAttempterTest.java
+++ b/src/test/java/uk/gov/pay/webhooks/deliveryqueue/managed/SendAttempterTest.java
@@ -38,15 +38,12 @@ import java.util.List;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
-import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 import static org.slf4j.event.Level.ERROR;
-import static uk.gov.service.payments.logging.LoggingKeys.GATEWAY_ACCOUNT_ID;
-import static uk.gov.service.payments.logging.LoggingKeys.SERVICE_EXTERNAL_ID;
 
 @ExtendWith(MockitoExtension.class)
 @ExtendWith(DropwizardExtensionsSupport.class)
@@ -177,28 +174,6 @@ class SendAttempterTest {
         assertThat(loggingEvent.getThrowable().getMessage(), is(errorMessage));
     }
 
-    @Test
-    void should_set_gateway_account_and_service_context_for_send_attempt_logs() throws IOException, InvalidKeyException, InterruptedException {
-        given(mockWebhookMessageSender.sendWebhookMessage(any(WebhookMessageEntity.class)))
-                .willAnswer(_ -> {
-                    assertThat(MDC.get(GATEWAY_ACCOUNT_ID), is("gateway-account-id-1"));
-                    assertThat(MDC.get(SERVICE_EXTERNAL_ID), is("service-id-1"));
-                    throw new IOException("boom");
-                });
-
-        MDC.put(GATEWAY_ACCOUNT_ID, "previous-gateway-account-id");
-        MDC.put(SERVICE_EXTERNAL_ID, "previous-service-id");
-
-        var webhookMessage = webhookMessageDao.create(webhookMessageEntity);
-        var enqueuedItem = webhookDeliveryQueueDao.enqueueFrom(webhookMessage, DeliveryStatus.PENDING, instantSource.instant());
-        var sendAttempter = new SendAttempter(webhookDeliveryQueueDao, instantSource, mockWebhookMessageSender, mockEnvironment);
-
-        sendAttempter.attemptSend(enqueuedItem);
-
-        assertThat(MDC.get(GATEWAY_ACCOUNT_ID), is("gateway-account-id-1"));
-        assertThat(MDC.get(SERVICE_EXTERNAL_ID),  is("service-id-1"));
-        logs.assertContains("Exception caught by request");
-    }
 
     @Test
     void should_enqueue_retries_if_failure() throws IOException, InvalidKeyException, InterruptedException {

--- a/src/test/java/uk/gov/pay/webhooks/deliveryqueue/managed/SendAttempterTest.java
+++ b/src/test/java/uk/gov/pay/webhooks/deliveryqueue/managed/SendAttempterTest.java
@@ -7,7 +7,6 @@ import io.dropwizard.testing.junit5.DropwizardExtensionsSupport;
 import io.github.netmikey.logunit.api.LogCapturer;
 import org.apache.http.StatusLine;
 import org.apache.http.client.methods.CloseableHttpResponse;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -16,7 +15,6 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.FieldSource;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.slf4j.MDC;
 import uk.gov.pay.webhooks.deliveryqueue.DeliveryStatus;
 import uk.gov.pay.webhooks.deliveryqueue.WebhookNotActiveException;
 import uk.gov.pay.webhooks.deliveryqueue.dao.WebhookDeliveryQueueDao;
@@ -98,10 +96,6 @@ class SendAttempterTest {
         given(mockEnvironment.metrics()).willReturn(mockMetricRegistry);
     }
 
-    @AfterEach
-    void tearDown() {
-        MDC.clear();
-    }
 
     @Test
     void should_set_delivery_status_based_on_status_code() throws IOException, InterruptedException, InvalidKeyException {

--- a/src/test/java/uk/gov/pay/webhooks/deliveryqueue/managed/SendAttempterTest.java
+++ b/src/test/java/uk/gov/pay/webhooks/deliveryqueue/managed/SendAttempterTest.java
@@ -166,8 +166,7 @@ class SendAttempterTest {
         assertThat(loggingEvent.getLevel(), is(ERROR));
         assertThat(loggingEvent.getThrowable().getMessage(), is(errorMessage));
     }
-
-
+    
     @Test
     void should_enqueue_retries_if_failure() throws IOException, InvalidKeyException, InterruptedException {
         given(mockHttpResponse.getStatusLine()).willReturn(mockStatusLine);

--- a/src/test/java/uk/gov/pay/webhooks/deliveryqueue/managed/SendAttempterTest.java
+++ b/src/test/java/uk/gov/pay/webhooks/deliveryqueue/managed/SendAttempterTest.java
@@ -95,7 +95,7 @@ class SendAttempterTest {
         webhookMessageEntity.setCreatedDate(instantSource.instant());
         given(mockEnvironment.metrics()).willReturn(mockMetricRegistry);
     }
-    
+
     @Test
     void should_set_delivery_status_based_on_status_code() throws IOException, InterruptedException, InvalidKeyException {
         given(mockHttpResponse.getStatusLine()).willReturn(mockStatusLine);

--- a/src/test/java/uk/gov/pay/webhooks/deliveryqueue/managed/SendAttempterTest.java
+++ b/src/test/java/uk/gov/pay/webhooks/deliveryqueue/managed/SendAttempterTest.java
@@ -7,6 +7,7 @@ import io.dropwizard.testing.junit5.DropwizardExtensionsSupport;
 import io.github.netmikey.logunit.api.LogCapturer;
 import org.apache.http.StatusLine;
 import org.apache.http.client.methods.CloseableHttpResponse;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -15,6 +16,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.FieldSource;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.slf4j.MDC;
 import uk.gov.pay.webhooks.deliveryqueue.DeliveryStatus;
 import uk.gov.pay.webhooks.deliveryqueue.WebhookNotActiveException;
 import uk.gov.pay.webhooks.deliveryqueue.dao.WebhookDeliveryQueueDao;
@@ -36,12 +38,15 @@ import java.util.List;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 import static org.slf4j.event.Level.ERROR;
+import static uk.gov.service.payments.logging.LoggingKeys.GATEWAY_ACCOUNT_ID;
+import static uk.gov.service.payments.logging.LoggingKeys.SERVICE_EXTERNAL_ID;
 
 @ExtendWith(MockitoExtension.class)
 @ExtendWith(DropwizardExtensionsSupport.class)
@@ -85,6 +90,7 @@ class SendAttempterTest {
         WebhookEntity webhookEntity = new WebhookEntity();
         webhookEntity.setLive(true);
         webhookEntity.setServiceId("service-id-1");
+        webhookEntity.setGatewayAccountId("gateway-account-id-1");
         webhookEntity.setCreatedDate(Instant.parse("2007-12-03T10:15:30.00Z"));
         webhookEntity.setCallbackUrl("http://example.com");
         webhookEntity.setSigningKey("some-signing-key");
@@ -93,6 +99,11 @@ class SendAttempterTest {
         webhookMessageEntity.setWebhookEntity(webhookEntity);
         webhookMessageEntity.setCreatedDate(instantSource.instant());
         given(mockEnvironment.metrics()).willReturn(mockMetricRegistry);
+    }
+
+    @AfterEach
+    void tearDown() {
+        MDC.clear();
     }
 
     @Test
@@ -164,6 +175,29 @@ class SendAttempterTest {
         var loggingEvent = logs.assertContains("Error during webhook message send");
         assertThat(loggingEvent.getLevel(), is(ERROR));
         assertThat(loggingEvent.getThrowable().getMessage(), is(errorMessage));
+    }
+
+    @Test
+    void should_set_and_clear_gateway_account_and_service_context_for_send_attempt_logs() throws IOException, InvalidKeyException, InterruptedException {
+        given(mockWebhookMessageSender.sendWebhookMessage(any(WebhookMessageEntity.class)))
+                .willAnswer(_ -> {
+                    assertThat(MDC.get(GATEWAY_ACCOUNT_ID), is("gateway-account-id-1"));
+                    assertThat(MDC.get(SERVICE_EXTERNAL_ID), is("service-id-1"));
+                    throw new IOException("boom");
+                });
+
+        MDC.put(GATEWAY_ACCOUNT_ID, "previous-gateway-account-id");
+        MDC.put(SERVICE_EXTERNAL_ID, "previous-service-id");
+
+        var webhookMessage = webhookMessageDao.create(webhookMessageEntity);
+        var enqueuedItem = webhookDeliveryQueueDao.enqueueFrom(webhookMessage, DeliveryStatus.PENDING, instantSource.instant());
+        var sendAttempter = new SendAttempter(webhookDeliveryQueueDao, instantSource, mockWebhookMessageSender, mockEnvironment);
+
+        sendAttempter.attemptSend(enqueuedItem);
+
+        assertNull(MDC.get(GATEWAY_ACCOUNT_ID));
+        assertNull(MDC.get(SERVICE_EXTERNAL_ID));
+        logs.assertContains("Exception caught by request");
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/webhooks/deliveryqueue/managed/SendAttempterTest.java
+++ b/src/test/java/uk/gov/pay/webhooks/deliveryqueue/managed/SendAttempterTest.java
@@ -166,7 +166,7 @@ class SendAttempterTest {
         assertThat(loggingEvent.getLevel(), is(ERROR));
         assertThat(loggingEvent.getThrowable().getMessage(), is(errorMessage));
     }
-    
+
     @Test
     void should_enqueue_retries_if_failure() throws IOException, InvalidKeyException, InterruptedException {
         given(mockHttpResponse.getStatusLine()).willReturn(mockStatusLine);

--- a/src/test/java/uk/gov/pay/webhooks/deliveryqueue/managed/SendAttempterTest.java
+++ b/src/test/java/uk/gov/pay/webhooks/deliveryqueue/managed/SendAttempterTest.java
@@ -178,7 +178,7 @@ class SendAttempterTest {
     }
 
     @Test
-    void should_set_and_clear_gateway_account_and_service_context_for_send_attempt_logs() throws IOException, InvalidKeyException, InterruptedException {
+    void should_set_gateway_account_and_service_context_for_send_attempt_logs() throws IOException, InvalidKeyException, InterruptedException {
         given(mockWebhookMessageSender.sendWebhookMessage(any(WebhookMessageEntity.class)))
                 .willAnswer(_ -> {
                     assertThat(MDC.get(GATEWAY_ACCOUNT_ID), is("gateway-account-id-1"));
@@ -195,8 +195,8 @@ class SendAttempterTest {
 
         sendAttempter.attemptSend(enqueuedItem);
 
-        assertNull(MDC.get(GATEWAY_ACCOUNT_ID));
-        assertNull(MDC.get(SERVICE_EXTERNAL_ID));
+        assertThat(MDC.get(GATEWAY_ACCOUNT_ID), is("gateway-account-id-1"));
+        assertThat(MDC.get(SERVICE_EXTERNAL_ID),  is("service-id-1"));
         logs.assertContains("Exception caught by request");
     }
 

--- a/src/test/java/uk/gov/pay/webhooks/deliveryqueue/managed/WebhookMessagePollingServiceTest.java
+++ b/src/test/java/uk/gov/pay/webhooks/deliveryqueue/managed/WebhookMessagePollingServiceTest.java
@@ -15,6 +15,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
+import org.slf4j.MDC;
 import uk.gov.pay.webhooks.deliveryqueue.DeliveryStatus;
 import uk.gov.pay.webhooks.deliveryqueue.dao.WebhookDeliveryQueueDao;
 import uk.gov.pay.webhooks.deliveryqueue.dao.WebhookDeliveryQueueEntity;
@@ -35,9 +36,13 @@ import java.util.List;
 import java.util.stream.IntStream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
+import static uk.gov.pay.webhooks.app.WebhooksKeys.WEBHOOK_MESSAGE_EXTERNAL_ID;
+import static uk.gov.service.payments.logging.LoggingKeys.GATEWAY_ACCOUNT_ID;
+import static uk.gov.service.payments.logging.LoggingKeys.SERVICE_EXTERNAL_ID;
 
 @ExtendWith(DropwizardExtensionsSupport.class)
 @ExtendWith(MockitoExtension.class)
@@ -137,12 +142,30 @@ class WebhookMessagePollingServiceTest {
         });
     }
 
+    @Test
+    void should_populate_and_clear_gateway_account_and_service_logging_context_for_send_attempts() throws IOException, InvalidKeyException, InterruptedException {
+        when(webhookMessageSenderMock.sendWebhookMessage(any(WebhookMessageEntity.class))).thenAnswer(_ -> {
+            assertEquals("a-service-id", MDC.get(SERVICE_EXTERNAL_ID));
+            assertEquals("a-gateway-account-id", MDC.get(GATEWAY_ACCOUNT_ID));
+            return response;
+        });
+
+        setupOrderedDeliveryQueueWith(List.of("first-external-id"));
+
+        database.inTransaction(() -> webhookMessagePollingService.pollWebhookMessageQueue());
+
+        assertNull(MDC.get(SERVICE_EXTERNAL_ID));
+        assertNull(MDC.get(GATEWAY_ACCOUNT_ID));
+        assertNull(MDC.get(WEBHOOK_MESSAGE_EXTERNAL_ID));
+    }
+
     private void setupOrderedDeliveryQueueWith(List<String> messageIds) {
         WebhookEntity webhookEntity = new WebhookEntity();
 
         database.inTransaction(() -> {
             webhookEntity.setCallbackUrl("https://a-callback-url.test");
             webhookEntity.setServiceId("a-service-id");
+            webhookEntity.setGatewayAccountId("a-gateway-account-id");
             webhookEntity.setLive(false);
 
             webhookDao.create(webhookEntity);

--- a/src/test/java/uk/gov/pay/webhooks/validations/WebhookRequestValidatorTest.java
+++ b/src/test/java/uk/gov/pay/webhooks/validations/WebhookRequestValidatorTest.java
@@ -3,21 +3,30 @@ package uk.gov.pay.webhooks.validations;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.slf4j.MDC;
 import uk.gov.pay.webhooks.app.WebhooksConfig;
+import uk.gov.pay.webhooks.webhook.resource.CreateWebhookRequest;
 import uk.gov.service.payments.commons.api.exception.ValidationException;
 
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static uk.gov.pay.webhooks.app.WebhooksKeys.RESOURCE_IS_LIVE;
+import static uk.gov.service.payments.logging.LoggingKeys.GATEWAY_ACCOUNT_ID;
+import static uk.gov.service.payments.logging.LoggingKeys.MDC_REQUEST_ID_KEY;
+import static uk.gov.service.payments.logging.LoggingKeys.SERVICE_EXTERNAL_ID;
 
 class WebhookRequestValidatorTest {
     private WebhooksConfig webhooksConfig = mock(WebhooksConfig.class);
@@ -26,6 +35,11 @@ class WebhookRequestValidatorTest {
     @BeforeEach
     public void setUp() {
         when(webhooksConfig.getLiveDataAllowDomains()).thenReturn(Set.of("gov.uk"));
+    }
+
+    @AfterEach
+    void tearDown() {
+        MDC.clear();
     }
 
     @Test
@@ -124,5 +138,29 @@ class WebhookRequestValidatorTest {
                         "op", "replace",
                         "value", "https://gov.uk")));
         assertDoesNotThrow(() -> webhookRequestValidator.validate(request, false));
+    }
+
+    @Test
+    void should_clear_populated_mdc_context_after_validating_create_webhook_request() {
+        MDC.put(MDC_REQUEST_ID_KEY, "request-id");
+        MDC.put(GATEWAY_ACCOUNT_ID, "existing-gateway-account-id");
+        MDC.put(SERVICE_EXTERNAL_ID, "existing-service-id");
+        MDC.put(RESOURCE_IS_LIVE, "false");
+
+        var createWebhookRequest = new CreateWebhookRequest(
+                "new-service-id",
+                "new-gateway-account-id",
+                false,
+                "https://pay.gov.uk",
+                "description",
+                List.of()
+        );
+
+        assertDoesNotThrow(() -> webhookRequestValidator.validate(createWebhookRequest));
+
+        assertThat(MDC.get(MDC_REQUEST_ID_KEY), is("request-id"));
+        assertNull(MDC.get(GATEWAY_ACCOUNT_ID));
+        assertNull(MDC.get(SERVICE_EXTERNAL_ID));
+        assertNull(MDC.get(RESOURCE_IS_LIVE));
     }
 }

--- a/src/test/java/uk/gov/pay/webhooks/validations/WebhookRequestValidatorTest.java
+++ b/src/test/java/uk/gov/pay/webhooks/validations/WebhookRequestValidatorTest.java
@@ -18,9 +18,11 @@ import java.util.Set;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static uk.gov.pay.webhooks.app.WebhooksKeys.RESOURCE_IS_LIVE;
@@ -141,11 +143,14 @@ class WebhookRequestValidatorTest {
     }
 
     @Test
-    void should_clear_populated_mdc_context_after_validating_create_webhook_request() {
+    void should_populate_validator_specific_mdc_keys_during_create_webhook_validation_and_clear_them_afterwards() {
+        var callbackUrlService = mock(CallbackUrlService.class);
+        var validatorWithMockedCallbackUrlService = new WebhookRequestValidator(callbackUrlService);
+
         MDC.put(MDC_REQUEST_ID_KEY, "request-id");
         MDC.put(GATEWAY_ACCOUNT_ID, "existing-gateway-account-id");
         MDC.put(SERVICE_EXTERNAL_ID, "existing-service-id");
-        MDC.put(RESOURCE_IS_LIVE, "false");
+        MDC.put(RESOURCE_IS_LIVE, "true");
 
         var createWebhookRequest = new CreateWebhookRequest(
                 "new-service-id",
@@ -156,7 +161,15 @@ class WebhookRequestValidatorTest {
                 List.of()
         );
 
-        assertDoesNotThrow(() -> webhookRequestValidator.validate(createWebhookRequest));
+        doAnswer(_ -> {
+            assertEquals("request-id", MDC.get(MDC_REQUEST_ID_KEY));
+            assertEquals("new-gateway-account-id", MDC.get(GATEWAY_ACCOUNT_ID));
+            assertEquals("new-service-id", MDC.get(SERVICE_EXTERNAL_ID));
+            assertEquals("false", MDC.get(RESOURCE_IS_LIVE));
+            return null;
+        }).when(callbackUrlService).validateCallbackUrl("https://pay.gov.uk", false);
+
+        assertDoesNotThrow(() -> validatorWithMockedCallbackUrlService.validate(createWebhookRequest));
 
         assertThat(MDC.get(MDC_REQUEST_ID_KEY), is("request-id"));
         assertNull(MDC.get(GATEWAY_ACCOUNT_ID));

--- a/src/test/java/uk/gov/pay/webhooks/validations/WebhookRequestValidatorTest.java
+++ b/src/test/java/uk/gov/pay/webhooks/validations/WebhookRequestValidatorTest.java
@@ -148,9 +148,6 @@ class WebhookRequestValidatorTest {
         var validatorWithMockedCallbackUrlService = new WebhookRequestValidator(callbackUrlService);
 
         MDC.put(MDC_REQUEST_ID_KEY, "request-id");
-        MDC.put(GATEWAY_ACCOUNT_ID, "existing-gateway-account-id");
-        MDC.put(SERVICE_EXTERNAL_ID, "existing-service-id");
-        MDC.put(RESOURCE_IS_LIVE, "true");
 
         var createWebhookRequest = new CreateWebhookRequest(
                 "new-service-id",


### PR DESCRIPTION
**What did I do**
add gateway account and service IDs to MDC logging context:
           - include gateway_account_id and service_id in SendAttempter logs when available
           - use pay-java-commons logging key constants for MDC account/service fields
           - Push MDC context through webhook request, queue polling, and event handling flows
           - preserve and restore MDC context during webhook request validation
           - refactor duplicate request exception logging in SendAttempter
           - handle InterruptedException by interrupting the thread
           - add/update tests covering MDC and cleanup


**How to test and review **
- Unit test
- Code Review and PR comments